### PR TITLE
fix(logging): restore configurable log dir outside repo (e.g. ../logs)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,10 @@
 __pycache__/
 logs
 data
-.cursor
 *.swp
 artifacts/
-.agent/
 config/keywords.yaml
 config.local.yaml
 .claude/worktrees/
 .claude/settings.local.json
-.claude
 .opencode/package-lock.json

--- a/src/ushareiplay/core/app_handler.py
+++ b/src/ushareiplay/core/app_handler.py
@@ -39,11 +39,11 @@ class AppHandler:
             logging.Logger: Configured logger instance
         """
         from ushareiplay.core.config_loader import ConfigLoader
-        from ushareiplay.core.paths import ensure_dir, safe_workspace_path
+        from ushareiplay.core.paths import ensure_dir, resolve_log_directory
 
         cfg = ConfigLoader.load_config()
         configured = ((cfg or {}).get("logging", {}) or {}).get("directory", "")
-        log_dir_path = safe_workspace_path(configured, default_rel="logs")
+        log_dir_path = resolve_log_directory(configured, default_rel="logs")
         ensure_dir(log_dir_path)
 
         # Get current date for log file name

--- a/src/ushareiplay/core/paths.py
+++ b/src/ushareiplay/core/paths.py
@@ -32,6 +32,23 @@ def _is_within(child: Path, parent: Path) -> bool:
         return False
 
 
+def resolve_log_directory(configured: str, default_rel: str = "logs") -> Path:
+    """
+    Resolve logging.directory from config relative to repo root.
+
+    Unlike safe_workspace_path(), paths outside the repo (e.g. '../logs') are kept.
+    This restores historical behavior; logs are often intentionally placed beside
+    the repo to keep ripgrep/code search separate from large log files.
+    """
+    root = repo_root()
+    raw = (configured or "").strip()
+    if not raw:
+        return (root / default_rel).resolve()
+
+    p = Path(raw)
+    return (p if p.is_absolute() else (root / p)).resolve()
+
+
 def safe_workspace_path(configured: str, default_rel: str) -> Path:
     """
     Normalize a configured directory path to a workspace-safe location.

--- a/src/ushareiplay/managers/message_manager.py
+++ b/src/ushareiplay/managers/message_manager.py
@@ -25,11 +25,11 @@ def get_chat_logger(config=None):
     global chat_logger
     if chat_logger is None:
         from ushareiplay.core.config_loader import ConfigLoader
-        from ushareiplay.core.paths import ensure_dir, safe_workspace_path
+        from ushareiplay.core.paths import ensure_dir, resolve_log_directory
 
         cfg = ConfigLoader.load_config()
         configured = ((cfg or {}).get("logging", {}) or {}).get("directory", "")
-        log_dir_path = safe_workspace_path(configured, default_rel="logs")
+        log_dir_path = resolve_log_directory(configured, default_rel="logs")
         ensure_dir(log_dir_path)
         # Create chat logger
         chat_logger = logging.getLogger('chat')

--- a/tests/test_logging_directory_e2e.py
+++ b/tests/test_logging_directory_e2e.py
@@ -1,0 +1,88 @@
+"""
+E2E-style regression for logging.directory (especially ../logs).
+
+Regression source: commit that introduced safe_workspace_path redirected ../logs
+into <repo>/logs, so files never appeared under the parent directory. This test
+reproduces that layout in a temp tree and asserts the log file lands where config points.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+
+def test_resolve_log_directory_keeps_parent_path(tmp_path: Path, monkeypatch) -> None:
+    """../logs 必须解析到仓库上一级（与“安全重定向到仓库内”不同）。"""
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "src").mkdir()
+    (project / "config.yaml").write_text("", encoding="utf-8")
+    monkeypatch.chdir(project)
+
+    from ushareiplay.core.paths import repo_root, resolve_log_directory, safe_workspace_path
+
+    assert repo_root().resolve() == project.resolve()
+
+    resolved = resolve_log_directory("../logs", default_rel="logs")
+    assert resolved == (tmp_path / "logs").resolve()
+
+    redirected = safe_workspace_path("../logs", default_rel="logs")
+    assert redirected == (project / "logs").resolve()
+    assert redirected != resolved
+
+
+def test_probe_log_file_written_next_to_repo_not_inside(tmp_path: Path, monkeypatch) -> None:
+    """模拟 AppHandler / chat 使用的路径链：配置 ../logs 时探针文件写在上一级 logs。"""
+    project = tmp_path / "worktree"
+    project.mkdir()
+    (project / "src").mkdir()
+    (project / "config.yaml").write_text(
+        "logging:\n  directory: ../logs\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(project)
+
+    from ushareiplay.core.config_loader import ConfigLoader
+    from ushareiplay.core.paths import ensure_dir, resolve_log_directory
+
+    cfg = ConfigLoader.load_config("config.yaml")
+    raw = ((cfg or {}).get("logging", {}) or {}).get("directory", "")
+    log_dir = ensure_dir(resolve_log_directory(raw, default_rel="logs"))
+    probe = log_dir / "e2e_probe.log"
+    probe.write_text("ok\n", encoding="utf-8")
+
+    assert probe.exists()
+    assert probe.resolve().parent == (tmp_path / "logs").resolve()
+    assert not (project / "logs" / "e2e_probe.log").exists()
+
+
+def test_filehandler_writes_resolved_log_directory(tmp_path: Path, monkeypatch) -> None:
+    """与真实 logging.FileHandler 一致：目录与文件落在解析后的路径。"""
+    project = tmp_path / "myrepo"
+    project.mkdir()
+    (project / "src").mkdir()
+    (project / "config.yaml").write_text(
+        "logging:\n  directory: ../logs\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(project)
+
+    from ushareiplay.core.config_loader import ConfigLoader
+    from ushareiplay.core.paths import ensure_dir, resolve_log_directory
+
+    cfg = ConfigLoader.load_config("config.yaml")
+    raw = ((cfg or {}).get("logging", {}) or {}).get("directory", "")
+    log_dir = ensure_dir(resolve_log_directory(raw, default_rel="logs"))
+    log_file = log_dir / "handler_test.log"
+
+    logger = logging.getLogger("e2e_handler_test")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+    fh = logging.FileHandler(log_file, encoding="utf-8")
+    fh.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(fh)
+    logger.info("line")
+    fh.close()
+
+    assert log_file.read_text(encoding="utf-8").strip() == "line"
+    assert log_file.resolve().parent == (tmp_path / "logs").resolve()


### PR DESCRIPTION
## Summary

Application logs (`SoulHandler_*.log`, `chat.log`, etc.) were resolved through `safe_workspace_path()`, which redirects paths that escape the repo root (e.g. `../logs`) to `<repo>/logs`. That helper exists for workspace-scoped artifacts (Observability/agent outputs), not for user-chosen application log directories.

## Changes

- Add `resolve_log_directory()` in `paths.py`: resolve `logging.directory` relative to repo root **without** forcing paths under the repo.
- Switch `AppHandler` and `get_chat_logger()` to use `resolve_log_directory()`; keep `safe_workspace_path()` for artifact-style paths.
- Add `tests/test_logging_directory_e2e.py`: temp-repo layout + probe file + `FileHandler` write to prove files land beside the repo when `../logs` is configured.

## Verification

```bash
python -m pytest tests/test_logging_directory_e2e.py -v
```

All three tests pass locally.

Made with [Cursor](https://cursor.com)