### PR TITLE
fix(soul): detect foreground by package and handle tvLater

### DIFF
--- a/config.local.yaml.example
+++ b/config.local.yaml.example
@@ -18,3 +18,6 @@ appium:
 # Soul App 派对 ID（开发环境使用测试派对）
 soul:
   default_party_id: "FM00000000"   # 替换为你的测试派对 ID
+  # 可选：本机桌面/启动器包名（用于事件循环判定是否回到 Soul）
+  # launcher_packages:
+  #   - "com.miui.home"

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,9 @@ soul:
 #  owner_username: "Chainer"
   owner_username: "Joyer"
   package_name: "cn.soulapp.android"
+  # 用于判定「当前不在 Soul 前台」时尝试切回（可与 config.local.yaml 追加厂商桌面包名）
+  launcher_packages:
+    - "com.sec.android.app.launcher"
   chat_activity: ".component.startup.main.MainActivity"
 #  default_party_id: "FM18633292"
   default_party_id: "FM15321640"
@@ -63,6 +66,7 @@ soul:
     party_search_entry: "cn.soulapp.android:id/roomCard"
     content_container: "android:id/content"
     reminder_ok: "cn.soulapp.android:id/tvOk"
+    party_name_violation_later: "cn.soulapp.android:id/tvLater" # 派对名违规等弹窗「稍后再说」
     party_back: "cn.soulapp.android:id/tv_look"
     expand_seats: "cn.soulapp.android:id/tvHandleUserList" # 收起座位/展开座位
     collapse_seats: '//android.widget.TextView[@resource-id="cn.soulapp.android:id/tvHandleUserList" and @text="收起座位"]'

--- a/src/ushareiplay/events/chat_room_title.py
+++ b/src/ushareiplay/events/chat_room_title.py
@@ -4,7 +4,6 @@
 - 若已排队为「日推」且仍在冷却期，则忽略
 """
 
-__event__ = "RoomTitleRealtimeCheckEvent"
 __elements__ = ["chat_room_title"]
 
 import time
@@ -12,7 +11,7 @@ import time
 from ushareiplay.core.base_event import BaseEvent
 
 
-class RoomTitleRealtimeCheckEvent(BaseEvent):
+class ChatRoomTitleEvent(BaseEvent):
     _min_interval_s = 30.0
 
     def __init__(self, handler):
@@ -42,7 +41,6 @@ class RoomTitleRealtimeCheckEvent(BaseEvent):
             if "｜" in room_title_text:
                 return False
 
-            # 如果已经排队为「日推」且仍在冷却期，则忽略
             if (
                 title_manager.next_title == "日推"
                 and title_manager.theme_manager
@@ -53,6 +51,6 @@ class RoomTitleRealtimeCheckEvent(BaseEvent):
             title_manager.set_next_title("日推")
             return False
         except Exception as e:
-            self.logger.debug(f"RoomTitleRealtimeCheckEvent skipped: {e}")
+            self.logger.debug(f"ChatRoomTitleEvent skipped: {e}")
             return False
 

--- a/src/ushareiplay/events/party_name_violation_later.py
+++ b/src/ushareiplay/events/party_name_violation_later.py
@@ -1,0 +1,27 @@
+"""
+派对名违规等弹窗：检测到「稍后再说」时先关闭弹窗，并将房间标题排队为「日推」。
+"""
+
+__event__ = "PartyNameViolationLaterEvent"
+__elements__ = ["party_name_violation_later"]
+
+from ushareiplay.core.base_event import BaseEvent
+
+
+class PartyNameViolationLaterEvent(BaseEvent):
+    async def handle(self, key: str, element_wrapper):
+        try:
+            element = self.handler.wait_for_element_clickable_plus("party_name_violation_later")
+            if not element:
+                self.logger.warning("party_name_violation_later present in page_source but not clickable")
+                return False
+            element.click()
+            self.logger.info("Clicked party_name_violation_later (稍后再说)")
+
+            from ushareiplay.managers.title_manager import TitleManager
+
+            TitleManager.instance().set_next_title("日推")
+            return True
+        except Exception as e:
+            self.logger.error(f"PartyNameViolationLaterEvent: {e}")
+            return False

--- a/src/ushareiplay/events/risk_elements.py
+++ b/src/ushareiplay/events/risk_elements.py
@@ -25,6 +25,7 @@ __elements__ = [
     'close_widget',
     'party_back',
     'reload_more',
+    'go_back',
     'close_more_menu'
 ]
 

--- a/src/ushareiplay/events/room_title_realtime_check.py
+++ b/src/ushareiplay/events/room_title_realtime_check.py
@@ -1,0 +1,58 @@
+"""
+房名实时校验：
+- 若房名不包含「｜」，认为审核未通过/系统随机命名，排队重设为「日推」
+- 若已排队为「日推」且仍在冷却期，则忽略
+"""
+
+__event__ = "RoomTitleRealtimeCheckEvent"
+__elements__ = ["chat_room_title"]
+
+import time
+
+from ushareiplay.core.base_event import BaseEvent
+
+
+class RoomTitleRealtimeCheckEvent(BaseEvent):
+    _min_interval_s = 30.0
+
+    def __init__(self, handler):
+        super().__init__(handler)
+        self._last_check_ts = 0.0
+
+    async def handle(self, key: str, element_wrapper):
+        now = time.time()
+        if now - self._last_check_ts < self._min_interval_s:
+            return False
+        self._last_check_ts = now
+
+        try:
+            from ushareiplay.core.app_controller import AppController
+
+            controller = AppController.instance()
+            if controller and controller.ui_lock and controller.ui_lock.locked():
+                return False
+
+            from ushareiplay.managers.title_manager import TitleManager
+
+            title_manager = TitleManager.instance()
+            room_title_text = title_manager.get_room_title_text_from_ui()
+            if not room_title_text:
+                return False
+
+            if "｜" in room_title_text:
+                return False
+
+            # 如果已经排队为「日推」且仍在冷却期，则忽略
+            if (
+                title_manager.next_title == "日推"
+                and title_manager.theme_manager
+                and not title_manager.theme_manager.can_update_now()
+            ):
+                return False
+
+            title_manager.set_next_title("日推")
+            return False
+        except Exception as e:
+            self.logger.debug(f"RoomTitleRealtimeCheckEvent skipped: {e}")
+            return False
+

--- a/src/ushareiplay/managers/event_manager.py
+++ b/src/ushareiplay/managers/event_manager.py
@@ -10,7 +10,7 @@ import sys
 import time
 import traceback
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional, Set, Tuple
 
 from lxml import etree
 
@@ -38,15 +38,8 @@ class EventManager(Singleton):
         self._initialized = False
         self._consecutive_unknown_pages = 0
 
-        # 当切回 Soul/应用前台瞬间，page_source 可能为空或属于 Launcher。
-        # 这里用一组稳定的“锚点元素 id”辅助判断页面是否已就绪（来自 config.yaml 常用 tab/容器）。
-        self._soul_anchor_ids: Sequence[str] = (
-            "cn.soulapp.android:id/main_tab_planet",  # planet_tab / home_nav
-            "cn.soulapp.android:id/main_tab_square",  # square_tab
-            "cn.soulapp.android:id/action_bar_root",  # bottom_drawer
-            "cn.soulapp.android:id/tvChatRoomTitle",  # chat_room_title
-            "cn.soulapp.android:id/tslLayout",  # bottom_drawer_1
-        )
+    # 在 _process_events_once 中优先匹配（先于兜底 press_back 相关逻辑）
+    _PRIORITY_EVENT_KEYS: Tuple[str, ...] = ("party_name_violation_later",)
 
     @property
     def handler(self):
@@ -211,6 +204,37 @@ class EventManager(Singleton):
         except Exception:
             self.logger.error(f"Error loading events: {traceback.format_exc()}")
 
+    def _soul_package_name(self) -> str:
+        return (self.config.get("package_name") or "").strip() or "cn.soulapp.android"
+
+    def _launcher_packages(self) -> List[str]:
+        defaults = [
+            "com.sec.android.app.launcher",
+            "com.android.launcher",
+            "com.google.android.apps.nexuslauncher",
+        ]
+        extra = self.config.get("launcher_packages") or []
+        if not isinstance(extra, list):
+            return defaults
+        merged: List[str] = []
+        seen = set()
+        for p in extra + defaults:
+            if not p or p in seen:
+                continue
+            seen.add(p)
+            merged.append(p)
+        return merged
+
+    def _packages_from_parsed_root(self, root: etree._Element) -> Set[str]:
+        return {el.get("package") for el in root.iter() if el.get("package")}
+
+    def _packages_from_page_source(self, page_source: str) -> Optional[Set[str]]:
+        try:
+            root = etree.fromstring(page_source.encode("utf-8"))
+        except etree.XMLSyntaxError:
+            return None
+        return self._packages_from_parsed_root(root)
+
     def _find_element_in_page_source(self, root: etree._Element, element_key: str, module=None) -> Optional[
         etree._Element]:
         """
@@ -326,7 +350,16 @@ class EventManager(Singleton):
         triggered_count = 0
         root = etree.fromstring(page_source.encode("utf-8"))
 
-        for element_key, module_name in self.element_to_event.items():
+        keys_ordered: List[str] = []
+        for k in self._PRIORITY_EVENT_KEYS:
+            if k in self.element_to_event:
+                keys_ordered.append(k)
+        for k in self.element_to_event.keys():
+            if k not in keys_ordered:
+                keys_ordered.append(k)
+
+        for element_key in keys_ordered:
+            module_name = self.element_to_event[element_key]
             try:
                 module = self.event_modules.get(module_name)
                 xml_element = self._find_element_in_page_source(root, element_key, module)
@@ -358,40 +391,40 @@ class EventManager(Singleton):
 
         return triggered_count
 
-    def _is_soul_page_source_ready(self, page_source: str) -> bool:
-        if not page_source:
-            return False
-
-        if "cn.soulapp.android" not in page_source:
-            # 可能是 Launcher / 其他 app
-            return False
-
-        for anchor_id in self._soul_anchor_ids:
-            if anchor_id in page_source:
-                return True
-
-        # 兜底：如果包含包名但没有锚点（偶发），仍视为未就绪，避免误判导致 back。
-        return False
-
     @with_driver_recovery
     def _wait_page_source_ready(self, max_wait_s: float = 2.5, interval_s: float = 0.2) -> Optional[str]:
+        """
+        等待 page_source 可解析且 hierarchy 中已出现 Soul 包名（不依赖底部导航等锚点）。
+        若当前为桌面或其它应用，会间歇调用 switch_to_app 直至超时。
+        """
         deadline = time.time() + max_wait_s
         last_error = None
+        soul_pkg = self._soul_package_name()
 
         while time.time() < deadline:
             try:
                 src = self.handler.driver.page_source
                 if not src:
+                    self.handler.switch_to_app()
                     time.sleep(interval_s)
                     continue
 
-                if not self._is_soul_page_source_ready(src):
+                pkgs = self._packages_from_page_source(src)
+                if pkgs is None:
+                    last_error = "XMLSyntaxError"
                     time.sleep(interval_s)
                     continue
 
-                # 确保 XML 可解析，避免半截源码
-                etree.fromstring(src.encode("utf-8"))
-                return src
+                if soul_pkg in pkgs:
+                    return src
+
+                launchers = set(self._launcher_packages())
+                if pkgs & launchers:
+                    self.logger.debug(
+                        "PageSource foreground is not Soul (launcher detected); switching to Soul app"
+                    )
+                self.handler.switch_to_app()
+                time.sleep(interval_s)
             except etree.XMLSyntaxError as e:
                 last_error = e
                 time.sleep(interval_s)

--- a/src/ushareiplay/managers/title_manager.py
+++ b/src/ushareiplay/managers/title_manager.py
@@ -403,8 +403,14 @@ class TitleManager(Singleton):
                 # 仅在真正设置成功后检测：房名不含「｜」说明审核未通过、系统随机取名，则重设为 日推
                 room_title_text = self.get_room_title_text_from_ui()
                 if room_title_text and '｜' not in room_title_text:
-                    self.next_title = '日推'
-                    self.logger.info(f'房名未包含分隔符｜(当前: {room_title_text!r})，可能审核未通过，已排队重设为 日推')
+                    # 若已排队为「日推」但尚在冷却期，则无需重复排队/刷日志
+                    if self.next_title == '日推' and self.theme_manager and not self.theme_manager.can_update_now():
+                        pass
+                    else:
+                        self.next_title = '日推'
+                        self.logger.info(
+                            f'房名未包含分隔符｜(当前: {room_title_text!r})，可能审核未通过，已排队重设为 日推'
+                        )
 
                 # 标题更新成功后，检查是否需要恢复notice
                 notice_restore_result = self._restore_notice_if_needed()


### PR DESCRIPTION
Wait for a parseable page_source that contains Soul's package instead of requiring anchor IDs, preventing false unknown-page back loops. Add a tvLater handler to dismiss naming-violation dialogs and queue title reset to 日推.

Made-with: Cursor