### PR TITLE
feat(qq_music): cache play mode and self-heal via playlist UI

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -237,6 +237,10 @@ qq_music:
     play_mode_list: '//android.widget.ImageView[@content-desc="列表循环"]'
     play_mode_single: '//android.widget.ImageView[@content-desc="单曲循环"]'
     play_mode_random: '//android.widget.ImageView[@content-desc="随机播放"]'
+    # 播放列表页（歌曲队列/正在播放列表弹层）上的播放模式按钮（用于模式校验自愈）
+    play_mode_list_in_playlist: '//android.widget.ImageButton[@content-desc="顺序播放"]'
+    play_mode_single_in_playlist: '//android.widget.ImageButton[@content-desc="单曲循环"]'
+    play_mode_random_in_playlist: '//android.widget.ImageButton[@content-desc="随机播放"]'
     music_tabs: '//android.widget.RelativeLayout[@content-desc="歌手 按钮"]/..'
 
     minimize_screen: '//android.widget.ImageView[@content-desc="返回"]'
@@ -324,7 +328,7 @@ commands:
     error_template: "别名绑定失败: {error}"
   - prefix: "info"
     level: 0
-    response_template: "{current_playlist}\n{online_users}\n{party_duration}"
+    response_template: "播放模式: {play_mode}\n{current_playlist}\n{online_users}\n{party_duration}"
     error_template: "Failed to get playback info, because {error}"
   - prefix: "singer"
     level: 1

--- a/openspec/changes/2026-05-03-qqmusic-play-mode-cache/.openspec.yaml
+++ b/openspec/changes/2026-05-03-qqmusic-play-mode-cache/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-03
+

--- a/openspec/changes/2026-05-03-qqmusic-play-mode-cache/design.md
+++ b/openspec/changes/2026-05-03-qqmusic-play-mode-cache/design.md
@@ -1,0 +1,87 @@
+## Overview
+
+为 QQ 音乐的“播放模式”（顺序/单曲/随机）引入进程内状态记录，减少 `mode` 命令的冗余 App 切换与 UI 读取。同时通过 `get_playlist_info()`（播放列表界面）顺手做一次校验，实现状态自愈，降低“记录与真实状态不一致”的风险。
+
+## Current State
+
+- `ModeCommand` 每次执行都会 `switch_to_app()` 并通过 `play_mode_*` 元素识别当前模式；如果已是目标模式则直接返回，但不会记录到全局状态。
+- `QQMusicHandler.get_playlist_info()` 会切到 QQ 音乐并进入播放列表界面读取列表信息；该界面可见播放模式按钮（由 XPath `//android.widget.ImageButton[@content-desc="随机播放"/"顺序播放"/"单曲循环"]` 判定）。
+- `InfoCommand` 从 `InfoManager` 读取缓存并返回展示信息，目前不包含播放模式。
+
+## Proposed Design
+
+### 1) In-memory state in `QQMusicHandler`
+
+新增字段：
+
+- `QQMusicHandler.play_mode_key: str`，取值：
+  - `unknown`（默认）
+  - `list`（顺序播放）
+  - `single`（单曲循环）
+  - `random`（随机播放）
+
+并提供一个稳定的显示映射（用于返回/日志）：
+
+- `list` → `顺序播放`
+- `single` → `单曲循环`
+- `random` → `随机播放`
+- `unknown` → `未知`
+
+### 2) `mode` command: write-through + short-circuit
+
+在 `ModeCommand` 中：
+
+- 当 UI 识别出 `current_mode == target_mode`（already_target）时：
+  - 写入 `QQMusicHandler.play_mode_key = <target>`
+  - 返回“已经是xxx模式”
+- 当 UI 点击切换并确认达到目标模式时：
+  - 写入 `QQMusicHandler.play_mode_key = <target>`
+  - 返回“成功切换到xxx模式”
+
+短路逻辑：
+
+- 若 `QQMusicHandler.play_mode_key != unknown` 且请求目标与记录一致：
+  - 直接返回“已经是xxx模式”
+  - 不调用 `switch_to_app()`，避免切换/读取开销
+- 若记录为 `unknown`：
+  - 不短路，保持现有 UI 识别/切换流程
+
+### 3) Self-heal on playlist UI (`get_playlist_info`)
+
+在 `QQMusicHandler.get_playlist_info()`：
+
+- 进入播放列表界面后，执行一次“播放模式识别”：
+  - 通过等待任一模式按钮出现来判定模式（list/single/random）
+  - 若与 `play_mode_key` 不一致，则记录 warning 日志并更新缓存为识别到的模式
+
+该校验不应影响 `get_playlist_info()` 的主功能：
+
+- 若模式按钮未能识别（超时/偶发 UI 异常）：
+  - 不抛出错误，不阻断播放列表读取
+  - 只记录日志（或保持静默，视现有日志噪音策略）
+
+### 4) `info` output
+
+在 `InfoCommand.process()` 的返回 dict 中追加：
+
+- `play_mode_key`: `unknown|list|single|random`
+- `play_mode`: 中文映射（未知/顺序播放/单曲循环/随机播放）
+
+保持原有字段不变，且 unknown 状态也应可展示为“未知”。
+
+## Configuration / Selectors
+
+为避免硬编码 XPath，播放列表界面的三种模式按钮应通过 `config.yaml` 的 element key 管理（复用或新增 key）：
+
+- `play_mode_random`: `//android.widget.ImageButton[@content-desc="随机播放"]`
+- `play_mode_list`: `//android.widget.ImageButton[@content-desc="顺序播放"]`
+- `play_mode_single`: `//android.widget.ImageButton[@content-desc="单曲循环"]`
+
+要求：这些 key 在“播放列表弹层/列表页”可命中。
+
+## Edge Cases & Decisions
+
+- **unknown 的语义**：unknown 下不做短路；任何更新/切换都必须走 UI。
+- **漂移与自愈**：用户手动在 QQ 音乐里更改模式，可能导致缓存过时；一旦系统执行一次“查看播放列表”，即可利用同 UI 校验并自愈。
+- **一致性与性能**：短路以性能为主，自愈以正确性为主；两者结合避免频繁切 App，同时给出可接受的纠偏路径。
+

--- a/openspec/changes/2026-05-03-qqmusic-play-mode-cache/proposal.md
+++ b/openspec/changes/2026-05-03-qqmusic-play-mode-cache/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+当前 `mode`（播放模式切换）命令每次执行都会切到 QQ 音乐并通过 UI 实时识别/切换模式。由于系统没有记录“当前播放模式”，即使用户连续两次切换到同一模式，也会重复进行 App 切换与 UI 读取，效率低、延迟高。
+
+此外，刚开服/重启后系统也无法知道 QQ 音乐当前处于哪种播放模式，必须通过 UI 才能确认。因此需要一个“默认 unknown + 在合适时机校验自愈”的轻量状态机制，以减少冗余操作并降低状态漂移风险。
+
+## What Changes
+
+- 新增 QQ 音乐播放模式的进程内记录（默认 `unknown`）。
+- `mode` 命令在切换成功后写入记录；当请求切换到与记录一致的模式时可直接短路返回“已是该模式”（仅当记录非 unknown）。
+- `QQMusicHandler.get_playlist_info()` 在进入“播放列表弹层/列表页”后，利用同一界面可见的三种模式按钮进行一次校验；若发现记录与 UI 识别不一致，自动修正记录（自愈）。
+- `info` 命令返回值附带当前记录的播放模式（并保持 unknown 的语义：unknown 下不短路）。
+
+## Capabilities
+
+### New Capabilities
+
+- `qqmusic-play-mode-cache`: 在进程内缓存 QQ 音乐播放模式（unknown/list/single/random），支持写入与读取。
+- `qqmusic-play-mode-self-heal`: 在播放列表界面读取模式并自动纠正缓存，降低漂移概率。
+
+### Modified Capabilities
+
+- `mode-command-optimization`: 对播放模式切换命令增加“同模式短路”优化。
+- `info-extended`: `info` 输出增加当前播放模式信息。
+
+## Non-Goals
+
+- 不将播放模式持久化到数据库（避免跨重启“记住错误状态”）。
+- 不改变现有 `mode` 命令对 unknown 状态的行为：unknown 下必须走 UI 识别/切换。
+- 不重构 QQ 音乐整体导航/播放页逻辑，只在现有调用链上增加最小状态记录与校验。
+
+## Acceptance Criteria
+
+- 默认状态为 `unknown`：
+  - 刚启动时执行 `mode` 任意模式切换，仍会切到 QQ 音乐并执行 UI 操作（不短路）。
+- 一旦 `mode` 切换成功或识别到“已经是目标模式”，系统应记录当前模式。
+- 记录为某模式时，再次执行同模式切换：
+  - 应直接返回“已经是该模式”，不再切换到 QQ 音乐 UI（短路）。
+- 执行任意一次“查看播放列表”（触发 `get_playlist_info()`）时：
+  - 应在播放列表界面识别真实模式，并在发现不一致时自动更新记录。
+- `info` 返回中应包含当前播放模式（unknown/list/single/random 或中文映射），且不会破坏原有字段。
+

--- a/openspec/changes/2026-05-03-qqmusic-play-mode-cache/tasks.md
+++ b/openspec/changes/2026-05-03-qqmusic-play-mode-cache/tasks.md
@@ -1,0 +1,22 @@
+## Tasks
+
+- [ ] 盘点并校准 selector
+  - [ ] 确认 `config.yaml` 中 `play_mode_list/play_mode_single/play_mode_random` 是否已对应播放列表界面的 XPath；若不一致则更新或新增 key
+
+- [ ] 引入播放模式缓存（进程内）
+  - [ ] 在 `QQMusicHandler` 新增 `play_mode_key`（默认 `unknown`）与中文映射辅助方法/属性
+
+- [ ] 优化 `mode` 命令
+  - [ ] 在 recorded!=unknown 且目标一致时短路返回
+  - [ ] 在 already_target / 切换成功时写入 `play_mode_key`
+
+- [ ] 播放列表自愈校验
+  - [ ] 在 `QQMusicHandler.get_playlist_info()` 进入播放列表界面后识别并修正 `play_mode_key`
+
+- [ ] 扩展 `info` 输出
+  - [ ] `InfoCommand` 返回中追加 `play_mode`/`play_mode_key`
+
+- [ ] 最小回归
+  - [ ] `python tests/test_imports.py`
+  - [ ] `python tests/test_playlist_response_format.py`
+

--- a/src/ushareiplay/commands/info.py
+++ b/src/ushareiplay/commands/info.py
@@ -65,6 +65,12 @@ class InfoCommand(BaseCommand):
         else:
             result["current_playlist"] = "暂无活跃歌单"
 
+        from ushareiplay.handlers.qq_music_handler import QQMusicHandler
+        music_handler = QQMusicHandler.instance()
+        play_mode_key = getattr(music_handler, 'play_mode_key', 'unknown') if music_handler else 'unknown'
+        result["play_mode_key"] = play_mode_key
+        result["play_mode"] = music_handler.play_mode_key_to_name(play_mode_key) if music_handler else "未知"
+
         return result
 
     def update(self):

--- a/src/ushareiplay/commands/mode.py
+++ b/src/ushareiplay/commands/mode.py
@@ -25,6 +25,14 @@ class ModeCommand(BaseCommand):
             if mode not in [0, 1, -1]:
                 raise ValueError
 
+            target_key = {0: 'list', 1: 'single', -1: 'random'}[mode]
+            if getattr(self.handler, 'play_mode_key', 'unknown') != 'unknown' and self.handler.play_mode_key == target_key:
+                return {
+                    'success': True,
+                    'mode': self.handler.play_mode_key_to_name(target_key),
+                    'message': f'已经是{self.handler.play_mode_key_to_name(target_key)}模式'
+                }
+
             # 直接实现切换模式逻辑
             result = await self._change_play_mode_direct(mode)
             return result
@@ -106,12 +114,14 @@ class ModeCommand(BaseCommand):
             # 3. 检查是否找到播放模式元素
             current_mode_element = found_element
             current_mode = key_to_mode(found_element_key)
+            self.handler._update_play_mode_key({0: 'list', 1: 'single', -1: 'random'}[current_mode], reason='mode_ui_detect')
 
             log_step("Step2", current_mode=mode_names[current_mode], target_mode=mode_names[target_mode])
 
             # 如果已经是目标模式，直接返回
             if current_mode == target_mode:
                 log_step("Result", status="PASS", mode=mode_names[target_mode], reason="already_target")
+                self.handler._update_play_mode_key({0: 'list', 1: 'single', -1: 'random'}[target_mode], reason='mode_already_target')
                 return {
                     'success': True,
                     'mode': mode_names[target_mode],
@@ -141,12 +151,14 @@ class ModeCommand(BaseCommand):
                 # 确定当前模式
                 current_mode_element = found_element
                 current_mode = key_to_mode(found_element_key)
+                self.handler._update_play_mode_key({0: 'list', 1: 'single', -1: 'random'}[current_mode], reason='mode_ui_detect_after_click')
 
                 log_step("Step3", after_click_current_mode=mode_names[current_mode])
 
                 # 检查是否达到目标模式
                 if current_mode == target_mode:
                     log_step("Result", status="PASS", mode=mode_names[target_mode], attempt=attempt + 1)
+                    self.handler._update_play_mode_key({0: 'list', 1: 'single', -1: 'random'}[target_mode], reason='mode_switch_success')
                     return {
                         'success': True,
                         'mode': mode_names[target_mode],

--- a/src/ushareiplay/handlers/qq_music_handler.py
+++ b/src/ushareiplay/handlers/qq_music_handler.py
@@ -22,6 +22,28 @@ class QQMusicHandler(AppHandler, Singleton):
         self.last_lyrics_lines = []
         self.no_skip = 0
         self.list_mode = 'unknown'
+        self.play_mode_key = 'unknown'
+
+    @staticmethod
+    def play_mode_key_to_name(key: str) -> str:
+        return {
+            'list': '顺序播放',
+            'single': '单曲循环',
+            'random': '随机播放',
+            'unknown': '未知',
+        }.get(key, '未知')
+
+    def _update_play_mode_key(self, new_key: str, reason: str):
+        if not new_key:
+            return
+        if new_key not in ('unknown', 'list', 'single', 'random'):
+            self.logger.warning(f"Invalid play_mode_key={new_key}, ignored (reason={reason})")
+            return
+        if self.play_mode_key != new_key:
+            self.logger.info(
+                f"play_mode_key updated: {self.play_mode_key} -> {new_key} (reason={reason})"
+            )
+        self.play_mode_key = new_key
 
     def open_favorites_entry(self, timeout: int = 10):
         """
@@ -728,6 +750,29 @@ class QQMusicHandler(AppHandler, Singleton):
         if not playlist_current:
             self.logger.error("Failed to find playlist playing")
             return {'error': 'Failed to find playlist playing'}
+
+        detected = None
+        detected_key, _ = self.try_find_any_element_plus(
+            [
+                'play_mode_list_in_playlist',
+                'play_mode_single_in_playlist',
+                'play_mode_random_in_playlist',
+            ]
+        )
+        if detected_key == 'play_mode_list_in_playlist':
+            detected = 'list'
+        elif detected_key == 'play_mode_single_in_playlist':
+            detected = 'single'
+        elif detected_key == 'play_mode_random_in_playlist':
+            detected = 'random'
+
+        if detected:
+            if self.play_mode_key != detected:
+                self.logger.warning(
+                    f"play_mode_key drift detected in playlist UI: "
+                    f"recorded={self.play_mode_key}, detected={detected}"
+                )
+            self._update_play_mode_key(detected, reason='playlist_ui_self_heal')
 
         playlist_info = []
 


### PR DESCRIPTION
## Summary
- 记录 QQ 音乐播放模式为进程内状态（默认 unknown），`mode` 成功/已是目标时写入。
- `get_playlist_info()` 进入播放列表页后用播放列表页按钮自愈校验，发现漂移自动修正缓存。
- `mode` 对已知模式同目标请求做短路，避免重复切 App/UI 读取；`info` 输出附带当前播放模式。

## Test plan
- `uv sync --frozen`
- `uv run python tests/test_imports.py`
- `uv run python tests/test_playlist_response_format.py`
- E2E（真实运行）：注入 `:playlist` 触发自愈后，`info` 显示真实模式；`mode` 连续执行同目标第二次短路（不再出现 `[MODE_TEST]` 步骤日志）。


Made with [Cursor](https://cursor.com)