### PR TITLE
fix(events): 发帖退出「不保存」菜单纳入风险元素

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -173,6 +173,8 @@ soul:
     confirm_close_6: "cn.soulapp.android:id/tv_cancel"
     confirm_close_7: '//android.widget.TextView[@text="暂不需要"]'
     left_top_close: "cn.soulapp.android:id/leftTopCloseImage"
+    # 发帖/动态页点左上角关闭后底部菜单（ESC 无法关闭）；需点此项避免与 left_top_close 循环
+    post_draft_dont_save: '//android.widget.TextView[@resource-id="cn.soulapp.android:id/title" and @text="不保存"]'
     bottom_drawer_1: "cn.soulapp.android:id/tslLayout" # 底部抽屉
     bag_tab: '//android.widget.TextView[@resource-id="cn.soulapp.android:id/tvTab" and @text="背包"]' # 背包
     home_nav: "cn.soulapp.android:id/main_tab_planet" #  星球

--- a/src/ushareiplay/events/risk_elements.py
+++ b/src/ushareiplay/events/risk_elements.py
@@ -8,6 +8,8 @@
 - collapse_seats: 收起座位
 
 当检测到这些元素时，自动点击处理，避免界面不稳定。
+
+- post_draft_dont_save: 发帖退出菜单「不保存」（ESC 无效时避免反复点关闭死循环）
 """
 
 __event__ = "RiskElementsEvent"
@@ -30,6 +32,7 @@ __elements__ = [
     'confirm_close',
     'close_more_menu',
     'left_top_close',
+    'post_draft_dont_save',
 ]
 
 from ushareiplay.core.base_event import BaseEvent

--- a/src/ushareiplay/managers/event_manager.py
+++ b/src/ushareiplay/managers/event_manager.py
@@ -42,6 +42,8 @@ class EventManager(Singleton):
     _PRIORITY_EVENT_KEYS: Tuple[str, ...] = (
         "accidental_touch_locker",
         "party_name_violation_later",
+        # 发帖退出底部菜单与 left_top_close 同时存在时须先点「不保存」，否则会反复点关闭
+        "post_draft_dont_save",
     )
 
     @property


### PR DESCRIPTION
## 背景

Soul 发帖/动态编辑页点击左上角关闭后，会弹出底部菜单（试试 AI 润色 / 保存草稿 / **不保存** / 取消）。该菜单无法用 ESC 关闭；若自动化仍去点左上角关闭，会反复弹出菜单形成死循环。

## 改动

- 在 `config.yaml` 增加 `post_draft_dont_save`，XPath 匹配 `title` + 文案「不保存」。
- 在 `risk_elements.py` 的 `__elements__` 中注册，由 `RiskElementsEvent` 自动点击关闭。
- 在 `EventManager._PRIORITY_EVENT_KEYS` 中优先匹配该 key，避免与 `left_top_close` 同时出现在层级时先误点关闭。

## 验证

未接设备时仅做语法检查；需在真机 Soul 上打开发帖退出菜单确认可被自动点击关闭。

Made with [Cursor](https://cursor.com)