### PR TITLE
feat: 分身退出事件聚合

### DIFF
--- a/src/ushareiplay/dal/user_dao.py
+++ b/src/ushareiplay/dal/user_dao.py
@@ -78,4 +78,30 @@ class UserDAO:
         if user and user.level < target_level:
             user.level = target_level
             await user.save()
-        return user 
+        return user
+
+    @staticmethod
+    async def get_all_avatar_usernames(username: str) -> set:
+        """
+        获取某个用户（可以是别名或主账号）所有分身的 username 集合，
+        包含主账号自身。
+
+        用于分身退出事件聚合：只有当集合中的所有账号都离线时，
+        才真正触发退出事件。
+
+        Args:
+            username: 任意分身或主账号的昵称
+        Returns:
+            主账号 + 所有别名的 username set
+        """
+        raw_user = await UserDAO.get_or_create_raw(username)
+        canonical = await UserDAO.resolve_canonical(raw_user)
+
+        # 查出所有指向该主账号的别名
+        aliases = await User.filter(canonical_user_id=canonical.id).values_list(
+            "username", flat=True
+        )
+
+        result = set(aliases)
+        result.add(canonical.username)  # 主账号本身也加进来
+        return result

--- a/src/ushareiplay/managers/command_manager.py
+++ b/src/ushareiplay/managers/command_manager.py
@@ -247,17 +247,47 @@ class CommandManager(Singleton):
 
     async def notify_user_leave(self, username: str):
         """
-        Notify all commands when a user leaves
-        
+        Notify all commands when a user leaves.
+        For avatar users (with canonical mapping), only triggers when ALL aliases
+        of the same canonical user are offline.
+
         Args:
             username: Username of the user who left
         """
-        for module in self.get_command_modules().values():
-            try:
-                if hasattr(module.command, 'user_leave'):
-                    await module.command.user_leave(username)
-            except Exception:
-                self.logger.error(f"Error in command user_leave: {traceback.format_exc()}")
+        try:
+            from ushareiplay.dal.user_dao import UserDAO
+            from ushareiplay.managers.info_manager import InfoManager
+
+            all_avatars = await UserDAO.get_all_avatar_usernames(username)
+            online_users = InfoManager.instance().get_online_users()
+            still_online = all_avatars & online_users
+
+            if still_online:
+                self.logger.info(
+                    f"User leave skipped for '{username}': "
+                    f"avatars still online: {still_online}"
+                )
+                return
+
+            # 以主账号 canonical username 触发退出事件
+            raw_user = await UserDAO.get_or_create_raw(username)
+            canonical_user = await UserDAO.resolve_canonical(raw_user)
+            canonical_username = canonical_user.username
+
+            self.logger.info(
+                f"All avatars offline for '{username}' → triggering user_leave "
+                f"as canonical '{canonical_username}'"
+            )
+
+            for module in self.get_command_modules().values():
+                try:
+                    if hasattr(module.command, 'user_leave'):
+                        await module.command.user_leave(canonical_username)
+                except Exception:
+                    self.logger.error(f"Error in command user_leave: {traceback.format_exc()}")
+
+        except Exception:
+            self.logger.error(f"Error in notify_user_leave: {traceback.format_exc()}")
 
     async def notify_user_enter(self, username: str):
         """

--- a/test_avatar_exit.py
+++ b/test_avatar_exit.py
@@ -1,0 +1,119 @@
+"""
+分身退出事件聚合测试
+验证：只有当主账号 + 全部别名都不在线时，才触发退出事件
+"""
+import asyncio
+from tortoise import Tortoise
+from ushareiplay.models.user import User
+from ushareiplay.dal.user_dao import UserDAO
+
+
+async def setup_db():
+    await Tortoise.init(
+        db_url="sqlite://:memory:",
+        modules={"models": ["ushareiplay.models.user"]},
+    )
+    await Tortoise.generate_schemas()
+
+
+async def teardown_db():
+    await Tortoise.close_connections()
+
+
+async def test_get_all_avatar_usernames():
+    """主账号 + 全部别名的 username 集合"""
+    await setup_db()
+    try:
+        canonical = await User.create(username="小明", level=0)
+        await User.create(username="明明", level=0, canonical_user_id=canonical.id)
+        await User.create(username="小M", level=0, canonical_user_id=canonical.id)
+
+        result = await UserDAO.get_all_avatar_usernames("小明")
+        assert result == {"小明", "明明", "小M"}, f"Expected all avatars, got: {result}"
+        print("PASS: test_get_all_avatar_usernames")
+    finally:
+        await teardown_db()
+
+
+async def test_no_leave_if_alias_still_online():
+    """某分身退出，但另一分身仍在线 → 不触发 user_leave"""
+    await setup_db()
+    try:
+        canonical = await User.create(username="小明", level=0)
+        await User.create(username="明明", level=0, canonical_user_id=canonical.id)
+
+        # 模拟在线集合：明明已离线，但小明还在线
+        online_users = {"小明", "张三"}
+
+        all_avatars = await UserDAO.get_all_avatar_usernames("明明")
+        still_online = all_avatars & online_users
+        should_trigger = len(still_online) == 0
+
+        assert not should_trigger, "应该不触发退出事件，小明仍在线"
+        print("PASS: test_no_leave_if_alias_still_online")
+    finally:
+        await teardown_db()
+
+
+async def test_leave_when_all_avatars_offline():
+    """主账号 + 全部别名都离线 → 触发 user_leave"""
+    await setup_db()
+    try:
+        canonical = await User.create(username="小明", level=0)
+        await User.create(username="明明", level=0, canonical_user_id=canonical.id)
+
+        online_users = {"张三", "李四"}  # 小明和明明都不在线
+
+        all_avatars = await UserDAO.get_all_avatar_usernames("明明")
+        still_online = all_avatars & online_users
+        should_trigger = len(still_online) == 0
+
+        assert should_trigger, "全部分身都离线，应该触发退出事件"
+        print("PASS: test_leave_when_all_avatars_offline")
+    finally:
+        await teardown_db()
+
+
+async def test_no_aliases_user_triggers_immediately():
+    """没有分身的普通用户离开 → 直接触发（行为不变）"""
+    await setup_db()
+    try:
+        await User.create(username="张三", level=0)  # 无别名
+
+        online_users = {"李四"}  # 张三已离线
+
+        all_avatars = await UserDAO.get_all_avatar_usernames("张三")
+        still_online = all_avatars & online_users
+        should_trigger = len(still_online) == 0
+
+        assert should_trigger, "无分身的普通用户离开应立即触发"
+        print("PASS: test_no_aliases_user_triggers_immediately")
+    finally:
+        await teardown_db()
+
+
+async def test_alias_queried_resolves_to_canonical_group():
+    """通过别名查询，返回的集合仍包含主账号和其他别名"""
+    await setup_db()
+    try:
+        canonical = await User.create(username="小明", level=0)
+        await User.create(username="明明", level=0, canonical_user_id=canonical.id)
+        await User.create(username="小M", level=0, canonical_user_id=canonical.id)
+
+        # 用别名 "明明" 查询
+        result = await UserDAO.get_all_avatar_usernames("明明")
+        assert "小明" in result, "主账号应在结果中"
+        assert "明明" in result, "查询用的别名应在结果中"
+        assert "小M" in result, "其他别名应在结果中"
+        assert len(result) == 3, f"结果应有3个成员，实际: {result}"
+        print("PASS: test_alias_queried_resolves_to_canonical_group")
+    finally:
+        await teardown_db()
+
+
+if __name__ == "__main__":
+    asyncio.run(test_get_all_avatar_usernames())
+    asyncio.run(test_no_leave_if_alias_still_online())
+    asyncio.run(test_leave_when_all_avatars_offline())
+    asyncio.run(test_no_aliases_user_triggers_immediately())
+    asyncio.run(test_alias_queried_resolves_to_canonical_group())


### PR DESCRIPTION
实现退出事件的分身聚合逻辑：
1. 在 UserDAO 新增 `get_all_avatar_usernames` 方法，用于查询主账号及所有别名
2. 在 CommandManager.`notify_user_leave` 中加入聚合判断，只有当主账号及其所有别名都不在线时，才真正触发 `user_leave` 事件
3. 新增 `test_avatar_exit.py` 包含完整的聚合逻辑验证