### PR TITLE
Refactor AppHandler UI helpers and driver refresh

### DIFF
--- a/docs/superpowers/plans/2026-05-07-architecture-hardening-slice.md
+++ b/docs/superpowers/plans/2026-05-07-architecture-hardening-slice.md
@@ -1,0 +1,1056 @@
+# Architecture Hardening Slice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce the highest-risk architecture pressure from `architecture_review.md` with a small, testable slice: split `AppHandler` UI helper responsibilities, centralize driver refresh notifications, and move root-level tests into pytest.
+
+**Architecture:** Keep `AppHandler` as the public compatibility facade for `SoulHandler` and `QQMusicHandler`, but move low-level UI operations into focused helper classes under `src/ushareiplay/core/ui/`. Add a lightweight driver subscriber registry to `AppController` so driver reinitialization updates every registered component through one path. Convert the four standalone root tests into normal pytest tests under `tests/` so the suite covers the cleanup without Appium.
+
+**Tech Stack:** Python 3.13, Appium Python Client, Selenium WebDriverWait/action APIs, Tortoise ORM, pytest, pytest-asyncio, uv.
+
+---
+
+## Scope
+
+This plan intentionally implements one independent architecture-hardening slice from the review. It does not introduce a ServiceRegistry, split `QQMusicHandler`, split `config.yaml`, or replace every `time.sleep()`/`print()`/broad `except Exception` in the project. Those are follow-up plans because each touches a different subsystem and should remain independently testable.
+
+## File Structure
+
+- Create `src/ushareiplay/core/ui/__init__.py`: exports the helper classes for import tests and future reuse.
+- Create `src/ushareiplay/core/ui/element_finder.py`: owns locator resolution, wait/find helpers, child element helpers, safe text/attribute helpers, and any-element helpers.
+- Create `src/ushareiplay/core/ui/key_actions.py`: owns Android key presses, clipboard, paste, app switching, and activity switching.
+- Create `src/ushareiplay/core/ui/gesture_handler.py`: owns coordinate taps, W3C swipes, and `scroll_container_until_element`.
+- Create `src/ushareiplay/core/ui/navigation.py`: owns `navigate_to_element`.
+- Modify `src/ushareiplay/core/app_handler.py`: keep logger/driver/config/controller setup and expose existing public methods as thin delegates to helper instances.
+- Modify `src/ushareiplay/core/app_controller.py`: add driver subscriber registration and replace hard-coded driver assignment in `reinitialize_driver()`.
+- Modify `tests/test_imports.py`: include the new `ushareiplay.core.ui.*` modules.
+- Create `tests/test_app_controller_driver_subscribers.py`: unit-test driver subscriber registration and notification without calling `AppController.__init__`.
+- Create `tests/test_command_parser_no_config_mutation.py`: pytest version of root `test_command_parser_no_config_mutation.py`.
+- Create `tests/test_keyword_acl.py`: pytest version of root `test_keyword_acl.py`.
+- Create `tests/test_user_canonical_mapping.py`: pytest version of root `test_user_canonical_mapping.py`.
+- Create `tests/test_avatar_exit.py`: pytest version of root `test_avatar_exit.py`.
+- Delete root `test_command_parser_no_config_mutation.py`, `test_keyword_acl.py`, `test_user_canonical_mapping.py`, and `test_avatar_exit.py` after the moved tests pass.
+
+## Task 1: Add Focused UI Helper Modules
+
+**Files:**
+- Create: `src/ushareiplay/core/ui/__init__.py`
+- Create: `src/ushareiplay/core/ui/element_finder.py`
+- Create: `src/ushareiplay/core/ui/key_actions.py`
+- Create: `src/ushareiplay/core/ui/gesture_handler.py`
+- Create: `src/ushareiplay/core/ui/navigation.py`
+- Modify: `tests/test_imports.py`
+
+- [ ] **Step 1: Write import coverage for new modules**
+
+Add these entries to `MODULES` in `tests/test_imports.py` immediately after `"ushareiplay.core.driver_decorator"`:
+
+```python
+    "ushareiplay.core.ui",
+    "ushareiplay.core.ui.element_finder",
+    "ushareiplay.core.ui.gesture_handler",
+    "ushareiplay.core.ui.key_actions",
+    "ushareiplay.core.ui.navigation",
+```
+
+- [ ] **Step 2: Run import test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q tests/test_imports.py
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'ushareiplay.core.ui'`.
+
+- [ ] **Step 3: Create `src/ushareiplay/core/ui/__init__.py`**
+
+```python
+from ushareiplay.core.ui.element_finder import ElementFinder
+from ushareiplay.core.ui.gesture_handler import GestureHandler
+from ushareiplay.core.ui.key_actions import KeyActions
+from ushareiplay.core.ui.navigation import Navigator
+
+__all__ = [
+    "ElementFinder",
+    "GestureHandler",
+    "KeyActions",
+    "Navigator",
+]
+```
+
+- [ ] **Step 4: Create `src/ushareiplay/core/ui/element_finder.py`**
+
+Copy these methods from `AppHandler` into an `ElementFinder` class:
+
+```python
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from appium.webdriver.common.appiumby import AppiumBy
+from selenium.common.exceptions import StaleElementReferenceException, TimeoutException
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from ushareiplay.core.driver_decorator import with_driver_recovery
+
+
+class ElementFinder:
+    def __init__(self, owner):
+        self.owner = owner
+
+    @property
+    def driver(self):
+        return self.owner.driver
+
+    @property
+    def config(self):
+        return self.owner.config
+
+    @property
+    def logger(self):
+        return self.owner.logger
+```
+
+Then move the full current bodies of these methods from `AppHandler` into `ElementFinder`, replacing `self.log_debug(...)` with `self.owner.log_debug(...)` only where the original method used `log_debug`:
+
+```python
+    @with_driver_recovery(op="read")
+    def wait_for_element(self, locator_type, locator_value, timeout=10):
+        ...
+
+    @with_driver_recovery(op="read")
+    def wait_for_element_plus(self, element_key: str, timeout: int = 10) -> WebElement:
+        ...
+
+    def is_element_clickable(self, element):
+        ...
+
+    @with_driver_recovery(op="read")
+    def wait_for_element_clickable_plus(self, element_key: str, timeout: int = 10) -> WebElement:
+        ...
+
+    @with_driver_recovery(op="read")
+    def wait_for_element_clickable(self, locator_type, locator_value, timeout=10):
+        ...
+
+    @with_driver_recovery(op="read")
+    def try_find_element_plus(self, element_key: str, log=False, clickable=False) -> WebElement:
+        ...
+
+    @with_driver_recovery(op="read")
+    def try_find_element(self, locator_type, locator_value, log=True, clickable=False):
+        ...
+
+    @with_driver_recovery(op="read")
+    def wait_for_element_polling(self, locator_type, locator_value, timeout=10, poll_frequency=0.5):
+        ...
+
+    @with_driver_recovery(op="read")
+    def wait_for_element_clickable_polling(self, locator_type, locator_value, timeout=10, poll_frequency=0.5):
+        ...
+
+    def find_child_element(self, parent, locator_type, locator_value):
+        ...
+
+    def find_child_elements(self, parent, locator_type, locator_value):
+        ...
+
+    def get_element_text(self, element):
+        ...
+
+    def try_get_attribute(self, element, attribute):
+        ...
+
+    def _get_locator(self, element_key: str) -> tuple:
+        ...
+
+    @with_driver_recovery(op="read")
+    def find_elements_plus(self, element_key: str) -> list:
+        ...
+
+    def find_child_element_plus(self, parent, element_key):
+        ...
+
+    def find_child_elements_plus(self, parent, element_key: str) -> list:
+        ...
+
+    @with_driver_recovery(op="read")
+    def wait_for_any_element_plus(self, element_keys: list, timeout: int = 10) -> Tuple[Optional[str], Optional[WebElement]]:
+        ...
+
+    def try_find_any_element_plus(self, element_keys: list) -> Tuple[Optional[str], Optional[WebElement]]:
+        ...
+```
+
+Keep the existing behavior exactly. Do not improve exception handling or sleeps in this task.
+
+- [ ] **Step 5: Create `src/ushareiplay/core/ui/key_actions.py`**
+
+```python
+from __future__ import annotations
+
+import time
+
+from ushareiplay.core.driver_decorator import with_driver_recovery
+
+
+class KeyActions:
+    def __init__(self, owner):
+        self.owner = owner
+
+    @property
+    def driver(self):
+        return self.owner.driver
+
+    @property
+    def config(self):
+        return self.owner.config
+
+    @property
+    def logger(self):
+        return self.owner.logger
+```
+
+Then move the full current bodies of these methods from `AppHandler` into `KeyActions`:
+
+```python
+    @with_driver_recovery(retry=False, op="write")
+    def switch_to_app(self):
+        ...
+
+    @with_driver_recovery(retry=False, op="write")
+    def close_app(self):
+        ...
+
+    @with_driver_recovery(retry=False, op="write")
+    def switch_to_activity(self, activity):
+        ...
+
+    @with_driver_recovery(retry=False, op="write")
+    def press_enter(self, element):
+        ...
+
+    @with_driver_recovery(retry=False, op="write")
+    def press_back(self):
+        ...
+
+    @with_driver_recovery(retry=False, op="write")
+    def press_dpad_down(self):
+        ...
+
+    @with_driver_recovery(retry=False, op="write")
+    def press_volume_up(self):
+        ...
+
+    @with_driver_recovery(retry=False, op="write")
+    def press_volume_down(self):
+        ...
+
+    @with_driver_recovery(retry=False, op="write")
+    def press_right_key(self, times=1):
+        ...
+
+    @with_driver_recovery(retry=False, op="write")
+    def set_clipboard_text(self, text):
+        ...
+
+    @with_driver_recovery(retry=False, op="write")
+    def paste_text(self):
+        ...
+```
+
+When moving `press_back`, preserve `self.owner.error_count = 0` because `error_count` lives on `AppHandler`.
+
+- [ ] **Step 6: Create `src/ushareiplay/core/ui/gesture_handler.py`**
+
+```python
+from __future__ import annotations
+
+import traceback
+from typing import Optional, Tuple
+
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.actions import interaction
+from selenium.webdriver.common.actions.action_builder import ActionBuilder
+from selenium.webdriver.common.actions.pointer_input import PointerInput
+from selenium.webdriver.remote.webelement import WebElement
+
+from ushareiplay.core.driver_decorator import with_driver_recovery
+
+
+class GestureHandler:
+    def __init__(self, owner):
+        self.owner = owner
+
+    @property
+    def driver(self):
+        return self.owner.driver
+
+    @property
+    def logger(self):
+        return self.owner.logger
+```
+
+Then move the full current bodies of these methods from `AppHandler` into `GestureHandler`:
+
+```python
+    @with_driver_recovery(retry=False, op="write")
+    def click_element_at(self, element, x_ratio=0.5, y_ratio=0.5, x_offset=0, y_offset=0):
+        ...
+
+    @with_driver_recovery(retry=False, op="write")
+    def _perform_swipe(self, start_x: int, start_y: int, end_x: int, end_y: int, duration_ms: int = 300) -> bool:
+        ...
+
+    @with_driver_recovery(op="read")
+    def scroll_container_until_element(
+        self,
+        element_key: str,
+        container_key: str,
+        direction: str = "up",
+        attribute_name: str = None,
+        attribute_value: str = None,
+        max_swipes: int = 10,
+    ) -> Tuple[Optional[str], Optional[WebElement], list[str]]:
+        ...
+```
+
+Inside `scroll_container_until_element`, replace helper calls with owner calls so the facade remains the dependency point:
+
+```python
+container = self.owner.wait_for_element_clickable_plus(container_key)
+container = self.owner.wait_for_element_plus(container_key)
+found = self.owner.find_child_element_plus(container, element_key)
+elements = self.owner.find_child_elements_plus(container, element_key)
+value = self.owner.try_get_attribute(element, attr)
+ok = self._perform_swipe(sx, sy, ex, ey, duration_ms=100)
+```
+
+- [ ] **Step 7: Create `src/ushareiplay/core/ui/navigation.py`**
+
+```python
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from selenium.webdriver.remote.webelement import WebElement
+
+
+class Navigator:
+    def __init__(self, owner):
+        self.owner = owner
+
+    @property
+    def logger(self):
+        return self.owner.logger
+
+    def navigate_to_element(
+        self,
+        target_key: str,
+        interference_keys: list = None,
+        home_key: str = "home_nav",
+        back_keys=None,
+        max_attempts: int = 10,
+    ) -> Tuple[Optional[str], Optional[WebElement]]:
+        ...
+```
+
+Move the full current body of `AppHandler.navigate_to_element` into `Navigator.navigate_to_element`, replacing `self.press_back()`, `self.wait_for_any_element_plus(...)`, `self.try_find_any_element_plus(...)`, and `self.click_element_at(...)` with `self.owner.press_back()`, `self.owner.wait_for_any_element_plus(...)`, `self.owner.try_find_any_element_plus(...)`, and `self.owner.click_element_at(...)`.
+
+- [ ] **Step 8: Run import test to verify helper modules import**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q tests/test_imports.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/ushareiplay/core/ui tests/test_imports.py
+git commit -m "refactor: add ui helper modules"
+```
+
+## Task 2: Turn `AppHandler` Into a Compatibility Facade
+
+**Files:**
+- Modify: `src/ushareiplay/core/app_handler.py`
+
+- [ ] **Step 1: Add helper construction to `AppHandler.__init__`**
+
+Add imports near the existing imports:
+
+```python
+from ushareiplay.core.ui import ElementFinder, GestureHandler, KeyActions, Navigator
+```
+
+After `self.controller = controller`, add:
+
+```python
+        self.element_finder = ElementFinder(self)
+        self.key_actions = KeyActions(self)
+        self.gestures = GestureHandler(self)
+        self.navigator = Navigator(self)
+```
+
+- [ ] **Step 2: Replace moved methods with delegates**
+
+For every method moved in Task 1, replace the old body in `AppHandler` with a one-line delegate. Use exactly these wrappers so existing `SoulHandler`, `QQMusicHandler`, managers, commands, and events keep calling the same public methods:
+
+```python
+    def wait_for_element(self, *args, **kwargs):
+        return self.element_finder.wait_for_element(*args, **kwargs)
+
+    def wait_for_element_plus(self, *args, **kwargs):
+        return self.element_finder.wait_for_element_plus(*args, **kwargs)
+
+    def is_element_clickable(self, *args, **kwargs):
+        return self.element_finder.is_element_clickable(*args, **kwargs)
+
+    def wait_for_element_clickable_plus(self, *args, **kwargs):
+        return self.element_finder.wait_for_element_clickable_plus(*args, **kwargs)
+
+    def wait_for_element_clickable(self, *args, **kwargs):
+        return self.element_finder.wait_for_element_clickable(*args, **kwargs)
+
+    def switch_to_app(self, *args, **kwargs):
+        return self.key_actions.switch_to_app(*args, **kwargs)
+
+    def close_app(self, *args, **kwargs):
+        return self.key_actions.close_app(*args, **kwargs)
+
+    def switch_to_activity(self, *args, **kwargs):
+        return self.key_actions.switch_to_activity(*args, **kwargs)
+
+    def press_enter(self, *args, **kwargs):
+        return self.key_actions.press_enter(*args, **kwargs)
+
+    def press_back(self, *args, **kwargs):
+        return self.key_actions.press_back(*args, **kwargs)
+
+    def press_dpad_down(self, *args, **kwargs):
+        return self.key_actions.press_dpad_down(*args, **kwargs)
+
+    def press_volume_up(self, *args, **kwargs):
+        return self.key_actions.press_volume_up(*args, **kwargs)
+
+    def press_volume_down(self, *args, **kwargs):
+        return self.key_actions.press_volume_down(*args, **kwargs)
+
+    def press_right_key(self, *args, **kwargs):
+        return self.key_actions.press_right_key(*args, **kwargs)
+
+    def try_find_element_plus(self, *args, **kwargs):
+        return self.element_finder.try_find_element_plus(*args, **kwargs)
+
+    def try_find_element(self, *args, **kwargs):
+        return self.element_finder.try_find_element(*args, **kwargs)
+
+    def wait_for_element_polling(self, *args, **kwargs):
+        return self.element_finder.wait_for_element_polling(*args, **kwargs)
+
+    def wait_for_element_clickable_polling(self, *args, **kwargs):
+        return self.element_finder.wait_for_element_clickable_polling(*args, **kwargs)
+
+    def set_clipboard_text(self, *args, **kwargs):
+        return self.key_actions.set_clipboard_text(*args, **kwargs)
+
+    def paste_text(self, *args, **kwargs):
+        return self.key_actions.paste_text(*args, **kwargs)
+
+    def find_child_element(self, *args, **kwargs):
+        return self.element_finder.find_child_element(*args, **kwargs)
+
+    def find_child_elements(self, *args, **kwargs):
+        return self.element_finder.find_child_elements(*args, **kwargs)
+
+    def get_element_text(self, *args, **kwargs):
+        return self.element_finder.get_element_text(*args, **kwargs)
+
+    def try_get_attribute(self, *args, **kwargs):
+        return self.element_finder.try_get_attribute(*args, **kwargs)
+
+    def _get_locator(self, *args, **kwargs):
+        return self.element_finder._get_locator(*args, **kwargs)
+
+    def find_elements_plus(self, *args, **kwargs):
+        return self.element_finder.find_elements_plus(*args, **kwargs)
+
+    def click_element_at(self, *args, **kwargs):
+        return self.gestures.click_element_at(*args, **kwargs)
+
+    def find_child_element_plus(self, *args, **kwargs):
+        return self.element_finder.find_child_element_plus(*args, **kwargs)
+
+    def find_child_elements_plus(self, *args, **kwargs):
+        return self.element_finder.find_child_elements_plus(*args, **kwargs)
+
+    def _perform_swipe(self, *args, **kwargs):
+        return self.gestures._perform_swipe(*args, **kwargs)
+
+    def scroll_container_until_element(self, *args, **kwargs):
+        return self.gestures.scroll_container_until_element(*args, **kwargs)
+
+    def wait_for_any_element_plus(self, *args, **kwargs):
+        return self.element_finder.wait_for_any_element_plus(*args, **kwargs)
+
+    def try_find_any_element_plus(self, *args, **kwargs):
+        return self.element_finder.try_find_any_element_plus(*args, **kwargs)
+
+    def navigate_to_element(self, *args, **kwargs):
+        return self.navigator.navigate_to_element(*args, **kwargs)
+```
+
+- [ ] **Step 3: Remove unused imports from `app_handler.py`**
+
+After the delegation rewrite, remove imports that are only needed by helper modules:
+
+```python
+import time
+import traceback
+from typing import Optional, Tuple
+
+from appium.webdriver.common.appiumby import AppiumBy
+from ushareiplay.core.driver_decorator import with_driver_recovery
+from selenium.common.exceptions import (
+    StaleElementReferenceException,
+    TimeoutException,
+)
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.actions import interaction
+from selenium.webdriver.common.actions.action_builder import ActionBuilder
+from selenium.webdriver.common.actions.pointer_input import PointerInput
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+```
+
+Keep only imports still used by `AppHandler` itself:
+
+```python
+import logging
+from datetime import datetime
+
+from ushareiplay.core.log_formatter import ColoredFormatter
+from ushareiplay.core.ui import ElementFinder, GestureHandler, KeyActions, Navigator
+```
+
+- [ ] **Step 4: Run syntax and import checks**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m py_compile src/ushareiplay/core/app_handler.py src/ushareiplay/core/ui/element_finder.py src/ushareiplay/core/ui/key_actions.py src/ushareiplay/core/ui/gesture_handler.py src/ushareiplay/core/ui/navigation.py
+uv run pytest -q tests/test_imports.py
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ushareiplay/core/app_handler.py src/ushareiplay/core/ui
+git commit -m "refactor: delegate app handler ui operations"
+```
+
+## Task 3: Add Driver Subscriber Registry
+
+**Files:**
+- Modify: `src/ushareiplay/core/app_controller.py`
+- Create: `tests/test_app_controller_driver_subscribers.py`
+
+- [ ] **Step 1: Write tests for registration, duplicate prevention, and notification**
+
+Create `tests/test_app_controller_driver_subscribers.py`:
+
+```python
+from types import SimpleNamespace
+
+from ushareiplay.core.app_controller import AppController
+
+
+class DriverAware:
+    def __init__(self):
+        self.driver = None
+
+
+def controller_without_init():
+    controller = AppController.__new__(AppController)
+    controller._driver_subscribers = []
+    controller.logger = None
+    return controller
+
+
+def test_register_driver_subscriber_adds_unique_objects():
+    controller = controller_without_init()
+    subscriber = DriverAware()
+
+    controller.register_driver_subscriber(subscriber)
+    controller.register_driver_subscriber(subscriber)
+
+    assert controller._driver_subscribers == [subscriber]
+
+
+def test_notify_driver_subscribers_sets_driver_on_each_registered_object():
+    controller = controller_without_init()
+    first = DriverAware()
+    second = DriverAware()
+    new_driver = SimpleNamespace(name="new-driver")
+
+    controller.register_driver_subscriber(first)
+    controller.register_driver_subscriber(second)
+    controller._notify_driver_subscribers(new_driver)
+
+    assert first.driver is new_driver
+    assert second.driver is new_driver
+```
+
+- [ ] **Step 2: Run the new test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q tests/test_app_controller_driver_subscribers.py
+```
+
+Expected: FAIL with `AttributeError: 'AppController' object has no attribute 'register_driver_subscriber'`.
+
+- [ ] **Step 3: Initialize subscriber storage in `AppController.__init__`**
+
+In `src/ushareiplay/core/app_controller.py`, after `self.driver = self._init_driver()`, add:
+
+```python
+        self._driver_subscribers = []
+```
+
+- [ ] **Step 4: Add subscriber methods to `AppController`**
+
+Add these methods before `reinitialize_driver()`:
+
+```python
+    def register_driver_subscriber(self, component) -> None:
+        """Register a component whose .driver reference must track controller.driver."""
+        if component is None:
+            return
+        if component in self._driver_subscribers:
+            return
+        self._driver_subscribers.append(component)
+        if hasattr(component, "driver"):
+            component.driver = self.driver
+
+    def _notify_driver_subscribers(self, driver) -> None:
+        for component in list(self._driver_subscribers):
+            if not hasattr(component, "driver"):
+                continue
+            component.driver = driver
+            if self.logger:
+                self.logger.debug(
+                    "更新 %s.driver",
+                    component.__class__.__name__,
+                )
+```
+
+- [ ] **Step 5: Register driver-aware components in `_init_handlers()`**
+
+After each driver-aware component is created in `_init_handlers()`, register it:
+
+```python
+            self.soul_handler = SoulHandler.instance(
+                self.driver, self.config["soul"], self
+            )
+            self.register_driver_subscriber(self.soul_handler)
+            self.music_handler = QQMusicHandler.instance(
+                self.driver, self.config["qq_music"], self
+            )
+            self.register_driver_subscriber(self.music_handler)
+```
+
+After `self.music_manager = MusicManager.instance()`, add:
+
+```python
+            self.register_driver_subscriber(self.music_manager)
+```
+
+- [ ] **Step 6: Replace hard-coded driver updates in `reinitialize_driver()`**
+
+Replace this block:
+
+```python
+            # 4. 更新所有组件的driver引用
+            if self.soul_handler:
+                self.soul_handler.driver = self.driver
+                if self.logger:
+                    self.logger.debug("更新 soul_handler.driver")
+
+            if self.music_handler:
+                self.music_handler.driver = self.driver
+                if self.logger:
+                    self.logger.debug("更新 music_handler.driver")
+
+            # 5. 更新music_manager（关键修复！）
+            if hasattr(self, "music_manager") and self.music_manager:
+                self.music_manager.driver = self.driver
+                if self.logger:
+                    self.logger.debug("更新 music_manager.driver")
+
+            # 6. 切换回应用
+```
+
+With:
+
+```python
+            # 4. 更新所有订阅组件的driver引用
+            self._notify_driver_subscribers(self.driver)
+
+            # 5. 切换回应用
+```
+
+- [ ] **Step 7: Run focused tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q tests/test_app_controller_driver_subscribers.py tests/test_imports.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/ushareiplay/core/app_controller.py tests/test_app_controller_driver_subscribers.py
+git commit -m "refactor: centralize driver subscriber updates"
+```
+
+## Task 4: Move Root Tests Into `tests/`
+
+**Files:**
+- Create: `tests/test_command_parser_no_config_mutation.py`
+- Create: `tests/test_keyword_acl.py`
+- Create: `tests/test_user_canonical_mapping.py`
+- Create: `tests/test_avatar_exit.py`
+- Delete: `test_command_parser_no_config_mutation.py`
+- Delete: `test_keyword_acl.py`
+- Delete: `test_user_canonical_mapping.py`
+- Delete: `test_avatar_exit.py`
+
+- [ ] **Step 1: Create pytest version of command parser mutation test**
+
+Create `tests/test_command_parser_no_config_mutation.py`:
+
+```python
+from ushareiplay.core.command_parser import CommandParser
+
+
+def test_command_parser_does_not_mutate_shared_config():
+    commands = [
+        {"prefix": "help", "response_template": "ok"},
+        {"prefix": "play", "response_template": "ok"},
+    ]
+    parser = CommandParser(commands)
+
+    help_result = parser.parse_command("help")
+    assert help_result is not None
+    assert help_result["prefix"] == "help"
+    assert help_result.get("parameters") == []
+
+    play_result = parser.parse_command("play foo")
+    assert play_result is not None
+    assert play_result["prefix"] == "play"
+    assert play_result.get("parameters") == ["foo"]
+
+    assert "parameters" not in commands[0]
+    assert "parameters" not in commands[1]
+```
+
+- [ ] **Step 2: Create pytest version of keyword ACL test**
+
+Create `tests/test_keyword_acl.py`:
+
+```python
+import pytest
+
+from ushareiplay.core.db_manager import DatabaseManager
+from ushareiplay.dal.keyword_dao import KeywordDAO
+from ushareiplay.dal.user_dao import UserDAO
+
+
+@pytest.mark.asyncio
+async def test_private_keyword_acl_and_canonical_alias_access():
+    db = DatabaseManager(db_url="sqlite://:memory:")
+    await db.init()
+    try:
+        user_a = await UserDAO.get_or_create("A")
+        user_b = await UserDAO.get_or_create("B")
+        user_c = await UserDAO.get_or_create("C")
+
+        await KeywordDAO.create(
+            keyword="k1",
+            command=":help",
+            creator_id=user_a.id,
+            is_public=False,
+        )
+
+        assert await KeywordDAO.find_accessible_keyword("k1", "A") is not None
+        assert await KeywordDAO.find_accessible_keyword("k1", "B") is None
+
+        await KeywordDAO.grant_users("k1", [user_b.id, user_c.id])
+        assert await KeywordDAO.find_accessible_keyword("k1", "B") is not None
+        assert await KeywordDAO.find_accessible_keyword("k1", "C") is not None
+
+        await KeywordDAO.revoke_users("k1", [user_b.id])
+        assert await KeywordDAO.find_accessible_keyword("k1", "B") is None
+        assert await KeywordDAO.find_accessible_keyword("k1", "C") is not None
+
+        alias_user = await UserDAO.get_or_create_raw("A2")
+        alias_user.canonical_user_id = user_a.id
+        await alias_user.save(update_fields=["canonical_user_id"])
+        assert await KeywordDAO.find_accessible_keyword("k1", "A2") is not None
+    finally:
+        await db.close()
+```
+
+- [ ] **Step 3: Create pytest version of canonical user mapping test**
+
+Create `tests/test_user_canonical_mapping.py`:
+
+```python
+import pytest
+
+from ushareiplay.core.db_manager import DatabaseManager
+from ushareiplay.dal.user_dao import UserDAO
+
+
+@pytest.mark.asyncio
+async def test_alias_username_resolves_to_canonical_user():
+    db = DatabaseManager(db_url="sqlite://:memory:")
+    await db.init()
+    try:
+        canonical = await UserDAO.get_or_create("小明")
+        canonical.level = 3
+        await canonical.save(update_fields=["level"])
+
+        alias_raw = await UserDAO.get_or_create_raw("明明")
+        alias_raw.canonical_user_id = canonical.id
+        await alias_raw.save(update_fields=["canonical_user_id"])
+
+        resolved = await UserDAO.get_or_create("明明")
+        assert resolved.id == canonical.id
+        assert resolved.username == "小明"
+        assert resolved.level == 3
+
+        resolved2 = await UserDAO.get_or_create("小明")
+        assert resolved2.id == canonical.id
+    finally:
+        await db.close()
+```
+
+- [ ] **Step 4: Create pytest version of avatar exit tests**
+
+Create `tests/test_avatar_exit.py`:
+
+```python
+import pytest
+from tortoise import Tortoise
+
+from ushareiplay.dal.user_dao import UserDAO
+from ushareiplay.models.user import User
+
+
+@pytest.fixture
+async def user_db():
+    await Tortoise.init(
+        db_url="sqlite://:memory:",
+        modules={"models": ["ushareiplay.models.user"]},
+    )
+    await Tortoise.generate_schemas()
+    try:
+        yield
+    finally:
+        await Tortoise.close_connections()
+
+
+@pytest.mark.asyncio
+async def test_get_all_avatar_usernames(user_db):
+    canonical = await User.create(username="小明", level=0)
+    await User.create(username="明明", level=0, canonical_user_id=canonical.id)
+    await User.create(username="小M", level=0, canonical_user_id=canonical.id)
+
+    result = await UserDAO.get_all_avatar_usernames("小明")
+
+    assert result == {"小明", "明明", "小M"}
+
+
+@pytest.mark.asyncio
+async def test_no_leave_if_alias_still_online(user_db):
+    canonical = await User.create(username="小明", level=0)
+    await User.create(username="明明", level=0, canonical_user_id=canonical.id)
+
+    online_users = {"小明", "张三"}
+    all_avatars = await UserDAO.get_all_avatar_usernames("明明")
+    still_online = all_avatars & online_users
+
+    assert len(still_online) != 0
+
+
+@pytest.mark.asyncio
+async def test_leave_when_all_avatars_offline(user_db):
+    canonical = await User.create(username="小明", level=0)
+    await User.create(username="明明", level=0, canonical_user_id=canonical.id)
+
+    online_users = {"张三", "李四"}
+    all_avatars = await UserDAO.get_all_avatar_usernames("明明")
+    still_online = all_avatars & online_users
+
+    assert len(still_online) == 0
+
+
+@pytest.mark.asyncio
+async def test_no_aliases_user_triggers_immediately(user_db):
+    await User.create(username="张三", level=0)
+
+    online_users = {"李四"}
+    all_avatars = await UserDAO.get_all_avatar_usernames("张三")
+    still_online = all_avatars & online_users
+
+    assert len(still_online) == 0
+
+
+@pytest.mark.asyncio
+async def test_alias_queried_resolves_to_canonical_group(user_db):
+    canonical = await User.create(username="小明", level=0)
+    await User.create(username="明明", level=0, canonical_user_id=canonical.id)
+    await User.create(username="小M", level=0, canonical_user_id=canonical.id)
+
+    result = await UserDAO.get_all_avatar_usernames("明明")
+
+    assert "小明" in result
+    assert "明明" in result
+    assert "小M" in result
+    assert len(result) == 3
+```
+
+- [ ] **Step 5: Run moved tests while root files still exist**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q tests/test_command_parser_no_config_mutation.py tests/test_keyword_acl.py tests/test_user_canonical_mapping.py tests/test_avatar_exit.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Delete root standalone tests**
+
+Delete these files:
+
+```bash
+rm test_command_parser_no_config_mutation.py test_keyword_acl.py test_user_canonical_mapping.py test_avatar_exit.py
+```
+
+- [ ] **Step 7: Verify there are no root test files left**
+
+Run:
+
+```bash
+find . -maxdepth 1 -name 'test_*.py' -print
+```
+
+Expected: no output.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/test_command_parser_no_config_mutation.py tests/test_keyword_acl.py tests/test_user_canonical_mapping.py tests/test_avatar_exit.py
+git rm test_command_parser_no_config_mutation.py test_keyword_acl.py test_user_canonical_mapping.py test_avatar_exit.py
+git commit -m "test: move standalone tests into pytest suite"
+```
+
+## Task 5: Final Verification and Review Notes
+
+**Files:**
+- Modify only if earlier verification exposes issues.
+
+- [ ] **Step 1: Run syntax checks for touched source**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m py_compile src/ushareiplay/core/app_handler.py src/ushareiplay/core/app_controller.py src/ushareiplay/core/ui/__init__.py src/ushareiplay/core/ui/element_finder.py src/ushareiplay/core/ui/key_actions.py src/ushareiplay/core/ui/gesture_handler.py src/ushareiplay/core/ui/navigation.py
+```
+
+Expected: PASS with no output.
+
+- [ ] **Step 2: Run focused architecture-slice tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q tests/test_imports.py tests/test_app_controller_driver_subscribers.py tests/test_command_parser_no_config_mutation.py tests/test_keyword_acl.py tests/test_user_canonical_mapping.py tests/test_avatar_exit.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full test suite**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q
+```
+
+Expected: PASS. If a test requires external Appium/device state, document the exact failing test and reason; do not run `main.py` because AGENTS.md says it always fails in this environment without Appium and Android apps.
+
+- [ ] **Step 4: Inspect diff for accidental behavior changes**
+
+Run:
+
+```bash
+git diff -- src/ushareiplay/core/app_handler.py src/ushareiplay/core/ui src/ushareiplay/core/app_controller.py tests
+```
+
+Expected:
+- `AppHandler` keeps all previous public method names.
+- New helper modules contain the moved method bodies.
+- `reinitialize_driver()` calls `_notify_driver_subscribers(self.driver)`.
+- Root tests are represented under `tests/`.
+
+- [ ] **Step 5: Commit any verification fixes**
+
+If verification required fixes, commit them:
+
+```bash
+git add src/ushareiplay/core/app_handler.py src/ushareiplay/core/ui src/ushareiplay/core/app_controller.py tests
+git commit -m "fix: stabilize architecture hardening slice"
+```
+
+If no fixes were needed, skip this step.
+
+## Follow-Up Plans
+
+- ServiceRegistry/DI plan: remove direct `AppController.instance()` calls from `driver_decorator.py`, `command_manager.py`, `event_manager.py`, and `events/chat_room_title.py`.
+- Async blocking plan: replace or isolate `time.sleep()` calls beginning with event-loop paths in `AppController.start_monitoring()`, command execution, and handlers.
+- Logging plan: replace production `print()` calls with logger calls where a logger is available.
+- QQMusicHandler plan: split search, playlist, lyrics, quality filtering, and playback control into a `handlers/qq_music/` package.
+- Config plan: introduce layered config files while preserving `config.yaml` and `config.local.yaml` compatibility.
+
+## Self-Review
+
+- Spec coverage: This plan covers P0 `AppHandler` splitting, P2 driver reference observer pattern, and P2 root test cleanup. It scopes out DI, broad exception cleanup, full async sleep replacement, print/logger cleanup, QQMusic split, config split, and DB migration tooling as separate follow-up plans.
+- Placeholder scan: No `TBD`, `TODO`, "implement later", or unspecified test steps remain. The only ellipses appear in code move instructions where the exact source is the existing method body in `AppHandler`; the target method list and required substitutions are explicit.
+- Type consistency: Helper class names are `ElementFinder`, `KeyActions`, `GestureHandler`, and `Navigator` throughout. `AppController` uses `_driver_subscribers`, `register_driver_subscriber()`, and `_notify_driver_subscribers()` consistently.

--- a/src/ushareiplay/core/app_controller.py
+++ b/src/ushareiplay/core/app_controller.py
@@ -38,6 +38,7 @@ class AppController(Singleton):
         # 先创建主driver（会自动启动Soul app）
         self.obs.emit("driver.init.start")
         self.driver = self._init_driver()
+        self._driver_subscribers = []
         self.obs.emit("driver.init.ok")
 
         # 使用主driver启动其他应用
@@ -170,6 +171,31 @@ class AppController(Singleton):
         })
         return driver
 
+    def register_driver_subscriber(self, component) -> None:
+        """Register a component whose .driver reference must track controller.driver."""
+        if component is None:
+            return
+        if not hasattr(self, "_driver_subscribers"):
+            self._driver_subscribers = []
+        if component in self._driver_subscribers:
+            return
+        self._driver_subscribers.append(component)
+        if hasattr(component, "driver"):
+            component.driver = self.driver
+
+    def _notify_driver_subscribers(self, driver) -> None:
+        if not hasattr(self, "_driver_subscribers"):
+            self._driver_subscribers = []
+        for component in list(self._driver_subscribers):
+            if not hasattr(component, "driver"):
+                continue
+            component.driver = driver
+            if self.logger:
+                self.logger.debug(
+                    "更新 %s.driver",
+                    component.__class__.__name__,
+                )
+
     def reinitialize_driver(self) -> bool:
         """
         统一的driver重建入口
@@ -211,24 +237,10 @@ class AppController(Singleton):
             })
             self.logger.info("Optimized driver settings")
 
-            # 4. 更新所有组件的driver引用
-            if self.soul_handler:
-                self.soul_handler.driver = self.driver
-                if self.logger:
-                    self.logger.debug("更新 soul_handler.driver")
+            # 4. 更新所有订阅组件的driver引用
+            self._notify_driver_subscribers(self.driver)
 
-            if self.music_handler:
-                self.music_handler.driver = self.driver
-                if self.logger:
-                    self.logger.debug("更新 music_handler.driver")
-
-            # 5. 更新music_manager（关键修复！）
-            if hasattr(self, "music_manager") and self.music_manager:
-                self.music_manager.driver = self.driver
-                if self.logger:
-                    self.logger.debug("更新 music_manager.driver")
-
-            # 6. 切换回应用
+            # 5. 切换回应用
             if self.soul_handler:
                 self.soul_handler.switch_to_app()
 
@@ -281,9 +293,11 @@ class AppController(Singleton):
             self.soul_handler = SoulHandler.instance(
                 self.driver, self.config["soul"], self
             )
+            self.register_driver_subscriber(self.soul_handler)
             self.music_handler = QQMusicHandler.instance(
                 self.driver, self.config["qq_music"], self
             )
+            self.register_driver_subscriber(self.music_handler)
             self.logger = self.soul_handler.logger
 
             # Initialize managers using singleton pattern (no parameters needed)
@@ -302,6 +316,7 @@ class AppController(Singleton):
             self.topic_manager = TopicManager.instance()
             self.mic_manager = MicManager.instance()
             self.music_manager = MusicManager.instance()
+            self.register_driver_subscriber(self.music_manager)
             self.recovery_manager = RecoveryManager.instance()
             self.timer_manager = TimerManager.instance()
             self.command_manager = CommandManager.instance()

--- a/src/ushareiplay/core/app_handler.py
+++ b/src/ushareiplay/core/app_handler.py
@@ -1,24 +1,8 @@
 import logging
-import os
-import time
-import traceback
 from datetime import datetime
-from typing import Optional, Tuple
 
-from appium.webdriver.common.appiumby import AppiumBy
 from ushareiplay.core.log_formatter import ColoredFormatter
-from ushareiplay.core.driver_decorator import with_driver_recovery
-from selenium.common.exceptions import (
-    StaleElementReferenceException,
-    TimeoutException,
-)
-from selenium.webdriver.common.action_chains import ActionChains
-from selenium.webdriver.common.actions import interaction
-from selenium.webdriver.common.actions.action_builder import ActionBuilder
-from selenium.webdriver.common.actions.pointer_input import PointerInput
-from selenium.webdriver.remote.webelement import WebElement
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
+from ushareiplay.core.ui import ElementFinder, GestureHandler, KeyActions, Navigator
 
 
 class AppHandler:
@@ -31,6 +15,10 @@ class AppHandler:
         self.logger.debug(f"AppHandler logger 设置完成: {self.__class__.__name__}")
         self.error_count = 0
         self.controller = controller
+        self.element_finder = ElementFinder(self)
+        self.key_actions = KeyActions(self)
+        self.gesture_handler = GestureHandler(self)
+        self.navigator = Navigator(self)
         self.logger.debug(f"AppHandler.__init__ 完成: {self.__class__.__name__}")
 
     def _setup_logger(self):
@@ -111,801 +99,147 @@ class AppHandler:
         """Log warning level message"""
         self.logger.warning(message)
 
-    @with_driver_recovery(op="read")
     def wait_for_element(self, locator_type, locator_value, timeout=10):
-        """Wait for element to be present and return it"""
-        try:
-            element = WebDriverWait(self.driver, timeout).until(
-                EC.presence_of_element_located((locator_type, locator_value))
-            )
-            self.log_debug(f"Found element: {locator_value}")
-            return element
-        except Exception as e:
-            self.logger.warning(
-                f"Element not found within {timeout} seconds: {locator_value}"
-            )
-            self.logger.warning(f"Error: {str(e)}")
-            return None
+        return self.element_finder.wait_for_element(locator_type, locator_value, timeout=timeout)
 
-    @with_driver_recovery(op="read")
-    def wait_for_element_plus(self, element_key: str, timeout: int = 10) -> WebElement:
-        """Enhanced wait_for_element using just element key"""
-        try:
-            locator_type, value = self._get_locator(element_key)
-            element = WebDriverWait(self.driver, timeout).until(
-                EC.presence_of_element_located((locator_type, value))
-            )
-            self.logger.debug(f"Found  element: {element_key}")
-            return element
-        except TimeoutException:
-            self.logger.warning(
-                f"Element {element_key}:{value} not found within {timeout} seconds "
-            )
-            return None
+    def wait_for_element_plus(self, element_key: str, timeout: int = 10):
+        return self.element_finder.wait_for_element_plus(element_key, timeout=timeout)
 
     def is_element_clickable(self, element):
-        """Check if element is clickable
-        Args:
-            element: WebElement to check
-        Returns:
-            bool: True if element is clickable, False otherwise
-        """
-        try:
-            if not element:
-                return False
+        return self.element_finder.is_element_clickable(element)
 
-            # First check if element exists and is displayed
-            if not element.is_displayed():
-                return False
+    def wait_for_element_clickable_plus(self, element_key: str, timeout: int = 10):
+        return self.element_finder.wait_for_element_clickable_plus(element_key, timeout=timeout)
 
-            # Then check if element is enabled
-            if not element.is_enabled():
-                return False
-
-            # Finally check clickable attribute
-            clickable = element.get_attribute("clickable")
-            return clickable == "true"
-
-        except Exception as e:
-            self.logger.warning(f"Error checking if element is clickable: {str(e)}")
-            return False
-
-    @with_driver_recovery(op="read")
-    def wait_for_element_clickable_plus(
-            self, element_key: str, timeout: int = 10
-    ) -> WebElement:
-        """Enhanced wait_for_element using just element key"""
-        try:
-            locator_type, value = self._get_locator(element_key)
-            element = WebDriverWait(self.driver, timeout).until(
-                EC.element_to_be_clickable((locator_type, value))
-            )
-            self.logger.debug(f"Found clickable element: {element_key}")
-            return element
-        except TimeoutException:
-            self.logger.warning(
-                f"Clickable element {element_key}:{value} not found within {timeout} seconds "
-            )
-            return None
-        except StaleElementReferenceException:
-            self.logger.warning(f"Stale element reference for {element_key}:{value}")
-            return None
-
-    @with_driver_recovery(op="read")
     def wait_for_element_clickable(self, locator_type, locator_value, timeout=10):
-        """
-        Wait for element to be clickable and return it
-        Args:
-            locator_type: AppiumBy.ID or AppiumBy.XPATH etc.
-            locator_value: The locator value
-            timeout: Maximum time to wait in seconds
-        Returns:
-            WebElement if found and clickable, None if not
-        """
-        try:
-            element = WebDriverWait(self.driver, timeout).until(
-                EC.element_to_be_clickable((locator_type, locator_value))
-            )
-            self.logger.debug(f"Found clickable element: {locator_value}")
-            return element
-        except TimeoutException:
-            self.logger.warning(
-                f"Clickable element not found within {timeout} seconds: {locator_value}"
-            )
-            return None
+        return self.element_finder.wait_for_element_clickable(locator_type, locator_value, timeout=timeout)
 
-    @with_driver_recovery(retry=False, op="write")
-    def switch_to_app(self):
-        """Switch to specified app"""
-        self.driver.activate_app(self.config["package_name"])
-        time.sleep(0.1)
-        return True
+    def try_find_element_plus(self, element_key: str, log=False, clickable=False):
+        return self.element_finder.try_find_element_plus(element_key, log=log, clickable=clickable)
 
-    @with_driver_recovery(retry=False, op="write")
-    def close_app(self):
-        """关闭应用"""
-        self.driver.terminate_app(self.config["package_name"])
-
-    @with_driver_recovery(retry=False, op="write")
-    def switch_to_activity(self, activity):
-        """Switch to the specified activity"""
-        package_name = self.config["package_name"]
-        command = f"am start -n {package_name}/{activity}"
-        self.driver.execute_script("mobile: shell", {"command": command})
-
-    @with_driver_recovery(retry=False, op="write")
-    def press_enter(self, element):
-        """
-        Press Enter key on the given element
-        Args:
-            element: The WebElement to send Enter key to
-        """
-        self.driver.press_keycode(66)
-        self.logger.debug("Pressed Return Key")
-
-    @with_driver_recovery(retry=False, op="write")
-    def press_back(self):
-        """Press Android back button"""
-        self.driver.press_keycode(4)  # Android back key code
-        self.error_count = 0
-        self.logger.debug("Pressed back button")
-        return True
-
-    @with_driver_recovery(retry=False, op="write")
-    def press_dpad_down(self):
-        """Press Android DPAD down button"""
-        self.driver.press_keycode(20)  # KEYCODE_DPAD_DOWN
-        self.logger.debug("Pressed DPAD down button")
-
-    @with_driver_recovery(retry=False, op="write")
-    def press_volume_up(self):
-        """Press Android volume up button"""
-        self.driver.press_keycode(24)  # KEYCODE_VOLUME_UP
-        self.logger.debug("Pressed volume up button")
-
-    @with_driver_recovery(retry=False, op="write")
-    def press_volume_down(self):
-        """Press Android volume down button"""
-        self.driver.press_keycode(25)  # KEYCODE_VOLUME_DOWN
-        self.logger.debug("Pressed volume down button")
-
-    @with_driver_recovery(retry=False, op="write")
-    def press_right_key(self, times=1):
-        """Simulate pressing the right key multiple times
-        Args:
-            times: int, number of times to press the right key
-        """
-        for _ in range(times):
-            self.driver.execute_script(
-                "mobile: shell", {"command": "input keyevent KEYCODE_DPAD_RIGHT"}
-            )
-            time.sleep(0.1)  # Small delay between key presses
-
-    @with_driver_recovery(op="read")
-    def try_find_element_plus(
-            self, element_key: str, log=False, clickable=False
-    ) -> WebElement:
-        """Enhanced try_find_element using just element key"""
-        try:
-            if log:
-                self.logger.info(f"Looking for element '{element_key}'")
-
-            if element_key not in self.config["elements"]:
-                if log:
-                    self.logger.error(
-                        f"Element key '{element_key}' not defined in configuration"
-                    )
-                return None
-
-            locator_type, value = self._get_locator(element_key)
-            if log:
-                self.logger.info(
-                    f"Using locator type {locator_type} with value '{value}'"
-                )
-
-            element = self.driver.find_element(locator_type, value)
-            if element:
-                if log:
-                    try:
-                        element_text = element.text
-                        element_attrs = {
-                            "displayed": element.is_displayed(),
-                            "enabled": element.is_enabled(),
-                            "text": element_text,
-                        }
-                        # Try to get additional attributes
-                        for attr in ["content-desc", "resource-id", "className"]:
-                            element_attrs[attr] = element.get_attribute(attr)
-
-                        self.logger.info(
-                            f"Found element '{element_key}': {element_attrs}"
-                        )
-                    except Exception as attr_e:
-                        self.logger.warning(
-                            f"Found element '{element_key}' but couldn't get attributes: {str(attr_e)}"
-                        )
-
-                if clickable:
-                    if log:
-                        self.logger.info(
-                            f"Waiting for element '{element_key}' to be clickable"
-                        )
-                    element = self.wait_for_element_clickable_plus(element_key)
-                    if element and log:
-                        self.logger.info(
-                            f"Element '{element_key}' is now clickable"
-                        )
-            return element
-
-        except Exception as e:
-            if log:
-                self.logger.warning(
-                    f"Error in try_find_element_plus for '{element_key}': {str(e)}"
-                )
-            return None
-
-    @with_driver_recovery(op="read")
     def try_find_element(self, locator_type, locator_value, log=True, clickable=False):
-        """Try to find element and return it"""
-        try:
-            element = self.driver.find_element(locator_type, locator_value)
-            if element and clickable:
-                element = self.wait_for_element_clickable(locator_type, locator_value)
-            return element
-        except Exception as e:
-            if log:
-                self.logger.warning(
-                    f"Element not found: {locator_value}, error: {str(e)}"
-                )
-            return None
+        return self.element_finder.try_find_element(locator_type, locator_value, log=log, clickable=clickable)
 
-    @with_driver_recovery(op="read")
     def wait_for_element_polling(
             self, locator_type, locator_value, timeout=10, poll_frequency=0.5
     ):
-        """
-        Wait for element using polling strategy
-        Args:
-            locator_type: AppiumBy.ID or AppiumBy.XPATH etc.
-            locator_value: The locator value
-            timeout: Maximum time to wait in seconds
-            poll_frequency: How often to poll for the element
-        Returns:
-            WebElement if found, None if not found
-        """
-        end_time = time.time() + timeout
-        while time.time() < end_time:
-            try:
-                element = self.driver.find_element(locator_type, locator_value)
-                if element and element.is_displayed():
-                    self.logger.debug(f"Found element after polling: {locator_value}")
-                    return element
-            except Exception:
-                pass
-            time.sleep(poll_frequency)
-            self.logger.debug(f"Polling for element: {locator_value}")
-        self.logger.warning(
-            f"Element not found after polling for {timeout} seconds: {locator_value}"
+        return self.element_finder.wait_for_element_polling(
+            locator_type,
+            locator_value,
+            timeout=timeout,
+            poll_frequency=poll_frequency,
         )
-        return None
 
-    @with_driver_recovery(op="read")
     def wait_for_element_clickable_polling(
             self, locator_type, locator_value, timeout=10, poll_frequency=0.5
     ):
-        """
-        Wait for element to be clickable using polling strategy
-        Args:
-            locator_type: AppiumBy.ID or AppiumBy.XPATH etc.
-            locator_value: The locator value
-            timeout: Maximum time to wait in seconds
-            poll_frequency: How often to poll for the element
-        Returns:
-            WebElement if found and clickable, None if not
-        """
-        end_time = time.time() + timeout
-        while time.time() < end_time:
-            try:
-                element = self.driver.find_element(locator_type, locator_value)
-                if element and element.is_displayed() and element.is_enabled():
-                    self.logger.debug(
-                        f"Found clickable element after polling: {locator_value}"
-                    )
-                    return element
-            except Exception:
-                pass
-            time.sleep(poll_frequency)
-            self.logger.debug(f"Polling for clickable element: {locator_value}")
-        self.logger.warning(
-            f"Clickable element not found after polling for {timeout} seconds: {locator_value}"
+        return self.element_finder.wait_for_element_clickable_polling(
+            locator_type,
+            locator_value,
+            timeout=timeout,
+            poll_frequency=poll_frequency,
         )
-        return None
-
-    @with_driver_recovery(retry=False, op="write")
-    def set_clipboard_text(self, text):
-        """Set clipboard text using Appium's native method
-        Args:
-            text: str, text to be copied to clipboard
-        """
-        self.driver.set_clipboard_text(text)
-        self.logger.debug(f"Copied '{text}' to clipboard")
-
-    @with_driver_recovery(retry=False, op="write")
-    def paste_text(self):
-        """Execute paste operation using Android keycode"""
-        self.driver.press_keycode(279)  # KEYCODE_PASTE = 279
-        self.logger.debug("Pressed paste key")
 
     def find_child_element(self, parent, locator_type, locator_value):
-        """Find child element of parent element
-        Args:
-            parent: WebElement, parent element
-            locator_type: AppiumBy.ID or AppiumBy.XPATH etc.
-            locator_value: The locator value
-        Returns:
-            WebElement if found, None if not found
-        """
-        try:
-            return parent.find_element(locator_type, locator_value)
-        except Exception:
-            return None
+        return self.element_finder.find_child_element(parent, locator_type, locator_value)
 
     def find_child_elements(self, parent, locator_type, locator_value):
-        """Find child elements of parent element
-        Args:
-            parent: WebElement, parent element
-            locator_type: AppiumBy.ID or AppiumBy.XPATH etc.
-            locator_value: The locator value
-        Returns:
-            List of WebElements if found, empty list if not found
-        """
-        try:
-            return parent.find_elements(locator_type, locator_value)
-        except Exception:
-            return []
+        return self.element_finder.find_child_elements(parent, locator_type, locator_value)
 
     def get_element_text(self, element):
-        """Get element text safely
-        Args:
-            element: WebElement
-        Returns:
-            str: element text or empty string if element is None
-        """
-        try:
-            return element.text if element else ""
-        except Exception as e:
-            self.logger.warning(f"Error getting element text: {str(e)}")
-            return ""
+        return self.element_finder.get_element_text(element)
 
     def try_get_attribute(self, element, attribute):
-        """Try to get an attribute from a web element, catching StaleElementReferenceException."""
-        try:
-            return element.get_attribute(attribute)
-        except StaleElementReferenceException:
-            self.logger.warning(
-                f"Unable to get  attribute {attribute}: Element is no longer attached to the DOM."
-            )
-            return None
+        return self.element_finder.try_get_attribute(element, attribute)
 
-    def _get_locator(self, element_key: str) -> tuple:
-        """Helper to get locator type and value from element key"""
-        if element_key not in self.config["elements"]:
-            raise ValueError(f"Element key '{element_key}' not found in config")
+    def _get_locator(self, element_key: str):
+        return self.element_finder._get_locator(element_key)
 
-        value = self.config["elements"][element_key]
-        locator_type = AppiumBy.XPATH if value.startswith("//") else AppiumBy.ID
-        return locator_type, value
+    def find_elements_plus(self, element_key: str):
+        return self.element_finder.find_elements_plus(element_key)
 
-    def _reversed_if_needed(self, lst: list, direction: str) -> list:
-        return list(reversed(lst)) if direction in ("down", "right") else lst
+    def find_child_element_plus(self, parent, element_key):
+        return self.element_finder.find_child_element_plus(parent, element_key)
 
-    @with_driver_recovery(op="read")
-    def find_elements_plus(self, element_key: str) -> list:
-        """Enhanced find_elements using just element key"""
-        try:
-            locator_type, value = self._get_locator(element_key)
-            return self.driver.find_elements(locator_type, value)
-        except Exception as e:
-            self.logger.warning(
-                f"Failed to find elements '{element_key}' with value '{value}': {str(e)}"
-            )
-            return []
+    def find_child_elements_plus(self, parent, element_key: str):
+        return self.element_finder.find_child_elements_plus(parent, element_key)
 
-    @with_driver_recovery(retry=False, op="write")
+    def wait_for_any_element_plus(self, element_keys: list, timeout: int = 10):
+        return self.element_finder.wait_for_any_element_plus(element_keys, timeout=timeout)
+
+    def try_find_any_element_plus(self, element_keys: list):
+        return self.element_finder.try_find_any_element_plus(element_keys)
+
+    def switch_to_app(self):
+        return self.key_actions.switch_to_app()
+
+    def close_app(self):
+        return self.key_actions.close_app()
+
+    def switch_to_activity(self, activity):
+        return self.key_actions.switch_to_activity(activity)
+
+    def press_enter(self, element):
+        return self.key_actions.press_enter(element)
+
+    def press_back(self):
+        return self.key_actions.press_back()
+
+    def press_dpad_down(self):
+        return self.key_actions.press_dpad_down()
+
+    def press_volume_up(self):
+        return self.key_actions.press_volume_up()
+
+    def press_volume_down(self):
+        return self.key_actions.press_volume_down()
+
+    def press_right_key(self, times=1):
+        return self.key_actions.press_right_key(times=times)
+
+    def set_clipboard_text(self, text):
+        return self.key_actions.set_clipboard_text(text)
+
+    def paste_text(self):
+        return self.key_actions.paste_text()
+
     def click_element_at(
             self, element, x_ratio=0.5, y_ratio=0.5, x_offset=0, y_offset=0
     ):
-        """Click element at specified position ratio
-        Args:
-            element: WebElement to click
-            x_ratio: float, horizontal position ratio (0.0 to 1.0), default 0.5 for center
-            y_ratio: float, vertical position ratio (0.0 to 1.0), default 0.5 for center
-        Returns:
-            bool: True if click successful, False otherwise
-        """
-        try:
-            if not element:
-                return False
+        return self.gesture_handler.click_element_at(
+            element,
+            x_ratio=x_ratio,
+            y_ratio=y_ratio,
+            x_offset=x_offset,
+            y_offset=y_offset,
+        )
 
-            # Get element size and location
-            size = element.size
-            location = element.location
+    def _reversed_if_needed(self, lst: list, direction: str):
+        return self.gesture_handler._reversed_if_needed(lst, direction)
 
-            # Calculate click position
-            click_x = location["x"] + int(x_offset) + int(size["width"] * x_ratio)
-            click_y = location["y"] + int(y_offset) + int(size["height"] * y_ratio)
-            if click_y < 110:
-                self.logger.warning(
-                    f"Click position is too top, click_x: {click_x}, click_y: {click_y}"
-                )
-                click_y = 110
-
-            # Perform tap action at calculated position
-            actions = ActionChains(self.driver)
-            actions.w3c_actions = ActionBuilder(
-                self.driver, mouse=PointerInput(interaction.POINTER_TOUCH, "touch")
-            )
-            actions.w3c_actions.pointer_action.move_to_location(click_x, click_y)
-            actions.w3c_actions.pointer_action.pointer_down()
-            actions.w3c_actions.pointer_action.pause(0.1)
-            actions.w3c_actions.pointer_action.pointer_up()
-            actions.perform()
-
-            self.logger.debug(f"Clicked element at position ({click_x}, {click_y})")
-            return True
-
-        except Exception:
-            self.logger.error(f"Error clicking element: {traceback.format_exc()}")
-            return False
-
-    def find_child_element_plus(self, parent, element_key):
-        """Find child element using element key from config
-        Args:
-            parent: Parent element to search within
-            element_key: Key in config elements section
-        Returns:
-            WebElement or None if not found
-        """
-        try:
-            element_id = self.config["elements"][element_key]
-            if element_id.startswith("//"):
-                return self.find_child_element(parent, AppiumBy.XPATH, element_id)
-            else:
-                return self.find_child_element(parent, AppiumBy.ID, element_id)
-        except Exception:
-            self.logger.debug(f"Failed to find child element {element_key}")
-            return None
-
-    def find_child_elements_plus(self, parent, element_key: str) -> list:
-        """Find child elements using element key from config within a parent container.
-        Args:
-            parent: Parent WebElement to search within
-            element_key: Key in config elements section
-        Returns:
-            List[WebElement]: child elements (empty list if not found / error)
-        """
-        try:
-            if not parent:
-                return []
-            locator_type, value = self._get_locator(element_key)
-            return parent.find_elements(locator_type, value)
-        except Exception:
-            self.logger.debug(
-                f"Failed to find child elements {element_key}"
-            )
-            return []
-
-    @with_driver_recovery(retry=False, op="write")
     def _perform_swipe(
             self, start_x: int, start_y: int, end_x: int, end_y: int, duration_ms: int = 300
-    ) -> bool:
-        """在指定坐标执行一次滑动（简化为单段 W3C 手势，避免复杂链路导致 InvalidElementState）。
+    ):
+        return self.gesture_handler._perform_swipe(
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            duration_ms=duration_ms,
+        )
 
-        Args:
-            start_x: 起点 X
-            start_y: 起点 Y
-            end_x: 终点 X
-            end_y: 终点 Y
-            duration_ms: 按下到抬起的持续时间（毫秒）
-        Returns:
-            bool: 是否执行成功
-        """
-        try:
-            # 一些设备/系统版本对复杂多步 W3C actions 支持不稳定，这里改为：
-            # 1. 移动到起点
-            # 2. 按下
-            # 3. 在给定时长内移动到终点
-            # 4. 抬起
-            # self.logger.debug(
-            #     f"_perform_swipe: ({start_x}, {start_y}) -> ({end_x}, {end_y}), duration={duration_ms}ms"
-            # )
-
-            actions = ActionChains(self.driver)
-            actions.w3c_actions = ActionBuilder(
-                self.driver, mouse=PointerInput(interaction.POINTER_TOUCH, "touch")
-            )
-
-            pointer = actions.w3c_actions.pointer_action
-
-            # 起点
-            pointer.move_to_location(start_x, start_y)
-            pointer.pointer_down()
-
-            # 在 duration_ms 时间内完成从起点到终点的移动
-            # Appium / W3C 要求 duration 以秒为单位，通过 pause 来体现
-            pointer.move_to_location(end_x, end_y)
-            pointer.pause(max(0.01, duration_ms / 1000.0))
-
-            # 结束
-            pointer.pointer_up()
-
-            actions.perform()
-            return True
-        except Exception:
-            self.logger.error(f"Error performing swipe: {traceback.format_exc()}")
-            return False
-
-    @with_driver_recovery(op="read")
     def scroll_container_until_element(
             self, element_key: str, container_key: str, direction: str = "up", attribute_name: str = None,
             attribute_value: str = None, max_swipes: int = 10
-    ) -> Tuple[Optional[str], Optional[WebElement], list[str]]:
-        """在指定容器内滚动，直到找到目标元素或无法继续滚动。
-
-        参数：
-            element_key: 目标元素在配置中的 key（应为容器的子元素）
-            container_key: 容器元素在配置中的 key
-            direction: 滚动方向，支持 'up'|'down'|'left'|'right'，默认 'up'（自下向上）
-            attribute_name: 要匹配的属性名（支持 | 分隔的多个属性）
-            attribute_value: 要匹配的属性值
-            max_swipes: 最多滑动次数，默认 10 次
-
-        策略：
-            以 'up' 为例：每次从容器可视部分约 80% 处滑动到容器顶部附近（约 10%），滑动后尝试查找子元素；
-            若找到则返回 (element_key, element, attribute_values)。若连续滑动后页面不再变化（page_source 无变化），则认为到达边界，返回 (None, None, attribute_values)。
-
-        返回：
-            (key, element, attribute_values): 找到目标元素时返回
-            (None, None, attribute_values): 未找到目标元素时返回
-            attribute_values: 搜索过程中找到的所有目标元素的 attribute 值列表，按元素出现顺序排列
-        """
-        # 收集所有找到的元素的 attribute 值列表
-        attribute_values_list = []
-        try:
-            # 获取容器（横滑区等父节点可能不可点击，回退为仅存在即可）
-            container = self.wait_for_element_clickable_plus(container_key)
-            if not container:
-                container = self.wait_for_element_plus(container_key)
-            if not container:
-                self.logger.warning(
-                    f"scroll_container_until_element: 容器未找到: {container_key}"
-                )
-                return None, None, attribute_values_list
-
-            # 方向规范化
-            valid_dirs = {"up", "down", "left", "right"}
-            if direction not in valid_dirs:
-                self.logger.warning(
-                    f"scroll_container_until_element: 非法方向 {direction}，使用默认 'up'"
-                )
-                direction = "up"
-
-            # 预计算容器可视坐标
-            loc = container.location
-            size = container.size
-            left = int(loc["x"])
-            top = int(loc["y"])
-            width = int(size["width"])
-            height = int(size["height"])
-
-            # 单次滑动的起止点计算（默认 'up'）
-            def compute_points(dir_name: str):
-                if dir_name == "up":
-                    start_x = left + int(width * 0.5)
-                    start_y = top + int(height * 0.9)
-                    end_x = left + int(width * 0.5)
-                    end_y = top + int(height * 0.1)
-                    return start_x, start_y, end_x, end_y
-                if dir_name == "down":
-                    start_x = left + int(width * 0.5)
-                    start_y = top + int(height * 0.1)
-                    end_x = left + int(width * 0.5)
-                    end_y = top + int(height * 0.9)
-                    return start_x, start_y, end_x, end_y
-                if dir_name == "left":
-                    start_x = left + int(width * 0.9)
-                    start_y = top + int(height * 0.5)
-                    end_x = left + int(width * 0.2)
-                    end_y = top + int(height * 0.5)
-                    return start_x, start_y, end_x, end_y
-                # right
-                start_x = left + int(width * 0.1)
-                start_y = top + int(height * 0.5)
-                end_x = left + int(width * 0.9)
-                end_y = top + int(height * 0.5)
-                return start_x, start_y, end_x, end_y
-
-            # 页面无变化检测：通过 page_source 哈希判断
-            def snapshot() -> int:
-                try:
-                    return hash(self.driver.page_source)
-                except Exception:
-                    return 0
-
-
-            # 开始循环滑动查找
-            prev_hash = snapshot()
-            stable_rounds = 0
-            max_stable_rounds = 2  # 连续多次无变化则认为到达边界
-            
-            # 收集所有找到的元素的 attribute 值列表
-            attribute_values_list = []
-
-            # 查找目标元素的辅助函数
-            def find_target_element() -> Tuple[Optional[str], Optional[WebElement]]:
-                """在容器内查找目标元素，支持属性匹配（支持 | 分隔的多个属性）"""
-                found = self.find_child_element_plus(container, element_key)
-                if found:
-                    if attribute_name and attribute_value:
-                        elements = self.find_child_elements_plus(container, element_key)
-                        for element in elements:
-                            # 收集所有找到的元素的 attribute 值（不管是否匹配）
-                            attr_list = attribute_name.split('|')
-                            collected_value = None
-                            for attr in attr_list:
-                                value = self.try_get_attribute(element, attr)
-                                if value is not None and value != 'null':
-                                    collected_value = value
-                                    break
-                            if collected_value is not None:
-                                attribute_values_list.append(collected_value)
-                            
-                            # 检查是否匹配目标值
-                            any_match = False
-                            for attr in attr_list:
-                                value = self.try_get_attribute(element, attr)
-                                if value == attribute_value:
-                                    any_match = True
-                                    break
-                            if any_match:
-                                return element_key, element
-                    else:
-                        # 如果没有指定属性匹配，也收集所有找到的元素
-                        elements = self.find_child_elements_plus(container, element_key)
-                        for element in elements:
-                            if attribute_name:
-                                attr_list = attribute_name.split('|')
-                                for attr in attr_list:
-                                    value = self.try_get_attribute(element, attr)
-                                    if value is not None and value != 'null':
-                                        attribute_values_list.append(value)
-                                        break
-                            else:
-                                # 如果没有指定属性名，优先使用 content-desc，如果没有则使用 text
-                                content_desc = self.try_get_attribute(element, "content-desc")
-                                if content_desc is not None and content_desc != 'null':
-                                    attribute_values_list.append(content_desc)
-                                else:
-                                    text = self.try_get_attribute(element, "text")
-                                    if text is not None and text != 'null':
-                                        attribute_values_list.append(text)
-                        return element_key, found
-                return None, None
-
-            for _ in range(max_swipes):
-                # 尝试在容器内查找目标
-                key, element = find_target_element()
-                if element:
-                    return key, element, self._reversed_if_needed(attribute_values_list, direction)
-
-                # 计算滑动坐标并执行滑动
-                sx, sy, ex, ey = compute_points(direction)
-                ok = self._perform_swipe(sx, sy, ex, ey, duration_ms=100)
-                if not ok:
-                    self.logger.warning(
-                        f"scroll_container_until_element: 滑动失败，终止:{element_key}"
-                    )
-                    return None, None, self._reversed_if_needed(attribute_values_list, direction)
-
-                # 滑动后再试一次（元素可能已进入可视区）
-                key, element = find_target_element()
-                if element:
-                    return key, element, self._reversed_if_needed(attribute_values_list, direction)
-
-                # 判断是否到底/到边（页面无变化）
-                cur_hash = snapshot()
-                if cur_hash == prev_hash:
-                    stable_rounds += 1
-                else:
-                    stable_rounds = 0
-                    prev_hash = cur_hash
-
-                if stable_rounds >= max_stable_rounds:
-                    self.logger.warning(
-                        f"scroll_container_until_element: 已到达边界，未找到目标元素:{element_key}"
-                    )
-                    return None, None, self._reversed_if_needed(attribute_values_list, direction)
-
-            self.logger.warning(
-                f"scroll_container_until_element: 达到最大滑动次数，未找到目标元素:{element_key}"
-            )
-            return None, None, self._reversed_if_needed(attribute_values_list, direction)
-        except Exception:
-            self.logger.error(
-                f"scroll_container_until_element error: {traceback.format_exc()}"
-            )
-            return None, None, self._reversed_if_needed(attribute_values_list, direction)
-
-    @with_driver_recovery(op="read")
-    def wait_for_any_element_plus(
-            self, element_keys: list, timeout: int = 10
-    ) -> Tuple[Optional[str], Optional[WebElement]]:
-        """
-        等待任意一个元素出现。
-
-        Args:
-            element_keys: 元素key列表（配置中的elements键）
-            timeout: 超时时间（秒）
-
-        Returns:
-            (key, element): 若找到则返回对应的元素key和元素对象
-            (None, None): 超时或未找到时返回
-        """
-        from selenium.webdriver.support.ui import WebDriverWait
-        from selenium.webdriver.support import expected_conditions as EC
-
-        locators = []
-        key_map = {}
-        for key in element_keys:
-            if key not in self.config["elements"]:
-                continue
-            value = self.config["elements"][key]
-            locator_type = AppiumBy.XPATH if value.startswith("//") else AppiumBy.ID
-            locators.append((locator_type, value))
-            key_map[(locator_type, value)] = key
-
-        if not locators:
-            self.logger.warning("wait_for_any_element_plus: 没有有效的元素key")
-            return None, None
-
-        try:
-            # Selenium 4.8+ 支持 EC.any_of
-            element = WebDriverWait(self.driver, timeout).until(
-                EC.any_of(
-                    *[EC.presence_of_element_located(locator) for locator in locators]
-                )
-            )
-            # 找到是哪个key
-            for locator, key in key_map.items():
-                try:
-                    found = self.driver.find_element(*locator)
-                    if found and found.id == element.id:
-                        return key, element
-                except Exception:
-                    continue
-            self.logger.warning("wait_for_any_element_plus: 找不到对应的key")
-            return None, None
-        except Exception as e:
-            self.logger.error(
-                f"wait_for_any_element_plus: {element_keys} 超时未找到任何元素: {str(e)}"
-            )
-            return None, None
-
-    def try_find_any_element_plus(
-            self, element_keys: list
-    ) -> Tuple[Optional[str], Optional[WebElement]]:
-        """
-        无等待遍历查找任意一个元素。
-
-        与 wait_for_any_element_plus 的区别：
-        - 不等待，不会因为元素不存在产生超时
-        - 按给定 key 顺序返回第一个命中的元素
-        """
-        for key in element_keys:
-            element = self.try_find_element_plus(key, log=False)
-            if element:
-                return key, element
-        return None, None
+    ):
+        return self.gesture_handler.scroll_container_until_element(
+            element_key,
+            container_key,
+            direction=direction,
+            attribute_name=attribute_name,
+            attribute_value=attribute_value,
+            max_swipes=max_swipes,
+        )
 
     def navigate_to_element(
             self,
@@ -914,83 +248,11 @@ class AppHandler:
             home_key: str = "home_nav",
             back_keys=None,
             max_attempts: int = 10,
-    ) -> Tuple[Optional[str], Optional[WebElement]]:
-        """
-        导航到目标元素，通过检测当前页面状态并执行相应操作
-
-        Args:
-            home_key: 首页元素key，找到表示已回到首页，不能再返回
-            back_keys: 返回按钮key列表，找到则点击返回上一页
-            target_key: 目标元素key，找到则直接返回
-            interference_keys: 干扰元素key列表，出现则按系统返回键隐藏
-            max_attempts: 最大尝试次数，防止无限循环
-
-        Returns:
-            (key, element): 找到的元素key和元素对象
-            (None, None): 未找到或出错时返回
-        """
-        if back_keys is None:
-            back_keys = ["go_back", "minimize_screen"]
-        if interference_keys is None:
-            interference_keys = []
-
-        self.logger.info(f"开始导航到目标元素: {target_key}")
-        self.press_back()
-
-        for attempt in range(max_attempts):
-            self.logger.debug(f"导航尝试 {attempt + 1}/{max_attempts}")
-
-            # 构建检测元素列表，按优先级排序：干扰元素 -> 目标元素 -> 返回按钮 -> home元素
-            check_keys = interference_keys + [target_key] + back_keys + [home_key]
-
-            # 使用 wait_for_any_element_plus 检测当前状态
-            found_key, found_element = self.wait_for_any_element_plus(check_keys)
-
-            if not found_element:
-                self.logger.warning(f"第 {attempt + 1} 次尝试：未检测到任何元素")
-                # 按系统返回键尝试返回
-                self.press_back()
-                return None, None
-
-            # 根据找到的元素类型执行相应操作
-            if found_key == target_key:
-                # 命中目标后仅做干扰元素复核（无等待），避免误判后直接返回
-                interference_key, interference_element = self.try_find_any_element_plus(interference_keys)
-                if interference_element:
-                    self.logger.info(
-                        f"命中目标 {target_key} 后发现干扰元素 {interference_key}，先按返回键关闭后重试确认"
-                    )
-                    if not self.press_back():
-                        self.logger.error("按系统返回键失败")
-                        return None, None
-                    continue
-
-                self.logger.info(f"找到目标元素: {target_key}（已通过二次确认）")
-                return found_key, found_element
-
-            elif found_key in back_keys:
-                if self.click_element_at(found_element):
-                    self.logger.info(f"找到返回按钮: {found_key}，点击返回")
-                else:
-                    self.logger.warning(f"点击返回按钮失败: {found_key}")
-                    # 尝试系统返回键作为备选
-                    self.press_back()
-
-            elif found_key in interference_keys:
-                self.logger.info(f"发现干扰元素: {found_key}，按系统返回键隐藏")
-                if not self.press_back():
-                    self.logger.error("按系统返回键失败")
-                    return None, None
-
-            elif found_key == home_key:
-                self.logger.info(f"已回到首页: {home_key}，无法继续返回")
-                return found_key, found_element
-
-            else:
-                self.logger.warning(f"检测到未知元素: {found_key}")
-                self.press_back()
-                return None, None
-
-        # 达到最大尝试次数
-        self.logger.error(f"导航失败：达到最大尝试次数 {max_attempts}")
-        return None, None
+    ):
+        return self.navigator.navigate_to_element(
+            target_key,
+            interference_keys=interference_keys,
+            home_key=home_key,
+            back_keys=back_keys,
+            max_attempts=max_attempts,
+        )

--- a/src/ushareiplay/core/ui/__init__.py
+++ b/src/ushareiplay/core/ui/__init__.py
@@ -1,0 +1,11 @@
+from ushareiplay.core.ui.element_finder import ElementFinder
+from ushareiplay.core.ui.gesture_handler import GestureHandler
+from ushareiplay.core.ui.key_actions import KeyActions
+from ushareiplay.core.ui.navigation import Navigator
+
+__all__ = [
+    "ElementFinder",
+    "GestureHandler",
+    "KeyActions",
+    "Navigator",
+]

--- a/src/ushareiplay/core/ui/element_finder.py
+++ b/src/ushareiplay/core/ui/element_finder.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+import time
+from typing import Optional, Tuple
+
+from appium.webdriver.common.appiumby import AppiumBy
+from selenium.common.exceptions import StaleElementReferenceException, TimeoutException
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from ushareiplay.core.driver_decorator import with_driver_recovery
+
+
+class ElementFinder:
+    def __init__(self, owner):
+        self.owner = owner
+
+    def __getattr__(self, name):
+        return getattr(self.owner, name)
+
+    @property
+    def driver(self):
+        return self.owner.driver
+
+    @property
+    def config(self):
+        return self.owner.config
+
+    @property
+    def logger(self):
+        return self.owner.logger
+
+    @with_driver_recovery(op="read")
+    def wait_for_element(self, locator_type, locator_value, timeout=10):
+        """Wait for element to be present and return it"""
+        try:
+            element = WebDriverWait(self.driver, timeout).until(
+                EC.presence_of_element_located((locator_type, locator_value))
+            )
+            self.log_debug(f"Found element: {locator_value}")
+            return element
+        except Exception as e:
+            self.logger.warning(
+                f"Element not found within {timeout} seconds: {locator_value}"
+            )
+            self.logger.warning(f"Error: {str(e)}")
+            return None
+
+    @with_driver_recovery(op="read")
+    def wait_for_element_plus(self, element_key: str, timeout: int = 10) -> WebElement:
+        """Enhanced wait_for_element using just element key"""
+        try:
+            locator_type, value = self._get_locator(element_key)
+            element = WebDriverWait(self.driver, timeout).until(
+                EC.presence_of_element_located((locator_type, value))
+            )
+            self.logger.debug(f"Found  element: {element_key}")
+            return element
+        except TimeoutException:
+            self.logger.warning(
+                f"Element {element_key}:{value} not found within {timeout} seconds "
+            )
+            return None
+
+    def is_element_clickable(self, element):
+        """Check if element is clickable
+        Args:
+            element: WebElement to check
+        Returns:
+            bool: True if element is clickable, False otherwise
+        """
+        try:
+            if not element:
+                return False
+
+            # First check if element exists and is displayed
+            if not element.is_displayed():
+                return False
+
+            # Then check if element is enabled
+            if not element.is_enabled():
+                return False
+
+            # Finally check clickable attribute
+            clickable = element.get_attribute("clickable")
+            return clickable == "true"
+
+        except Exception as e:
+            self.logger.warning(f"Error checking if element is clickable: {str(e)}")
+            return False
+
+    @with_driver_recovery(op="read")
+    def wait_for_element_clickable_plus(
+            self, element_key: str, timeout: int = 10
+    ) -> WebElement:
+        """Enhanced wait_for_element using just element key"""
+        try:
+            locator_type, value = self._get_locator(element_key)
+            element = WebDriverWait(self.driver, timeout).until(
+                EC.element_to_be_clickable((locator_type, value))
+            )
+            self.logger.debug(f"Found clickable element: {element_key}")
+            return element
+        except TimeoutException:
+            self.logger.warning(
+                f"Clickable element {element_key}:{value} not found within {timeout} seconds "
+            )
+            return None
+        except StaleElementReferenceException:
+            self.logger.warning(f"Stale element reference for {element_key}:{value}")
+            return None
+
+    @with_driver_recovery(op="read")
+    def wait_for_element_clickable(self, locator_type, locator_value, timeout=10):
+        """
+        Wait for element to be clickable and return it
+        Args:
+            locator_type: AppiumBy.ID or AppiumBy.XPATH etc.
+            locator_value: The locator value
+            timeout: Maximum time to wait in seconds
+        Returns:
+            WebElement if found and clickable, None if not
+        """
+        try:
+            element = WebDriverWait(self.driver, timeout).until(
+                EC.element_to_be_clickable((locator_type, locator_value))
+            )
+            self.logger.debug(f"Found clickable element: {locator_value}")
+            return element
+        except TimeoutException:
+            self.logger.warning(
+                f"Clickable element not found within {timeout} seconds: {locator_value}"
+            )
+            return None
+
+    @with_driver_recovery(op="read")
+    def try_find_element_plus(
+            self, element_key: str, log=False, clickable=False
+    ) -> WebElement:
+        """Enhanced try_find_element using just element key"""
+        try:
+            if log:
+                self.logger.info(f"Looking for element '{element_key}'")
+
+            if element_key not in self.config["elements"]:
+                if log:
+                    self.logger.error(
+                        f"Element key '{element_key}' not defined in configuration"
+                    )
+                return None
+
+            locator_type, value = self._get_locator(element_key)
+            if log:
+                self.logger.info(
+                    f"Using locator type {locator_type} with value '{value}'"
+                )
+
+            element = self.driver.find_element(locator_type, value)
+            if element:
+                if log:
+                    try:
+                        element_text = element.text
+                        element_attrs = {
+                            "displayed": element.is_displayed(),
+                            "enabled": element.is_enabled(),
+                            "text": element_text,
+                        }
+                        # Try to get additional attributes
+                        for attr in ["content-desc", "resource-id", "className"]:
+                            element_attrs[attr] = element.get_attribute(attr)
+
+                        self.logger.info(
+                            f"Found element '{element_key}': {element_attrs}"
+                        )
+                    except Exception as attr_e:
+                        self.logger.warning(
+                            f"Found element '{element_key}' but couldn't get attributes: {str(attr_e)}"
+                        )
+
+                if clickable:
+                    if log:
+                        self.logger.info(
+                            f"Waiting for element '{element_key}' to be clickable"
+                        )
+                    element = self.wait_for_element_clickable_plus(element_key)
+                    if element and log:
+                        self.logger.info(
+                            f"Element '{element_key}' is now clickable"
+                        )
+            return element
+
+        except Exception as e:
+            if log:
+                self.logger.warning(
+                    f"Error in try_find_element_plus for '{element_key}': {str(e)}"
+                )
+            return None
+
+    @with_driver_recovery(op="read")
+    def try_find_element(self, locator_type, locator_value, log=True, clickable=False):
+        """Try to find element and return it"""
+        try:
+            element = self.driver.find_element(locator_type, locator_value)
+            if element and clickable:
+                element = self.wait_for_element_clickable(locator_type, locator_value)
+            return element
+        except Exception as e:
+            if log:
+                self.logger.warning(
+                    f"Element not found: {locator_value}, error: {str(e)}"
+                )
+            return None
+
+    @with_driver_recovery(op="read")
+    def wait_for_element_polling(
+            self, locator_type, locator_value, timeout=10, poll_frequency=0.5
+    ):
+        """
+        Wait for element using polling strategy
+        Args:
+            locator_type: AppiumBy.ID or AppiumBy.XPATH etc.
+            locator_value: The locator value
+            timeout: Maximum time to wait in seconds
+            poll_frequency: How often to poll for the element
+        Returns:
+            WebElement if found, None if not found
+        """
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            try:
+                element = self.driver.find_element(locator_type, locator_value)
+                if element and element.is_displayed():
+                    self.logger.debug(f"Found element after polling: {locator_value}")
+                    return element
+            except Exception:
+                pass
+            time.sleep(poll_frequency)
+            self.logger.debug(f"Polling for element: {locator_value}")
+        self.logger.warning(
+            f"Element not found after polling for {timeout} seconds: {locator_value}"
+        )
+        return None
+
+    @with_driver_recovery(op="read")
+    def wait_for_element_clickable_polling(
+            self, locator_type, locator_value, timeout=10, poll_frequency=0.5
+    ):
+        """
+        Wait for element to be clickable using polling strategy
+        Args:
+            locator_type: AppiumBy.ID or AppiumBy.XPATH etc.
+            locator_value: The locator value
+            timeout: Maximum time to wait in seconds
+            poll_frequency: How often to poll for the element
+        Returns:
+            WebElement if found and clickable, None if not
+        """
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            try:
+                element = self.driver.find_element(locator_type, locator_value)
+                if element and element.is_displayed() and element.is_enabled():
+                    self.logger.debug(
+                        f"Found clickable element after polling: {locator_value}"
+                    )
+                    return element
+            except Exception:
+                pass
+            time.sleep(poll_frequency)
+            self.logger.debug(f"Polling for clickable element: {locator_value}")
+        self.logger.warning(
+            f"Clickable element not found after polling for {timeout} seconds: {locator_value}"
+        )
+        return None
+
+    def find_child_element(self, parent, locator_type, locator_value):
+        """Find child element of parent element
+        Args:
+            parent: WebElement, parent element
+            locator_type: AppiumBy.ID or AppiumBy.XPATH etc.
+            locator_value: The locator value
+        Returns:
+            WebElement if found, None if not found
+        """
+        try:
+            return parent.find_element(locator_type, locator_value)
+        except Exception:
+            return None
+
+    def find_child_elements(self, parent, locator_type, locator_value):
+        """Find child elements of parent element
+        Args:
+            parent: WebElement, parent element
+            locator_type: AppiumBy.ID or AppiumBy.XPATH etc.
+            locator_value: The locator value
+        Returns:
+            List of WebElements if found, empty list if not found
+        """
+        try:
+            return parent.find_elements(locator_type, locator_value)
+        except Exception:
+            return []
+
+    def get_element_text(self, element):
+        """Get element text safely
+        Args:
+            element: WebElement
+        Returns:
+            str: element text or empty string if element is None
+        """
+        try:
+            return element.text if element else ""
+        except Exception as e:
+            self.logger.warning(f"Error getting element text: {str(e)}")
+            return ""
+
+    def try_get_attribute(self, element, attribute):
+        """Try to get an attribute from a web element, catching StaleElementReferenceException."""
+        try:
+            return element.get_attribute(attribute)
+        except StaleElementReferenceException:
+            self.logger.warning(
+                f"Unable to get  attribute {attribute}: Element is no longer attached to the DOM."
+            )
+            return None
+
+    def _get_locator(self, element_key: str) -> tuple:
+        """Helper to get locator type and value from element key"""
+        if element_key not in self.config["elements"]:
+            raise ValueError(f"Element key '{element_key}' not found in config")
+
+        value = self.config["elements"][element_key]
+        locator_type = AppiumBy.XPATH if value.startswith("//") else AppiumBy.ID
+        return locator_type, value
+
+    @with_driver_recovery(op="read")
+    def find_elements_plus(self, element_key: str) -> list:
+        """Enhanced find_elements using just element key"""
+        try:
+            locator_type, value = self._get_locator(element_key)
+            return self.driver.find_elements(locator_type, value)
+        except Exception as e:
+            self.logger.warning(
+                f"Failed to find elements '{element_key}' with value '{value}': {str(e)}"
+            )
+            return []
+
+    def find_child_element_plus(self, parent, element_key):
+        """Find child element using element key from config
+        Args:
+            parent: Parent element to search within
+            element_key: Key in config elements section
+        Returns:
+            WebElement or None if not found
+        """
+        try:
+            element_id = self.config["elements"][element_key]
+            if element_id.startswith("//"):
+                return self.find_child_element(parent, AppiumBy.XPATH, element_id)
+            else:
+                return self.find_child_element(parent, AppiumBy.ID, element_id)
+        except Exception:
+            self.logger.debug(f"Failed to find child element {element_key}")
+            return None
+
+    def find_child_elements_plus(self, parent, element_key: str) -> list:
+        """Find child elements using element key from config within a parent container.
+        Args:
+            parent: Parent WebElement to search within
+            element_key: Key in config elements section
+        Returns:
+            List[WebElement]: child elements (empty list if not found / error)
+        """
+        try:
+            if not parent:
+                return []
+            locator_type, value = self._get_locator(element_key)
+            return parent.find_elements(locator_type, value)
+        except Exception:
+            self.logger.debug(
+                f"Failed to find child elements {element_key}"
+            )
+            return []
+
+    @with_driver_recovery(op="read")
+    def wait_for_any_element_plus(
+            self, element_keys: list, timeout: int = 10
+    ) -> Tuple[Optional[str], Optional[WebElement]]:
+        """
+        等待任意一个元素出现。
+
+        Args:
+            element_keys: 元素key列表（配置中的elements键）
+            timeout: 超时时间（秒）
+
+        Returns:
+            (key, element): 若找到则返回对应的元素key和元素对象
+            (None, None): 超时或未找到时返回
+        """
+        locators = []
+        key_map = {}
+        for key in element_keys:
+            if key not in self.config["elements"]:
+                continue
+            value = self.config["elements"][key]
+            locator_type = AppiumBy.XPATH if value.startswith("//") else AppiumBy.ID
+            locators.append((locator_type, value))
+            key_map[(locator_type, value)] = key
+
+        if not locators:
+            self.logger.warning("wait_for_any_element_plus: 没有有效的元素key")
+            return None, None
+
+        try:
+            # Selenium 4.8+ 支持 EC.any_of
+            element = WebDriverWait(self.driver, timeout).until(
+                EC.any_of(
+                    *[EC.presence_of_element_located(locator) for locator in locators]
+                )
+            )
+            # 找到是哪个key
+            for locator, key in key_map.items():
+                try:
+                    found = self.driver.find_element(*locator)
+                    if found and found.id == element.id:
+                        return key, element
+                except Exception:
+                    continue
+            self.logger.warning("wait_for_any_element_plus: 找不到对应的key")
+            return None, None
+        except Exception as e:
+            self.logger.error(
+                f"wait_for_any_element_plus: {element_keys} 超时未找到任何元素: {str(e)}"
+            )
+            return None, None
+
+    def try_find_any_element_plus(
+            self, element_keys: list
+    ) -> Tuple[Optional[str], Optional[WebElement]]:
+        """
+        无等待遍历查找任意一个元素。
+
+        与 wait_for_any_element_plus 的区别：
+        - 不等待，不会因为元素不存在产生超时
+        - 按给定 key 顺序返回第一个命中的元素
+        """
+        for key in element_keys:
+            element = self.try_find_element_plus(key, log=False)
+            if element:
+                return key, element
+        return None, None

--- a/src/ushareiplay/core/ui/gesture_handler.py
+++ b/src/ushareiplay/core/ui/gesture_handler.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import traceback
+from typing import Optional, Tuple
+
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.actions import interaction
+from selenium.webdriver.common.actions.action_builder import ActionBuilder
+from selenium.webdriver.common.actions.pointer_input import PointerInput
+from selenium.webdriver.remote.webelement import WebElement
+
+from ushareiplay.core.driver_decorator import with_driver_recovery
+
+
+class GestureHandler:
+    def __init__(self, owner):
+        self.owner = owner
+
+    def __getattr__(self, name):
+        return getattr(self.owner, name)
+
+    @property
+    def driver(self):
+        return self.owner.driver
+
+    @property
+    def config(self):
+        return self.owner.config
+
+    @property
+    def logger(self):
+        return self.owner.logger
+
+    @with_driver_recovery(retry=False, op="write")
+    def click_element_at(
+            self, element, x_ratio=0.5, y_ratio=0.5, x_offset=0, y_offset=0
+    ):
+        """Click element at specified position ratio
+        Args:
+            element: WebElement to click
+            x_ratio: float, horizontal position ratio (0.0 to 1.0), default 0.5 for center
+            y_ratio: float, vertical position ratio (0.0 to 1.0), default 0.5 for center
+        Returns:
+            bool: True if click successful, False otherwise
+        """
+        try:
+            if not element:
+                return False
+
+            # Get element size and location
+            size = element.size
+            location = element.location
+
+            # Calculate click position
+            click_x = location["x"] + int(x_offset) + int(size["width"] * x_ratio)
+            click_y = location["y"] + int(y_offset) + int(size["height"] * y_ratio)
+            if click_y < 110:
+                self.logger.warning(
+                    f"Click position is too top, click_x: {click_x}, click_y: {click_y}"
+                )
+                click_y = 110
+
+            # Perform tap action at calculated position
+            actions = ActionChains(self.driver)
+            actions.w3c_actions = ActionBuilder(
+                self.driver, mouse=PointerInput(interaction.POINTER_TOUCH, "touch")
+            )
+            actions.w3c_actions.pointer_action.move_to_location(click_x, click_y)
+            actions.w3c_actions.pointer_action.pointer_down()
+            actions.w3c_actions.pointer_action.pause(0.1)
+            actions.w3c_actions.pointer_action.pointer_up()
+            actions.perform()
+
+            self.logger.debug(f"Clicked element at position ({click_x}, {click_y})")
+            return True
+
+        except Exception:
+            self.logger.error(f"Error clicking element: {traceback.format_exc()}")
+            return False
+
+    def _reversed_if_needed(self, lst: list, direction: str) -> list:
+        return list(reversed(lst)) if direction in ("down", "right") else lst
+
+    @with_driver_recovery(retry=False, op="write")
+    def _perform_swipe(
+            self, start_x: int, start_y: int, end_x: int, end_y: int, duration_ms: int = 300
+    ) -> bool:
+        """在指定坐标执行一次滑动（简化为单段 W3C 手势，避免复杂链路导致 InvalidElementState）。
+
+        Args:
+            start_x: 起点 X
+            start_y: 起点 Y
+            end_x: 终点 X
+            end_y: 终点 Y
+            duration_ms: 按下到抬起的持续时间（毫秒）
+        Returns:
+            bool: 是否执行成功
+        """
+        try:
+            # 一些设备/系统版本对复杂多步 W3C actions 支持不稳定，这里改为：
+            # 1. 移动到起点
+            # 2. 按下
+            # 3. 在给定时长内移动到终点
+            # 4. 抬起
+            # self.logger.debug(
+            #     f"_perform_swipe: ({start_x}, {start_y}) -> ({end_x}, {end_y}), duration={duration_ms}ms"
+            # )
+
+            actions = ActionChains(self.driver)
+            actions.w3c_actions = ActionBuilder(
+                self.driver, mouse=PointerInput(interaction.POINTER_TOUCH, "touch")
+            )
+
+            pointer = actions.w3c_actions.pointer_action
+
+            # 起点
+            pointer.move_to_location(start_x, start_y)
+            pointer.pointer_down()
+
+            # 在 duration_ms 时间内完成从起点到终点的移动
+            # Appium / W3C 要求 duration 以秒为单位，通过 pause 来体现
+            pointer.move_to_location(end_x, end_y)
+            pointer.pause(max(0.01, duration_ms / 1000.0))
+
+            # 结束
+            pointer.pointer_up()
+
+            actions.perform()
+            return True
+        except Exception:
+            self.logger.error(f"Error performing swipe: {traceback.format_exc()}")
+            return False
+
+    @with_driver_recovery(op="read")
+    def scroll_container_until_element(
+            self, element_key: str, container_key: str, direction: str = "up", attribute_name: str = None,
+            attribute_value: str = None, max_swipes: int = 10
+    ) -> Tuple[Optional[str], Optional[WebElement], list[str]]:
+        """在指定容器内滚动，直到找到目标元素或无法继续滚动。
+
+        参数：
+            element_key: 目标元素在配置中的 key（应为容器的子元素）
+            container_key: 容器元素在配置中的 key
+            direction: 滚动方向，支持 'up'|'down'|'left'|'right'，默认 'up'（自下向上）
+            attribute_name: 要匹配的属性名（支持 | 分隔的多个属性）
+            attribute_value: 要匹配的属性值
+            max_swipes: 最多滑动次数，默认 10 次
+
+        策略：
+            以 'up' 为例：每次从容器可视部分约 80% 处滑动到容器顶部附近（约 10%），滑动后尝试查找子元素；
+            若找到则返回 (element_key, element, attribute_values)。若连续滑动后页面不再变化（page_source 无变化），则认为到达边界，返回 (None, None, attribute_values)。
+
+        返回：
+            (key, element, attribute_values): 找到目标元素时返回
+            (None, None, attribute_values): 未找到目标元素时返回
+            attribute_values: 搜索过程中找到的所有目标元素的 attribute 值列表，按元素出现顺序排列
+        """
+        # 收集所有找到的元素的 attribute 值列表
+        attribute_values_list = []
+        try:
+            # 获取容器（横滑区等父节点可能不可点击，回退为仅存在即可）
+            container = self.wait_for_element_clickable_plus(container_key)
+            if not container:
+                container = self.wait_for_element_plus(container_key)
+            if not container:
+                self.logger.warning(
+                    f"scroll_container_until_element: 容器未找到: {container_key}"
+                )
+                return None, None, attribute_values_list
+
+            # 方向规范化
+            valid_dirs = {"up", "down", "left", "right"}
+            if direction not in valid_dirs:
+                self.logger.warning(
+                    f"scroll_container_until_element: 非法方向 {direction}，使用默认 'up'"
+                )
+                direction = "up"
+
+            # 预计算容器可视坐标
+            loc = container.location
+            size = container.size
+            left = int(loc["x"])
+            top = int(loc["y"])
+            width = int(size["width"])
+            height = int(size["height"])
+
+            # 单次滑动的起止点计算（默认 'up'）
+            def compute_points(dir_name: str):
+                if dir_name == "up":
+                    start_x = left + int(width * 0.5)
+                    start_y = top + int(height * 0.9)
+                    end_x = left + int(width * 0.5)
+                    end_y = top + int(height * 0.1)
+                    return start_x, start_y, end_x, end_y
+                if dir_name == "down":
+                    start_x = left + int(width * 0.5)
+                    start_y = top + int(height * 0.1)
+                    end_x = left + int(width * 0.5)
+                    end_y = top + int(height * 0.9)
+                    return start_x, start_y, end_x, end_y
+                if dir_name == "left":
+                    start_x = left + int(width * 0.9)
+                    start_y = top + int(height * 0.5)
+                    end_x = left + int(width * 0.2)
+                    end_y = top + int(height * 0.5)
+                    return start_x, start_y, end_x, end_y
+                # right
+                start_x = left + int(width * 0.1)
+                start_y = top + int(height * 0.5)
+                end_x = left + int(width * 0.9)
+                end_y = top + int(height * 0.5)
+                return start_x, start_y, end_x, end_y
+
+            # 页面无变化检测：通过 page_source 哈希判断
+            def snapshot() -> int:
+                try:
+                    return hash(self.driver.page_source)
+                except Exception:
+                    return 0
+
+            # 开始循环滑动查找
+            prev_hash = snapshot()
+            stable_rounds = 0
+            max_stable_rounds = 2  # 连续多次无变化则认为到达边界
+
+            # 收集所有找到的元素的 attribute 值列表
+            attribute_values_list = []
+
+            # 查找目标元素的辅助函数
+            def find_target_element() -> Tuple[Optional[str], Optional[WebElement]]:
+                """在容器内查找目标元素，支持属性匹配（支持 | 分隔的多个属性）"""
+                found = self.find_child_element_plus(container, element_key)
+                if found:
+                    if attribute_name and attribute_value:
+                        elements = self.find_child_elements_plus(container, element_key)
+                        for element in elements:
+                            # 收集所有找到的元素的 attribute 值（不管是否匹配）
+                            attr_list = attribute_name.split('|')
+                            collected_value = None
+                            for attr in attr_list:
+                                value = self.try_get_attribute(element, attr)
+                                if value is not None and value != 'null':
+                                    collected_value = value
+                                    break
+                            if collected_value is not None:
+                                attribute_values_list.append(collected_value)
+
+                            # 检查是否匹配目标值
+                            any_match = False
+                            for attr in attr_list:
+                                value = self.try_get_attribute(element, attr)
+                                if value == attribute_value:
+                                    any_match = True
+                                    break
+                            if any_match:
+                                return element_key, element
+                    else:
+                        # 如果没有指定属性匹配，也收集所有找到的元素
+                        elements = self.find_child_elements_plus(container, element_key)
+                        for element in elements:
+                            if attribute_name:
+                                attr_list = attribute_name.split('|')
+                                for attr in attr_list:
+                                    value = self.try_get_attribute(element, attr)
+                                    if value is not None and value != 'null':
+                                        attribute_values_list.append(value)
+                                        break
+                            else:
+                                # 如果没有指定属性名，优先使用 content-desc，如果没有则使用 text
+                                content_desc = self.try_get_attribute(element, "content-desc")
+                                if content_desc is not None and content_desc != 'null':
+                                    attribute_values_list.append(content_desc)
+                                else:
+                                    text = self.try_get_attribute(element, "text")
+                                    if text is not None and text != 'null':
+                                        attribute_values_list.append(text)
+                        return element_key, found
+                return None, None
+
+            for _ in range(max_swipes):
+                # 尝试在容器内查找目标
+                key, element = find_target_element()
+                if element:
+                    return key, element, self._reversed_if_needed(attribute_values_list, direction)
+
+                # 计算滑动坐标并执行滑动
+                sx, sy, ex, ey = compute_points(direction)
+                ok = self._perform_swipe(sx, sy, ex, ey, duration_ms=100)
+                if not ok:
+                    self.logger.warning(
+                        f"scroll_container_until_element: 滑动失败，终止:{element_key}"
+                    )
+                    return None, None, self._reversed_if_needed(attribute_values_list, direction)
+
+                # 滑动后再试一次（元素可能已进入可视区）
+                key, element = find_target_element()
+                if element:
+                    return key, element, self._reversed_if_needed(attribute_values_list, direction)
+
+                # 判断是否到底/到边（页面无变化）
+                cur_hash = snapshot()
+                if cur_hash == prev_hash:
+                    stable_rounds += 1
+                else:
+                    stable_rounds = 0
+                    prev_hash = cur_hash
+
+                if stable_rounds >= max_stable_rounds:
+                    self.logger.warning(
+                        f"scroll_container_until_element: 已到达边界，未找到目标元素:{element_key}"
+                    )
+                    return None, None, self._reversed_if_needed(attribute_values_list, direction)
+
+            self.logger.warning(
+                f"scroll_container_until_element: 达到最大滑动次数，未找到目标元素:{element_key}"
+            )
+            return None, None, self._reversed_if_needed(attribute_values_list, direction)
+        except Exception:
+            self.logger.error(
+                f"scroll_container_until_element error: {traceback.format_exc()}"
+            )
+            return None, None, self._reversed_if_needed(attribute_values_list, direction)

--- a/src/ushareiplay/core/ui/key_actions.py
+++ b/src/ushareiplay/core/ui/key_actions.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import time
+
+from ushareiplay.core.driver_decorator import with_driver_recovery
+
+
+class KeyActions:
+    def __init__(self, owner):
+        self.owner = owner
+
+    def __getattr__(self, name):
+        return getattr(self.owner, name)
+
+    @property
+    def driver(self):
+        return self.owner.driver
+
+    @property
+    def config(self):
+        return self.owner.config
+
+    @property
+    def logger(self):
+        return self.owner.logger
+
+    @property
+    def error_count(self):
+        return self.owner.error_count
+
+    @error_count.setter
+    def error_count(self, value):
+        self.owner.error_count = value
+
+    @with_driver_recovery(retry=False, op="write")
+    def switch_to_app(self):
+        """Switch to specified app"""
+        self.driver.activate_app(self.config["package_name"])
+        time.sleep(0.1)
+        return True
+
+    @with_driver_recovery(retry=False, op="write")
+    def close_app(self):
+        """关闭应用"""
+        self.driver.terminate_app(self.config["package_name"])
+
+    @with_driver_recovery(retry=False, op="write")
+    def switch_to_activity(self, activity):
+        """Switch to the specified activity"""
+        package_name = self.config["package_name"]
+        command = f"am start -n {package_name}/{activity}"
+        self.driver.execute_script("mobile: shell", {"command": command})
+
+    @with_driver_recovery(retry=False, op="write")
+    def press_enter(self, element):
+        """
+        Press Enter key on the given element
+        Args:
+            element: The WebElement to send Enter key to
+        """
+        self.driver.press_keycode(66)
+        self.logger.debug("Pressed Return Key")
+
+    @with_driver_recovery(retry=False, op="write")
+    def press_back(self):
+        """Press Android back button"""
+        self.driver.press_keycode(4)  # Android back key code
+        self.error_count = 0
+        self.logger.debug("Pressed back button")
+        return True
+
+    @with_driver_recovery(retry=False, op="write")
+    def press_dpad_down(self):
+        """Press Android DPAD down button"""
+        self.driver.press_keycode(20)  # KEYCODE_DPAD_DOWN
+        self.logger.debug("Pressed DPAD down button")
+
+    @with_driver_recovery(retry=False, op="write")
+    def press_volume_up(self):
+        """Press Android volume up button"""
+        self.driver.press_keycode(24)  # KEYCODE_VOLUME_UP
+        self.logger.debug("Pressed volume up button")
+
+    @with_driver_recovery(retry=False, op="write")
+    def press_volume_down(self):
+        """Press Android volume down button"""
+        self.driver.press_keycode(25)  # KEYCODE_VOLUME_DOWN
+        self.logger.debug("Pressed volume down button")
+
+    @with_driver_recovery(retry=False, op="write")
+    def press_right_key(self, times=1):
+        """Simulate pressing the right key multiple times
+        Args:
+            times: int, number of times to press the right key
+        """
+        for _ in range(times):
+            self.driver.execute_script(
+                "mobile: shell", {"command": "input keyevent KEYCODE_DPAD_RIGHT"}
+            )
+            time.sleep(0.1)  # Small delay between key presses
+
+    @with_driver_recovery(retry=False, op="write")
+    def set_clipboard_text(self, text):
+        """Set clipboard text using Appium's native method
+        Args:
+            text: str, text to be copied to clipboard
+        """
+        self.driver.set_clipboard_text(text)
+        self.logger.debug(f"Copied '{text}' to clipboard")
+
+    @with_driver_recovery(retry=False, op="write")
+    def paste_text(self):
+        """Execute paste operation using Android keycode"""
+        self.driver.press_keycode(279)  # KEYCODE_PASTE = 279
+        self.logger.debug("Pressed paste key")

--- a/src/ushareiplay/core/ui/navigation.py
+++ b/src/ushareiplay/core/ui/navigation.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from selenium.webdriver.remote.webelement import WebElement
+
+
+class Navigator:
+    def __init__(self, owner):
+        self.owner = owner
+
+    def __getattr__(self, name):
+        return getattr(self.owner, name)
+
+    @property
+    def driver(self):
+        return self.owner.driver
+
+    @property
+    def config(self):
+        return self.owner.config
+
+    @property
+    def logger(self):
+        return self.owner.logger
+
+    def navigate_to_element(
+            self,
+            target_key: str,
+            interference_keys: list = None,
+            home_key: str = "home_nav",
+            back_keys=None,
+            max_attempts: int = 10,
+    ) -> Tuple[Optional[str], Optional[WebElement]]:
+        """
+        导航到目标元素，通过检测当前页面状态并执行相应操作
+
+        Args:
+            home_key: 首页元素key，找到表示已回到首页，不能再返回
+            back_keys: 返回按钮key列表，找到则点击返回上一页
+            target_key: 目标元素key，找到则直接返回
+            interference_keys: 干扰元素key列表，出现则按系统返回键隐藏
+            max_attempts: 最大尝试次数，防止无限循环
+
+        Returns:
+            (key, element): 找到的元素key和元素对象
+            (None, None): 未找到或出错时返回
+        """
+        if back_keys is None:
+            back_keys = ["go_back", "minimize_screen"]
+        if interference_keys is None:
+            interference_keys = []
+
+        self.logger.info(f"开始导航到目标元素: {target_key}")
+        self.press_back()
+
+        for attempt in range(max_attempts):
+            self.logger.debug(f"导航尝试 {attempt + 1}/{max_attempts}")
+
+            # 构建检测元素列表，按优先级排序：干扰元素 -> 目标元素 -> 返回按钮 -> home元素
+            check_keys = interference_keys + [target_key] + back_keys + [home_key]
+
+            # 使用 wait_for_any_element_plus 检测当前状态
+            found_key, found_element = self.wait_for_any_element_plus(check_keys)
+
+            if not found_element:
+                self.logger.warning(f"第 {attempt + 1} 次尝试：未检测到任何元素")
+                # 按系统返回键尝试返回
+                self.press_back()
+                return None, None
+
+            # 根据找到的元素类型执行相应操作
+            if found_key == target_key:
+                # 命中目标后仅做干扰元素复核（无等待），避免误判后直接返回
+                interference_key, interference_element = self.try_find_any_element_plus(interference_keys)
+                if interference_element:
+                    self.logger.info(
+                        f"命中目标 {target_key} 后发现干扰元素 {interference_key}，先按返回键关闭后重试确认"
+                    )
+                    if not self.press_back():
+                        self.logger.error("按系统返回键失败")
+                        return None, None
+                    continue
+
+                self.logger.info(f"找到目标元素: {target_key}（已通过二次确认）")
+                return found_key, found_element
+
+            elif found_key in back_keys:
+                if self.click_element_at(found_element):
+                    self.logger.info(f"找到返回按钮: {found_key}，点击返回")
+                else:
+                    self.logger.warning(f"点击返回按钮失败: {found_key}")
+                    # 尝试系统返回键作为备选
+                    self.press_back()
+
+            elif found_key in interference_keys:
+                self.logger.info(f"发现干扰元素: {found_key}，按系统返回键隐藏")
+                if not self.press_back():
+                    self.logger.error("按系统返回键失败")
+                    return None, None
+
+            elif found_key == home_key:
+                self.logger.info(f"已回到首页: {home_key}，无法继续返回")
+                return found_key, found_element
+
+            else:
+                self.logger.warning(f"检测到未知元素: {found_key}")
+                self.press_back()
+                return None, None
+
+        # 达到最大尝试次数
+        self.logger.error(f"导航失败：达到最大尝试次数 {max_attempts}")
+        return None, None

--- a/tests/test_app_controller_driver_subscribers.py
+++ b/tests/test_app_controller_driver_subscribers.py
@@ -1,0 +1,127 @@
+from types import SimpleNamespace
+
+from ushareiplay.core.app_controller import AppController
+
+
+class DriverAware:
+    def __init__(self):
+        self.driver = None
+
+
+class FakeDriver:
+    def __init__(self, name):
+        self.name = name
+        self.quit_called = False
+        self.updated_settings = []
+
+    def quit(self):
+        self.quit_called = True
+
+    def update_settings(self, settings):
+        self.updated_settings.append(settings)
+
+
+class FakeLogger:
+    def __init__(self):
+        self.messages = []
+
+    def debug(self, *args, **kwargs):
+        self.messages.append(("debug", args, kwargs))
+
+    def info(self, *args, **kwargs):
+        self.messages.append(("info", args, kwargs))
+
+    def warning(self, *args, **kwargs):
+        self.messages.append(("warning", args, kwargs))
+
+    def error(self, *args, **kwargs):
+        self.messages.append(("error", args, kwargs))
+
+
+class FakeObserver:
+    def __init__(self):
+        self.events = []
+
+    def emit(self, event, **kwargs):
+        self.events.append((event, kwargs))
+
+
+class FakeSoulHandler(DriverAware):
+    def __init__(self):
+        super().__init__()
+        self.switch_to_app_called = False
+
+    def switch_to_app(self):
+        self.switch_to_app_called = True
+
+
+def controller_without_init(driver=None):
+    controller = AppController.__new__(AppController)
+    controller.driver = driver or FakeDriver("old-driver")
+    controller._driver_subscribers = []
+    controller._is_reinitializing = False
+    controller.logger = FakeLogger()
+    controller.obs = FakeObserver()
+    controller.soul_handler = None
+    return controller
+
+
+def test_register_driver_subscriber_adds_unique_objects_and_current_driver():
+    controller = controller_without_init()
+    subscriber = DriverAware()
+
+    controller.register_driver_subscriber(subscriber)
+    controller.register_driver_subscriber(subscriber)
+
+    assert controller._driver_subscribers == [subscriber]
+    assert subscriber.driver is controller.driver
+
+
+def test_notify_driver_subscribers_sets_driver_on_each_registered_object():
+    controller = controller_without_init()
+    first = DriverAware()
+    second = DriverAware()
+    new_driver = SimpleNamespace(name="new-driver")
+
+    controller.register_driver_subscriber(first)
+    controller.register_driver_subscriber(second)
+    controller._notify_driver_subscribers(new_driver)
+
+    assert first.driver is new_driver
+    assert second.driver is new_driver
+
+
+def test_reinitialize_driver_notifies_registered_subscribers(monkeypatch):
+    old_driver = FakeDriver("old-driver")
+    new_driver = FakeDriver("new-driver")
+    controller = controller_without_init(driver=old_driver)
+    soul_handler = FakeSoulHandler()
+    music_handler = DriverAware()
+    music_manager = DriverAware()
+    unregistered = DriverAware()
+    controller.soul_handler = soul_handler
+    controller.music_handler = music_handler
+    controller.music_manager = music_manager
+
+    controller.register_driver_subscriber(soul_handler)
+    controller.register_driver_subscriber(music_handler)
+    controller.register_driver_subscriber(music_manager)
+    monkeypatch.setattr(controller, "_init_driver", lambda: new_driver)
+    monkeypatch.setattr("ushareiplay.core.app_controller.time.sleep", lambda _: None)
+
+    assert controller.reinitialize_driver() is True
+
+    assert old_driver.quit_called is True
+    assert controller.driver is new_driver
+    assert soul_handler.driver is new_driver
+    assert music_handler.driver is new_driver
+    assert music_manager.driver is new_driver
+    assert unregistered.driver is None
+    assert soul_handler.switch_to_app_called is True
+    assert new_driver.updated_settings == [
+        {
+            "waitForIdleTimeout": 0,
+            "waitForSelectorTimeout": 2000,
+            "waitForPageLoad": 2000,
+        }
+    ]

--- a/tests/test_app_handler_ui_delegates.py
+++ b/tests/test_app_handler_ui_delegates.py
@@ -1,0 +1,98 @@
+from ushareiplay.core.app_handler import AppHandler
+from ushareiplay.core.ui import ElementFinder, GestureHandler, KeyActions, Navigator
+
+
+class RecordingHelper:
+    def __init__(self):
+        self.calls = []
+
+    def __getattr__(self, name):
+        def method(*args, **kwargs):
+            self.calls.append((name, args, kwargs))
+            return name, args, kwargs
+
+        return method
+
+
+def test_app_handler_delegates_ui_helper_methods():
+    handler = object.__new__(AppHandler)
+    handler.element_finder = RecordingHelper()
+    handler.key_actions = RecordingHelper()
+    handler.gesture_handler = RecordingHelper()
+    handler.navigator = RecordingHelper()
+
+    cases = [
+        ("element_finder", "wait_for_element", ("id", "value"), {"timeout": 3}, ("wait_for_element", ("id", "value"), {"timeout": 3})),
+        ("element_finder", "wait_for_element_plus", ("search_box",), {}, ("wait_for_element_plus", ("search_box",), {"timeout": 10})),
+        ("element_finder", "is_element_clickable", ("element",), {}, ("is_element_clickable", ("element",), {})),
+        ("element_finder", "wait_for_element_clickable_plus", ("search_box",), {}, ("wait_for_element_clickable_plus", ("search_box",), {"timeout": 10})),
+        ("element_finder", "wait_for_element_clickable", ("id", "value"), {}, ("wait_for_element_clickable", ("id", "value"), {"timeout": 10})),
+        ("element_finder", "try_find_element_plus", ("search_box",), {"log": True}, ("try_find_element_plus", ("search_box",), {"log": True, "clickable": False})),
+        ("element_finder", "try_find_element", ("id", "value"), {}, ("try_find_element", ("id", "value"), {"log": True, "clickable": False})),
+        ("element_finder", "wait_for_element_polling", ("id", "value"), {}, ("wait_for_element_polling", ("id", "value"), {"timeout": 10, "poll_frequency": 0.5})),
+        ("element_finder", "wait_for_element_clickable_polling", ("id", "value"), {}, ("wait_for_element_clickable_polling", ("id", "value"), {"timeout": 10, "poll_frequency": 0.5})),
+        ("element_finder", "find_child_element", ("parent", "id", "value"), {}, ("find_child_element", ("parent", "id", "value"), {})),
+        ("element_finder", "find_child_elements", ("parent", "id", "value"), {}, ("find_child_elements", ("parent", "id", "value"), {})),
+        ("element_finder", "get_element_text", ("element",), {}, ("get_element_text", ("element",), {})),
+        ("element_finder", "try_get_attribute", ("element", "text"), {}, ("try_get_attribute", ("element", "text"), {})),
+        ("element_finder", "_get_locator", ("search_box",), {}, ("_get_locator", ("search_box",), {})),
+        ("element_finder", "find_elements_plus", ("search_box",), {}, ("find_elements_plus", ("search_box",), {})),
+        ("element_finder", "find_child_element_plus", ("parent", "child"), {}, ("find_child_element_plus", ("parent", "child"), {})),
+        ("element_finder", "find_child_elements_plus", ("parent", "child"), {}, ("find_child_elements_plus", ("parent", "child"), {})),
+        ("element_finder", "wait_for_any_element_plus", (["a", "b"],), {}, ("wait_for_any_element_plus", (["a", "b"],), {"timeout": 10})),
+        ("element_finder", "try_find_any_element_plus", (["a", "b"],), {}, ("try_find_any_element_plus", (["a", "b"],), {})),
+        ("key_actions", "switch_to_app", (), {}, ("switch_to_app", (), {})),
+        ("key_actions", "close_app", (), {}, ("close_app", (), {})),
+        ("key_actions", "switch_to_activity", ("Activity",), {}, ("switch_to_activity", ("Activity",), {})),
+        ("key_actions", "press_enter", ("element",), {}, ("press_enter", ("element",), {})),
+        ("key_actions", "press_back", (), {}, ("press_back", (), {})),
+        ("key_actions", "press_dpad_down", (), {}, ("press_dpad_down", (), {})),
+        ("key_actions", "press_volume_up", (), {}, ("press_volume_up", (), {})),
+        ("key_actions", "press_volume_down", (), {}, ("press_volume_down", (), {})),
+        ("key_actions", "press_right_key", (), {"times": 2}, ("press_right_key", (), {"times": 2})),
+        ("key_actions", "set_clipboard_text", ("hello",), {}, ("set_clipboard_text", ("hello",), {})),
+        ("key_actions", "paste_text", (), {}, ("paste_text", (), {})),
+        ("gesture_handler", "click_element_at", ("element",), {"x_ratio": 0.2}, ("click_element_at", ("element",), {"x_ratio": 0.2, "y_ratio": 0.5, "x_offset": 0, "y_offset": 0})),
+        ("gesture_handler", "_perform_swipe", (1, 2, 3, 4), {}, ("_perform_swipe", (1, 2, 3, 4), {"duration_ms": 300})),
+        ("gesture_handler", "_reversed_if_needed", ([1, 2], "down"), {}, ("_reversed_if_needed", ([1, 2], "down"), {})),
+        ("gesture_handler", "scroll_container_until_element", ("item", "container"), {}, ("scroll_container_until_element", ("item", "container"), {"direction": "up", "attribute_name": None, "attribute_value": None, "max_swipes": 10})),
+        ("navigator", "navigate_to_element", ("target",), {"max_attempts": 1}, ("navigate_to_element", ("target",), {"interference_keys": None, "home_key": "home_nav", "back_keys": None, "max_attempts": 1})),
+    ]
+
+    for helper_name, method_name, args, kwargs, expected_call in cases:
+        result = getattr(handler, method_name)(*args, **kwargs)
+        assert result == expected_call
+        helper = getattr(handler, helper_name)
+        assert helper.calls[-1] == expected_call
+
+
+def test_ui_helper_methods_keep_driver_recovery_wrappers():
+    decorated_methods = [
+        ElementFinder.wait_for_element,
+        ElementFinder.wait_for_element_plus,
+        ElementFinder.wait_for_element_clickable_plus,
+        ElementFinder.wait_for_element_clickable,
+        ElementFinder.try_find_element_plus,
+        ElementFinder.try_find_element,
+        ElementFinder.wait_for_element_polling,
+        ElementFinder.wait_for_element_clickable_polling,
+        ElementFinder.find_elements_plus,
+        ElementFinder.wait_for_any_element_plus,
+        KeyActions.switch_to_app,
+        KeyActions.close_app,
+        KeyActions.switch_to_activity,
+        KeyActions.press_enter,
+        KeyActions.press_back,
+        KeyActions.press_dpad_down,
+        KeyActions.press_volume_up,
+        KeyActions.press_volume_down,
+        KeyActions.press_right_key,
+        KeyActions.set_clipboard_text,
+        KeyActions.paste_text,
+        GestureHandler.click_element_at,
+        GestureHandler._perform_swipe,
+        GestureHandler.scroll_container_until_element,
+    ]
+
+    for method in decorated_methods:
+        assert hasattr(method, "__wrapped__")

--- a/tests/test_avatar_exit.py
+++ b/tests/test_avatar_exit.py
@@ -2,118 +2,82 @@
 分身退出事件聚合测试
 验证：只有当主账号 + 全部别名都不在线时，才触发退出事件
 """
-import asyncio
+import pytest
+import pytest_asyncio
 from tortoise import Tortoise
-from ushareiplay.models.user import User
+
 from ushareiplay.dal.user_dao import UserDAO
+from ushareiplay.models.user import User
 
 
-async def setup_db():
+@pytest_asyncio.fixture
+async def user_db():
     await Tortoise.init(
         db_url="sqlite://:memory:",
         modules={"models": ["ushareiplay.models.user"]},
     )
     await Tortoise.generate_schemas()
-
-
-async def teardown_db():
-    await Tortoise.close_connections()
-
-
-async def test_get_all_avatar_usernames():
-    """主账号 + 全部别名的 username 集合"""
-    await setup_db()
     try:
-        canonical = await User.create(username="小明", level=0)
-        await User.create(username="明明", level=0, canonical_user_id=canonical.id)
-        await User.create(username="小M", level=0, canonical_user_id=canonical.id)
-
-        result = await UserDAO.get_all_avatar_usernames("小明")
-        assert result == {"小明", "明明", "小M"}, f"Expected all avatars, got: {result}"
-        print("PASS: test_get_all_avatar_usernames")
+        yield
     finally:
-        await teardown_db()
+        await Tortoise.close_connections()
 
 
-async def test_no_leave_if_alias_still_online():
-    """某分身退出，但另一分身仍在线 → 不触发 user_leave"""
-    await setup_db()
-    try:
-        canonical = await User.create(username="小明", level=0)
-        await User.create(username="明明", level=0, canonical_user_id=canonical.id)
+@pytest.mark.asyncio
+async def test_get_all_avatar_usernames(user_db):
+    canonical = await User.create(username="小明", level=0)
+    await User.create(username="明明", level=0, canonical_user_id=canonical.id)
+    await User.create(username="小M", level=0, canonical_user_id=canonical.id)
 
-        # 模拟在线集合：明明已离线，但小明还在线
-        online_users = {"小明", "张三"}
+    result = await UserDAO.get_all_avatar_usernames("小明")
 
-        all_avatars = await UserDAO.get_all_avatar_usernames("明明")
-        still_online = all_avatars & online_users
-        should_trigger = len(still_online) == 0
-
-        assert not should_trigger, "应该不触发退出事件，小明仍在线"
-        print("PASS: test_no_leave_if_alias_still_online")
-    finally:
-        await teardown_db()
+    assert result == {"小明", "明明", "小M"}
 
 
-async def test_leave_when_all_avatars_offline():
-    """主账号 + 全部别名都离线 → 触发 user_leave"""
-    await setup_db()
-    try:
-        canonical = await User.create(username="小明", level=0)
-        await User.create(username="明明", level=0, canonical_user_id=canonical.id)
+@pytest.mark.asyncio
+async def test_no_leave_if_alias_still_online(user_db):
+    canonical = await User.create(username="小明", level=0)
+    await User.create(username="明明", level=0, canonical_user_id=canonical.id)
 
-        online_users = {"张三", "李四"}  # 小明和明明都不在线
+    online_users = {"小明", "张三"}
+    all_avatars = await UserDAO.get_all_avatar_usernames("明明")
+    still_online = all_avatars & online_users
 
-        all_avatars = await UserDAO.get_all_avatar_usernames("明明")
-        still_online = all_avatars & online_users
-        should_trigger = len(still_online) == 0
-
-        assert should_trigger, "全部分身都离线，应该触发退出事件"
-        print("PASS: test_leave_when_all_avatars_offline")
-    finally:
-        await teardown_db()
+    assert len(still_online) != 0
 
 
-async def test_no_aliases_user_triggers_immediately():
-    """没有分身的普通用户离开 → 直接触发（行为不变）"""
-    await setup_db()
-    try:
-        await User.create(username="张三", level=0)  # 无别名
+@pytest.mark.asyncio
+async def test_leave_when_all_avatars_offline(user_db):
+    canonical = await User.create(username="小明", level=0)
+    await User.create(username="明明", level=0, canonical_user_id=canonical.id)
 
-        online_users = {"李四"}  # 张三已离线
+    online_users = {"张三", "李四"}
+    all_avatars = await UserDAO.get_all_avatar_usernames("明明")
+    still_online = all_avatars & online_users
 
-        all_avatars = await UserDAO.get_all_avatar_usernames("张三")
-        still_online = all_avatars & online_users
-        should_trigger = len(still_online) == 0
-
-        assert should_trigger, "无分身的普通用户离开应立即触发"
-        print("PASS: test_no_aliases_user_triggers_immediately")
-    finally:
-        await teardown_db()
+    assert len(still_online) == 0
 
 
-async def test_alias_queried_resolves_to_canonical_group():
-    """通过别名查询，返回的集合仍包含主账号和其他别名"""
-    await setup_db()
-    try:
-        canonical = await User.create(username="小明", level=0)
-        await User.create(username="明明", level=0, canonical_user_id=canonical.id)
-        await User.create(username="小M", level=0, canonical_user_id=canonical.id)
+@pytest.mark.asyncio
+async def test_no_aliases_user_triggers_immediately(user_db):
+    await User.create(username="张三", level=0)
 
-        # 用别名 "明明" 查询
-        result = await UserDAO.get_all_avatar_usernames("明明")
-        assert "小明" in result, "主账号应在结果中"
-        assert "明明" in result, "查询用的别名应在结果中"
-        assert "小M" in result, "其他别名应在结果中"
-        assert len(result) == 3, f"结果应有3个成员，实际: {result}"
-        print("PASS: test_alias_queried_resolves_to_canonical_group")
-    finally:
-        await teardown_db()
+    online_users = {"李四"}
+    all_avatars = await UserDAO.get_all_avatar_usernames("张三")
+    still_online = all_avatars & online_users
+
+    assert len(still_online) == 0
 
 
-if __name__ == "__main__":
-    asyncio.run(test_get_all_avatar_usernames())
-    asyncio.run(test_no_leave_if_alias_still_online())
-    asyncio.run(test_leave_when_all_avatars_offline())
-    asyncio.run(test_no_aliases_user_triggers_immediately())
-    asyncio.run(test_alias_queried_resolves_to_canonical_group())
+@pytest.mark.asyncio
+async def test_alias_queried_resolves_to_canonical_group(user_db):
+    canonical = await User.create(username="小明", level=0)
+    await User.create(username="明明", level=0, canonical_user_id=canonical.id)
+    await User.create(username="小M", level=0, canonical_user_id=canonical.id)
+
+    result = await UserDAO.get_all_avatar_usernames("明明")
+
+    assert "小明" in result
+    assert "明明" in result
+    assert "小M" in result
+    assert len(result) == 3

--- a/tests/test_command_parser_no_config_mutation.py
+++ b/tests/test_command_parser_no_config_mutation.py
@@ -1,27 +1,22 @@
 from ushareiplay.core.command_parser import CommandParser
 
 
-def main() -> None:
+def test_command_parser_does_not_mutate_shared_config():
     commands = [
         {"prefix": "help", "response_template": "ok"},
         {"prefix": "play", "response_template": "ok"},
     ]
     parser = CommandParser(commands)
 
-    r1 = parser.parse_command("help")
-    assert r1 is not None
-    assert r1["prefix"] == "help"
-    assert r1.get("parameters") == []
+    help_result = parser.parse_command("help")
+    assert help_result is not None
+    assert help_result["prefix"] == "help"
+    assert help_result.get("parameters") == []
 
-    r2 = parser.parse_command("play foo")
-    assert r2 is not None
-    assert r2["prefix"] == "play"
-    assert r2.get("parameters") == ["foo"]
+    play_result = parser.parse_command("play foo")
+    assert play_result is not None
+    assert play_result["prefix"] == "play"
+    assert play_result.get("parameters") == ["foo"]
 
-    # Shared config must not be mutated by parsing.
     assert "parameters" not in commands[0]
     assert "parameters" not in commands[1]
-
-
-if __name__ == "__main__":
-    main()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -17,6 +17,11 @@ MODULES = [
     "ushareiplay.core.log_formatter",
     "ushareiplay.core.element_wrapper",
     "ushareiplay.core.driver_decorator",
+    "ushareiplay.core.ui",
+    "ushareiplay.core.ui.element_finder",
+    "ushareiplay.core.ui.gesture_handler",
+    "ushareiplay.core.ui.key_actions",
+    "ushareiplay.core.ui.navigation",
     # models
     "ushareiplay.models",
     "ushareiplay.models.user",

--- a/tests/test_keyword_acl.py
+++ b/tests/test_keyword_acl.py
@@ -1,49 +1,40 @@
-import asyncio
+import pytest
 
 from ushareiplay.core.db_manager import DatabaseManager
-from ushareiplay.dal.user_dao import UserDAO
 from ushareiplay.dal.keyword_dao import KeywordDAO
+from ushareiplay.dal.user_dao import UserDAO
 
 
-async def main():
+@pytest.mark.asyncio
+async def test_private_keyword_acl_and_canonical_alias_access():
     db = DatabaseManager(db_url="sqlite://:memory:")
     await db.init()
+    try:
+        user_a = await UserDAO.get_or_create("A")
+        user_b = await UserDAO.get_or_create("B")
+        user_c = await UserDAO.get_or_create("C")
 
-    user_a = await UserDAO.get_or_create("A")
-    user_b = await UserDAO.get_or_create("B")
-    user_c = await UserDAO.get_or_create("C")
+        await KeywordDAO.create(
+            keyword="k1",
+            command=":help",
+            creator_id=user_a.id,
+            is_public=False,
+        )
 
-    await KeywordDAO.create(
-        keyword="k1",
-        command=":help",
-        creator_id=user_a.id,
-        is_public=False,
-    )
+        assert await KeywordDAO.find_accessible_keyword("k1", "A") is not None
+        assert await KeywordDAO.find_accessible_keyword("k1", "B") is None
 
-    # 默认私有：创建者可执行，其他人不可执行
-    assert await KeywordDAO.find_accessible_keyword("k1", "A") is not None
-    assert await KeywordDAO.find_accessible_keyword("k1", "B") is None
+        await KeywordDAO.grant_users("k1", [user_b.id, user_c.id])
+        assert await KeywordDAO.find_accessible_keyword("k1", "B") is not None
+        assert await KeywordDAO.find_accessible_keyword("k1", "C") is not None
 
-    # 授权：B/C 可执行
-    await KeywordDAO.grant_users("k1", [user_b.id, user_c.id])
-    assert await KeywordDAO.find_accessible_keyword("k1", "B") is not None
-    assert await KeywordDAO.find_accessible_keyword("k1", "C") is not None
+        await KeywordDAO.revoke_users("k1", [user_b.id])
+        assert await KeywordDAO.find_accessible_keyword("k1", "B") is None
+        assert await KeywordDAO.find_accessible_keyword("k1", "C") is not None
 
-    # 取消授权：B 不可执行，C 仍可执行
-    await KeywordDAO.revoke_users("k1", [user_b.id])
-    assert await KeywordDAO.find_accessible_keyword("k1", "B") is None
-    assert await KeywordDAO.find_accessible_keyword("k1", "C") is not None
-
-    # 别名：A2 绑定到 canonical A 后，应被视为创建者，可执行
-    alias_user = await UserDAO.get_or_create_raw("A2")
-    alias_user.canonical_user_id = user_a.id
-    await alias_user.save(update_fields=["canonical_user_id"])
-    assert await KeywordDAO.find_accessible_keyword("k1", "A2") is not None
-
-    await db.close()
-    print("test_keyword_acl.py OK")
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
-
+        alias_user = await UserDAO.get_or_create_raw("A2")
+        alias_user.canonical_user_id = user_a.id
+        await alias_user.save(update_fields=["canonical_user_id"])
+        assert await KeywordDAO.find_accessible_keyword("k1", "A2") is not None
+    finally:
+        await db.close()

--- a/tests/test_user_canonical_mapping.py
+++ b/tests/test_user_canonical_mapping.py
@@ -1,34 +1,28 @@
-import asyncio
+import pytest
 
 from ushareiplay.core.db_manager import DatabaseManager
 from ushareiplay.dal.user_dao import UserDAO
 
 
-async def main() -> None:
+@pytest.mark.asyncio
+async def test_alias_username_resolves_to_canonical_user():
     db = DatabaseManager(db_url="sqlite://:memory:")
     await db.init()
+    try:
+        canonical = await UserDAO.get_or_create("小明")
+        canonical.level = 3
+        await canonical.save(update_fields=["level"])
 
-    canonical = await UserDAO.get_or_create("小明")
-    canonical.level = 3
-    await canonical.save(update_fields=["level"])
+        alias_raw = await UserDAO.get_or_create_raw("明明")
+        alias_raw.canonical_user_id = canonical.id
+        await alias_raw.save(update_fields=["canonical_user_id"])
 
-    alias_raw = await UserDAO.get_or_create_raw("明明")
-    alias_raw.canonical_user_id = canonical.id
-    await alias_raw.save(update_fields=["canonical_user_id"])
+        resolved = await UserDAO.get_or_create("明明")
+        assert resolved.id == canonical.id
+        assert resolved.username == "小明"
+        assert resolved.level == 3
 
-    resolved = await UserDAO.get_or_create("明明")
-    assert resolved.id == canonical.id, (resolved.id, canonical.id)
-    assert resolved.username == "小明"
-    assert resolved.level == 3
-
-    # Ensure canonical resolves to itself
-    resolved2 = await UserDAO.get_or_create("小明")
-    assert resolved2.id == canonical.id
-
-    print("OK: alias username resolves to canonical user")
-    await db.close()
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
-
+        resolved2 = await UserDAO.get_or_create("小明")
+        assert resolved2.id == canonical.id
+    finally:
+        await db.close()


### PR DESCRIPTION
## Summary
- Split AppHandler UI operations into focused helper modules while preserving the AppHandler compatibility facade.
- Added driver subscriber registration so reinitialize_driver updates registered driver-aware components through one path.
- Converted standalone-style tests into pytest tests and added focused coverage for AppHandler delegation and driver reinitialization.

## Test Plan
- [x] uv run pytest -q
- [x] git diff --check