### PR TITLE
feat(events): auto-dismiss leftTopCloseImage popup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -172,6 +172,7 @@ soul:
     confirm_close_5: '//android.widget.TextView[@resource-id="cn.soulapp.android:id/btn_sure"]'
     confirm_close_6: "cn.soulapp.android:id/tv_cancel"
     confirm_close_7: '//android.widget.TextView[@text="暂不需要"]'
+    left_top_close: "cn.soulapp.android:id/leftTopCloseImage"
     bottom_drawer_1: "cn.soulapp.android:id/tslLayout" # 底部抽屉
     bag_tab: '//android.widget.TextView[@resource-id="cn.soulapp.android:id/tvTab" and @text="背包"]' # 背包
     home_nav: "cn.soulapp.android:id/main_tab_planet" #  星球

--- a/src/ushareiplay/events/risk_elements.py
+++ b/src/ushareiplay/events/risk_elements.py
@@ -28,7 +28,8 @@ __elements__ = [
     'go_back',
     'close_gift',
     'confirm_close',
-    'close_more_menu'
+    'close_more_menu',
+    'left_top_close',
 ]
 
 from ushareiplay.core.base_event import BaseEvent


### PR DESCRIPTION
## Summary
- 新增 `left_top_close` 元素配置 (`cn.soulapp.android:id/leftTopCloseImage`)
- 将 `left_top_close` 注册到 `RiskElementsEvent`，自动点击关闭无法用返回键关闭的弹窗

## Changes
- `config.yaml`: 新增 `left_top_close` selector
- `risk_elements.py`: 将 `left_top_close` 加入 `__elements__` 列表，复用现有的点击处理逻辑