### PR TITLE
fix(timer): delete one-shot timers after firing

### DIFF
--- a/docs/timers.md
+++ b/docs/timers.md
@@ -56,6 +56,6 @@ Table: `timer_events`
 
 ## Extension Points
 
-- **One-shot timers**: Set `repeat=False` — timer fires once then stays in DB with `enabled=False`.
+- **One-shot timers**: Set `repeat=False` — timer fires once then is deleted from DB.
 - **New timer commands**: Extend `TimerCommand.execute()` with new sub-commands.
 - **Migration from JSON**: `TimerManager._migrate_from_json()` handles legacy `timers.json` automatically on first start.

--- a/openspec/specs/timer-db-storage/spec.md
+++ b/openspec/specs/timer-db-storage/spec.md
@@ -23,9 +23,9 @@
 - **WHEN** 一个 repeat=True 的定时器被触发
 - **THEN** 系统 SHALL 将 next_trigger 更新为次日同一时间，并将更新写入数据库
 
-#### Scenario: 一次性定时器触发后在数据库中禁用
+#### Scenario: 一次性定时器触发后从数据库删除
 - **WHEN** 一个 repeat=False 的定时器被触发
-- **THEN** 系统 SHALL 将该定时器的 enabled 字段在数据库中置为 False
+- **THEN** 系统 SHALL 从数据库删除该定时器记录，并从内存缓存移除
 
 ### Requirement: 启动时从数据库加载定时器
 系统 SHALL 在 TimerManager 启动时从数据库加载所有定时器到内存缓存，不再读取 `config.yaml` 的 `initial_timers` 段。

--- a/src/ushareiplay/managers/timer_manager.py
+++ b/src/ushareiplay/managers/timer_manager.py
@@ -143,9 +143,9 @@ class TimerManager(Singleton):
                 await TimerDAO.update_next_trigger(timer_key, next_trigger)
                 self.logger.info(f"Timer {timer_key} scheduled for next day: {next_trigger}")
             else:
-                timer_data['enabled'] = False
-                await TimerDAO.update_enabled(timer_key, False)
-                self.logger.info(f"Timer {timer_key} completed and disabled")
+                await TimerDAO.delete_by_key(timer_key)
+                self._timers.pop(timer_key, None)
+                self.logger.info(f"Timer {timer_key} completed and deleted")
 
         except Exception as e:
             self.logger.error(f"Error triggering timer {timer_key}: {str(e)}")

--- a/tests/test_timer_add.py
+++ b/tests/test_timer_add.py
@@ -109,3 +109,42 @@ async def test_timer_command_strips_grouping_quotes_in_message(monkeypatch):
 
     await manager.close()
 
+
+@pytest.mark.asyncio
+async def test_one_shot_timer_deleted_after_trigger():
+    from datetime import datetime, timedelta
+
+    from ushareiplay.core.db_manager import DatabaseManager
+    from ushareiplay.dal.timer_dao import TimerDAO
+    from ushareiplay.managers.timer_manager import TimerManager
+
+    manager = DatabaseManager(db_url="sqlite://:memory:")
+    await manager.init()
+
+    tm = TimerManager.instance()
+    tm._logger = _DummyLogger()
+
+    await TimerDAO.create(
+        key="oneshot",
+        message="hello",
+        target_time="10",
+        repeat=False,
+        enabled=True,
+        next_trigger=datetime.now() - timedelta(seconds=1),
+    )
+    tm._timers["oneshot"] = {
+        "key": "oneshot",
+        "message": "hello",
+        "target_time": "10",
+        "repeat": False,
+        "enabled": True,
+        "next_trigger": (datetime.now() - timedelta(seconds=1)).isoformat(),
+    }
+
+    await tm._trigger_timer("oneshot", tm._timers["oneshot"])
+
+    assert await TimerDAO.get_by_key("oneshot") is None
+    assert "oneshot" not in tm._timers
+
+    await manager.close()
+


### PR DESCRIPTION
## Summary
- 一次性定时器（repeat=false）触发成功后：从数据库删除该记录，并从内存缓存移除，避免过期一次性定时器长期堆积。
- 同步更新 OpenSpec 主规格与 `docs/timers.md`。
- 增加回归测试覆盖“触发后删除”。

## Test plan
- [x] `pytest -q tests/test_timer_add.py`


Made with [Cursor](https://cursor.com)