### PR TITLE
fix(qq_music): retry favorites entry via my tab reset

### DIFF
--- a/src/ushareiplay/commands/fav.py
+++ b/src/ushareiplay/commands/fav.py
@@ -90,17 +90,9 @@ class FavCommand(BaseCommand):
             return {'error': 'Cannot switch to qq music'}
         self.handler.logger.info("Switched to QQ Music app")
 
-        self.handler.navigate_to_home()
-        self.handler.logger.info("Navigated to home page")
-
-        my_nav = self.handler.wait_for_element_clickable_plus('my_nav')
-        my_nav.click()
-        self.handler.logger.info("Clicked personal info navigation button")
-
-        # Click on favorites button
-        fav_entry = self.handler.wait_for_element_clickable_plus('fav_entry')
-        fav_entry.click()
-        self.handler.logger.info("Clicked favorites button")
+        err = self.handler.open_favorites_entry()
+        if err:
+            return err
 
         result_item = self.handler.try_find_element_plus('result_item')
         song_text = None
@@ -140,17 +132,9 @@ class FavCommand(BaseCommand):
             return {'error': 'Cannot switch to qq music'}
         self.handler.logger.info("Switched to QQ Music app")
 
-        self.handler.navigate_to_home()
-        self.handler.logger.info("Navigated to home page")
-
-        my_nav = self.handler.wait_for_element_clickable_plus('my_nav')
-        my_nav.click()
-        self.handler.logger.info("Clicked personal info navigation button")
-
-        # Click on favorites button
-        fav_entry = self.handler.wait_for_element_clickable_plus('fav_entry')
-        fav_entry.click()
-        self.handler.logger.info("Clicked favorites button")
+        err = self.handler.open_favorites_entry()
+        if err:
+            return err
 
         # Click on filter button
         filter_favourite = self.handler.wait_for_element_clickable_plus('filter_favourite')
@@ -230,17 +214,9 @@ class FavCommand(BaseCommand):
             return {'error': 'Cannot switch to qq music'}
         self.handler.logger.info("Switched to QQ Music app")
 
-        self.handler.navigate_to_home()
-        self.handler.logger.info("Navigated to home page")
-
-        my_nav = self.handler.wait_for_element_clickable_plus('my_nav')
-        my_nav.click()
-        self.handler.logger.info("Clicked personal info navigation button")
-
-        # Click on favorites button
-        fav_entry = self.handler.wait_for_element_clickable_plus('fav_entry')
-        fav_entry.click()
-        self.handler.logger.info("Clicked favorites button")
+        err = self.handler.open_favorites_entry()
+        if err:
+            return err
 
         # Click on filter button
         filter_favourite = self.handler.wait_for_element_clickable_plus('filter_favourite')
@@ -320,16 +296,9 @@ class FavCommand(BaseCommand):
             return {'error': 'Cannot switch to qq music'}
         self.handler.logger.info("Switched to QQ Music app")
 
-        self.handler.navigate_to_home()
-        self.handler.logger.info("Navigated to home page")
-
-        my_nav = self.handler.wait_for_element_clickable_plus('my_nav')
-        my_nav.click()
-        self.handler.logger.info("Clicked personal info navigation button")
-
-        fav_entry = self.handler.wait_for_element_clickable_plus('fav_entry')
-        fav_entry.click()
-        self.handler.logger.info("Clicked favorites button")
+        err = self.handler.open_favorites_entry()
+        if err:
+            return err
 
         # 1) 在“全部播放”按钮上下滑动其高度，目的是显示搜索框
         play_all_btn = self.handler.wait_for_element_clickable_plus('play_all')

--- a/src/ushareiplay/commands/play.py
+++ b/src/ushareiplay/commands/play.py
@@ -66,17 +66,9 @@ class PlayCommand(BaseCommand):
             return {'error': 'Cannot switch to qq music'}
         self.handler.logger.info(f"Switched to QQ Music app")
 
-        self.handler.navigate_to_home()
-        self.handler.logger.info("Navigated to home page")
-
-        my_nav = self.handler.wait_for_element_clickable_plus('my_nav')
-        my_nav.click()
-        self.handler.logger.info("Clicked personal info navigation button")
-
-        # Click on favorites button
-        fav_entry = self.handler.wait_for_element_clickable_plus('fav_entry')
-        fav_entry.click()
-        self.handler.logger.info("Clicked favorites button")
+        err = self.handler.open_favorites_entry()
+        if err:
+            return err
 
         result_item = self.handler.try_find_element_plus('result_item')
         song_text = None
@@ -88,6 +80,8 @@ class PlayCommand(BaseCommand):
                 singer_text = elements[2].text
 
         play_fav = self.handler.wait_for_element_clickable_plus('play_all')
+        if not play_fav:
+            return {'error': 'Cannot find play all button'}
         play_fav.click()
         self.handler.logger.info("Clicked play all button")
 

--- a/src/ushareiplay/handlers/qq_music_handler.py
+++ b/src/ushareiplay/handlers/qq_music_handler.py
@@ -23,6 +23,75 @@ class QQMusicHandler(AppHandler, Singleton):
         self.no_skip = 0
         self.list_mode = 'unknown'
 
+    def open_favorites_entry(self, timeout: int = 10):
+        """
+        进入“我的 -> 收藏”页。
+
+        已知问题：在“我的”页可能因滚动导致“收藏”入口不在可视区域；
+        经验兜底：再次点击一次底部“我的”Tab可触发页面回到默认/顶部，再重试查找。
+
+        Returns:
+            None: 成功进入收藏页
+            dict: 失败时返回 {'error': str}
+        """
+        try:
+            ok = self.navigate_to_home()
+            if not ok:
+                return {'error': 'Cannot navigate to QQ Music home page'}
+
+            my_nav = self.wait_for_element_clickable_plus('my_nav', timeout=timeout)
+            if not my_nav:
+                return {'error': 'Cannot find my_nav'}
+
+            my_nav.click()
+            self.logger.info("open_favorites_entry: Clicked my_nav")
+
+            fav_entry = self.wait_for_element_clickable_plus('fav_entry', timeout=timeout)
+            if fav_entry:
+                fav_entry.click()
+                self.logger.info("open_favorites_entry: Clicked fav_entry")
+                return None
+
+            # 兜底：再次点击“我的”复位页面后重试
+            self.logger.warning(
+                "open_favorites_entry: fav_entry not found, retrying by clicking my_nav again to reset page"
+            )
+            my_nav_retry = self.wait_for_element_clickable_plus('my_nav', timeout=timeout)
+            if my_nav_retry:
+                my_nav_retry.click()
+                time.sleep(0.3)
+
+            fav_entry = self.wait_for_element_clickable_plus('fav_entry', timeout=timeout)
+            if fav_entry:
+                fav_entry.click()
+                self.logger.info("open_favorites_entry: Clicked fav_entry after my_nav reset")
+                return None
+
+            # 第二层兜底：回到首页再进“我的”
+            self.logger.warning(
+                "open_favorites_entry: fav_entry still not found, retrying with home->my_nav reset"
+            )
+            ok = self.navigate_to_home()
+            if not ok:
+                return {'error': 'Cannot navigate to QQ Music home page (retry)'}
+
+            my_nav = self.wait_for_element_clickable_plus('my_nav', timeout=timeout)
+            if not my_nav:
+                return {'error': 'Cannot find my_nav (retry)'}
+            my_nav.click()
+            time.sleep(0.2)
+
+            fav_entry = self.wait_for_element_clickable_plus('fav_entry', timeout=timeout)
+            if not fav_entry:
+                return {'error': 'Cannot find fav_entry after my_nav reset'}
+            fav_entry.click()
+            self.logger.info("open_favorites_entry: Clicked fav_entry after home->my_nav reset")
+            return None
+
+        except Exception as e:
+            self.logger.error(f"open_favorites_entry error: {traceback.format_exc()}")
+            return {'error': f'open_favorites_entry exception: {str(e)}'}
+
     def ensure_favorited_in_playing_page(self, timeout: int = 10) -> bool:
         """
         在播放页自动弹出后，若当前未收藏则执行收藏。


### PR DESCRIPTION
When the "My" page is scrolled, the favorites entry can be offscreen and element lookup returns None. Retry by clicking the My tab again to reset the page, and guard against None clicks.

Made-with: Cursor