### PR TITLE
Refactor command loading to class-based modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,10 +73,11 @@ AppController
 
 ### Adding a New Command
 
-1. Create `src/commands/<name>_command.py` inheriting from `BaseCommand`
-2. Implement `execute(self, params, context)` method
-3. Add command config entry in `config.yaml` under the commands section
-4. `CommandManager` auto-discovers commands via dynamic loading — no registration needed
+1. Create `src/ushareiplay/commands/<name>.py` with exactly one `BaseCommand` subclass
+2. Implement `process(self, message_info, parameters)` on that class
+3. Do not add a `create_command()` factory or a module-level `command = None`
+4. Add command config entry in `config.yaml` under the commands section
+5. `CommandManager` auto-discovers commands via dynamic loading — no registration needed
 
 ### Configuration
 

--- a/docs/music.md
+++ b/docs/music.md
@@ -54,4 +54,4 @@ No DB model — music state is read live from QQ Music UI. `MusicManager` caches
 ## Extension Points
 
 - **New music source**: Add method to `QQMusicHandler`, expose via `MusicManager`, create new command in `src/ushareiplay/commands/`.
-- **New command**: Create `src/ushareiplay/commands/<name>.py` inheriting `BaseCommand`, implement `execute()`. No registration needed — `CommandManager` auto-discovers via dynamic import.
+- **New command**: Create `src/ushareiplay/commands/<name>.py` with exactly one `BaseCommand` subclass, implement `process()`, and do not add `create_command()` or `command = None`. No registration needed — `CommandManager` auto-discovers via dynamic import.

--- a/docs/superpowers/plans/2026-05-07-class-based-command-loading.md
+++ b/docs/superpowers/plans/2026-05-07-class-based-command-loading.md
@@ -1,0 +1,496 @@
+# Class-Based Command Loading Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove per-command factory boilerplate so each command module only defines a `BaseCommand` subclass, while `CommandManager` discovers and instantiates commands directly from the controller it already owns.
+
+**Architecture:** Keep `CommandManager` as the single loader and cache owner. It should resolve each module from `self.commands_path`, find the concrete `BaseCommand` subclass, instantiate it with the controller reference stored on the manager, and continue attaching the runtime instance to the imported module for backward-compatible caching. Migrate command modules in two batches so the codebase stays testable while the old factory protocol is still in place. Once all modules are class-only, remove the legacy factory fallback and update the developer docs to describe the new contract.
+
+**Tech Stack:** Python 3.13, pytest, uv.
+
+---
+
+## Scope
+
+This plan only changes command discovery, command module structure, and the small docs surface that tells contributors how to add a command. It does not redesign `BaseCommand`, change command parsing, or alter command behavior beyond removing the old `create_command()` / `command = None` module boilerplate.
+
+## File Structure
+
+- Modify `src/ushareiplay/managers/command_manager.py`: load modules from `self.commands_path`, resolve a concrete `BaseCommand` subclass, instantiate it with the manager's controller, and later remove the legacy factory branch.
+- Modify `src/ushareiplay/core/app_controller.py`: assign `self` to `self.command_manager.controller` during initialization so the manager can inject the controller into new command instances without importing `AppController`.
+- Modify `src/ushareiplay/commands/acc.py`
+- Modify `src/ushareiplay/commands/admin.py`
+- Modify `src/ushareiplay/commands/alias.py`
+- Modify `src/ushareiplay/commands/enter.py`
+- Modify `src/ushareiplay/commands/exit.py`
+- Modify `src/ushareiplay/commands/gift.py`
+- Modify `src/ushareiplay/commands/help.py`
+- Modify `src/ushareiplay/commands/info.py`
+- Modify `src/ushareiplay/commands/keyword.py`
+- Modify `src/ushareiplay/commands/mode.py`
+- Modify `src/ushareiplay/commands/next.py`
+- Modify `src/ushareiplay/commands/notice.py`
+- Modify `src/ushareiplay/commands/pack.py`
+- Modify `src/ushareiplay/commands/pause.py`
+- Modify `src/ushareiplay/commands/playlist.py`
+- Modify `src/ushareiplay/commands/room.py`
+- Modify `src/ushareiplay/commands/say.py`
+- Modify `src/ushareiplay/commands/seat.py`
+- Modify `src/ushareiplay/commands/skip.py`
+- Modify `src/ushareiplay/commands/vol.py`
+- Modify `src/ushareiplay/commands/album.py`
+- Modify `src/ushareiplay/commands/end.py`
+- Modify `src/ushareiplay/commands/fav.py`
+- Modify `src/ushareiplay/commands/lyrics.py`
+- Modify `src/ushareiplay/commands/mic.py`
+- Modify `src/ushareiplay/commands/play.py`
+- Modify `src/ushareiplay/commands/radio.py`
+- Modify `src/ushareiplay/commands/return.py`
+- Modify `src/ushareiplay/commands/singer.py`
+- Modify `src/ushareiplay/commands/theme.py`
+- Modify `src/ushareiplay/commands/timer.py`
+- Modify `src/ushareiplay/commands/title.py`
+- Modify `src/ushareiplay/commands/topic.py`
+- Modify `tests/test_command_manager_class_loading.py`
+- Modify `tests/test_simple_command_modules_class_only.py`
+- Modify `tests/test_stateful_command_modules_class_only.py`
+- Modify `tests/test_command_manager_no_legacy_factory.py`
+- Modify `CLAUDE.md`
+- Modify `docs/music.md`
+
+## Task 1: Teach `CommandManager` to Instantiate Command Classes
+
+**Files:**
+- Modify: `src/ushareiplay/managers/command_manager.py`
+- Modify: `src/ushareiplay/core/app_controller.py`
+- Create: `tests/test_command_manager_class_loading.py`
+
+- [ ] **Step 1: Write the failing test for class-based loading**
+
+Create `tests/test_command_manager_class_loading.py` with a temp module that defines only a `BaseCommand` subclass and no `create_command()` function:
+
+```python
+import asyncio
+from pathlib import Path
+
+
+class DummyController:
+    def __init__(self):
+        self.soul_handler = object()
+        self.music_handler = object()
+        self.marker = "ok"
+
+
+def test_load_command_module_instantiates_class_without_factory(tmp_path):
+    (tmp_path / "demo.py").write_text(
+        "from ushareiplay.core.base_command import BaseCommand\n"
+        "class DemoCommand(BaseCommand):\n"
+        "    async def process(self, message_info, parameters):\n"
+        "        return {'message': self.controller.marker}\n"
+    )
+
+    from ushareiplay.managers.command_manager import CommandManager
+
+    manager = CommandManager.__new__(CommandManager)
+    manager.__init__()
+    manager.commands_path = tmp_path
+    manager.controller = DummyController()
+
+    module = manager.load_command_module("demo")
+    assert module is not None
+    assert hasattr(module, "command")
+    assert module.command.controller is manager.controller
+    result = asyncio.run(module.command.process(None, []))
+    assert result == {"message": "ok"}
+```
+
+- [ ] **Step 2: Run the test to confirm the current loader cannot do this yet**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q tests/test_command_manager_class_loading.py
+```
+
+Expected: fail because `CommandManager` still requires the old factory contract.
+
+- [ ] **Step 3: Implement class-based discovery with controller injection**
+
+Update `src/ushareiplay/managers/command_manager.py` so it stores a controller reference and resolves command classes directly from the imported module. The essential shape should be:
+
+```python
+class CommandManager(Singleton):
+    def __init__(self):
+        self.controller = None
+        self._handler = None
+        self._logger = None
+        self.commands_path = Path(__file__).parent.parent / "commands"
+        self.command_modules = {}
+        self.command_parser = None
+
+    def _find_command_class(self, module):
+        from ushareiplay.core.base_command import BaseCommand
+
+        candidates = [
+            value
+            for value in module.__dict__.values()
+            if isinstance(value, type)
+            and issubclass(value, BaseCommand)
+            and value is not BaseCommand
+            and value.__module__ == module.__name__
+        ]
+        return candidates[0] if len(candidates) == 1 else None
+
+    def load_command_module(self, command):
+        module_path = (self.commands_path / f"{command}.py").resolve()
+        ...
+        command_cls = self._find_command_class(module)
+        if command_cls is None:
+            self.logger.error("Command module does not define a concrete BaseCommand subclass")
+            return None
+        module.command = command_cls(self.controller)
+        self.command_modules[command] = module
+        return module
+```
+
+Also update `src/ushareiplay/core/app_controller.py` so that after `self.command_manager = CommandManager.instance()` it assigns:
+
+```python
+self.command_manager.controller = self
+```
+
+That keeps the controller injection explicit and removes the need for `CommandManager` to import `AppController`.
+
+- [ ] **Step 4: Run the class-loading test again**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q tests/test_command_manager_class_loading.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ushareiplay/managers/command_manager.py src/ushareiplay/core/app_controller.py tests/test_command_manager_class_loading.py
+git commit -m "refactor: support class-based command loading"
+```
+
+## Task 2: Convert the Simple Command Modules
+
+**Files:**
+- Modify: `src/ushareiplay/commands/acc.py`
+- Modify: `src/ushareiplay/commands/admin.py`
+- Modify: `src/ushareiplay/commands/alias.py`
+- Modify: `src/ushareiplay/commands/enter.py`
+- Modify: `src/ushareiplay/commands/exit.py`
+- Modify: `src/ushareiplay/commands/gift.py`
+- Modify: `src/ushareiplay/commands/help.py`
+- Modify: `src/ushareiplay/commands/info.py`
+- Modify: `src/ushareiplay/commands/keyword.py`
+- Modify: `src/ushareiplay/commands/mode.py`
+- Modify: `src/ushareiplay/commands/next.py`
+- Modify: `src/ushareiplay/commands/notice.py`
+- Modify: `src/ushareiplay/commands/pack.py`
+- Modify: `src/ushareiplay/commands/pause.py`
+- Modify: `src/ushareiplay/commands/playlist.py`
+- Modify: `src/ushareiplay/commands/say.py`
+- Modify: `src/ushareiplay/commands/seat.py`
+- Modify: `src/ushareiplay/commands/skip.py`
+- Modify: `src/ushareiplay/commands/vol.py`
+- Create: `tests/test_simple_command_modules_class_only.py`
+
+- [ ] **Step 1: Write the failing source-level regression test**
+
+Create `tests/test_simple_command_modules_class_only.py` to verify that the simple command modules no longer contain the legacy factory boilerplate:
+
+```python
+from pathlib import Path
+
+
+SIMPLE_COMMANDS = {
+    "acc",
+    "admin",
+    "alias",
+    "enter",
+    "exit",
+    "gift",
+    "help",
+    "info",
+    "keyword",
+    "mode",
+    "next",
+    "notice",
+    "pack",
+    "pause",
+    "playlist",
+    "say",
+    "seat",
+    "skip",
+    "vol",
+}
+
+
+def test_simple_command_modules_are_class_only():
+    commands_path = Path(__file__).resolve().parents[1] / "src" / "ushareiplay" / "commands"
+    offenders = {}
+
+    for name in SIMPLE_COMMANDS:
+        source = (commands_path / f"{name}.py").read_text(encoding="utf-8")
+        hits = []
+        if "def create_command(" in source:
+            hits.append("create_command")
+        if "command = None" in source:
+            hits.append("command = None")
+        if hits:
+            offenders[name] = hits
+
+    assert not offenders, f"Simple command modules still use the old factory protocol: {offenders}"
+```
+
+- [ ] **Step 2: Run the test to confirm it fails on the current code**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q tests/test_simple_command_modules_class_only.py
+```
+
+Expected: fail because those modules still define `create_command()` and `command = None`.
+
+- [ ] **Step 3: Rewrite the simple command modules as pure classes**
+
+For each file listed in this task, delete the module-level factory boilerplate and keep only the class definition plus existing behavior. The resulting module shape should look like:
+
+```python
+from ushareiplay.core.base_command import BaseCommand
+
+
+class FooCommand(BaseCommand):
+    def __init__(self, controller):
+        super().__init__(controller)
+        self.handler = self.soul_handler
+```
+
+Apply that pattern to:
+
+`acc.py`, `admin.py`, `alias.py`, `enter.py`, `exit.py`, `gift.py`, `help.py`, `info.py`, `keyword.py`, `mode.py`, `next.py`, `notice.py`, `pack.py`, `pause.py`, `playlist.py`, `say.py`, `seat.py`, `skip.py`, `vol.py`.
+
+Keep each module's existing `process`, `update`, and helper methods unchanged apart from removing any `controller.<name>_command = ...` assignment and deleting the `create_command()` function plus `command = None`.
+
+- [ ] **Step 4: Run the simple-module regression test again**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q tests/test_simple_command_modules_class_only.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ushareiplay/commands/acc.py src/ushareiplay/commands/admin.py src/ushareiplay/commands/alias.py src/ushareiplay/commands/enter.py src/ushareiplay/commands/exit.py src/ushareiplay/commands/gift.py src/ushareiplay/commands/help.py src/ushareiplay/commands/info.py src/ushareiplay/commands/keyword.py src/ushareiplay/commands/mode.py src/ushareiplay/commands/next.py src/ushareiplay/commands/notice.py src/ushareiplay/commands/pack.py src/ushareiplay/commands/pause.py src/ushareiplay/commands/playlist.py src/ushareiplay/commands/say.py src/ushareiplay/commands/seat.py src/ushareiplay/commands/skip.py src/ushareiplay/commands/vol.py tests/test_simple_command_modules_class_only.py
+git commit -m "refactor: convert simple commands to class-only modules"
+```
+
+## Task 3: Convert the Stateful Command Modules
+
+**Files:**
+- Modify: `src/ushareiplay/commands/album.py`
+- Modify: `src/ushareiplay/commands/end.py`
+- Modify: `src/ushareiplay/commands/fav.py`
+- Modify: `src/ushareiplay/commands/lyrics.py`
+- Modify: `src/ushareiplay/commands/mic.py`
+- Modify: `src/ushareiplay/commands/play.py`
+- Modify: `src/ushareiplay/commands/radio.py`
+- Modify: `src/ushareiplay/commands/return.py`
+- Modify: `src/ushareiplay/commands/room.py`
+- Modify: `src/ushareiplay/commands/singer.py`
+- Modify: `src/ushareiplay/commands/theme.py`
+- Modify: `src/ushareiplay/commands/timer.py`
+- Modify: `src/ushareiplay/commands/title.py`
+- Modify: `src/ushareiplay/commands/topic.py`
+- Create: `tests/test_stateful_command_modules_class_only.py`
+
+- [ ] **Step 1: Write the failing source-level regression test**
+
+Create `tests/test_stateful_command_modules_class_only.py` with the same boilerplate check, but only for the stateful modules:
+
+```python
+from pathlib import Path
+
+
+STATEFUL_COMMANDS = {
+    "album",
+    "end",
+    "fav",
+    "lyrics",
+    "mic",
+    "play",
+    "radio",
+    "return",
+    "room",
+    "singer",
+    "theme",
+    "timer",
+    "title",
+    "topic",
+}
+
+
+def test_stateful_command_modules_are_class_only():
+    commands_path = Path(__file__).resolve().parents[1] / "src" / "ushareiplay" / "commands"
+    offenders = {}
+
+    for name in STATEFUL_COMMANDS:
+        source = (commands_path / f"{name}.py").read_text(encoding="utf-8")
+        hits = []
+        if "def create_command(" in source:
+            hits.append("create_command")
+        if "command = None" in source:
+            hits.append("command = None")
+        if hits:
+            offenders[name] = hits
+
+    assert not offenders, f"Stateful command modules still use the old factory protocol: {offenders}"
+```
+
+- [ ] **Step 2: Run the test to confirm it fails on the current code**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q tests/test_stateful_command_modules_class_only.py
+```
+
+Expected: fail because these modules still expose the factory protocol.
+
+- [ ] **Step 3: Rewrite the stateful command modules as pure classes**
+
+Apply the same class-only cleanup to:
+
+`album.py`, `end.py`, `fav.py`, `lyrics.py`, `mic.py`, `play.py`, `radio.py`, `return.py`, `room.py`, `singer.py`, `theme.py`, `timer.py`, `title.py`, `topic.py`.
+
+Keep existing behavior intact:
+
+```python
+class ReturnCommand(BaseCommand):
+    async def user_return(self, username: str):
+        ...
+
+class TimerCommand(BaseCommand):
+    def update(self):
+        ...
+
+class EndCommand(BaseCommand):
+    def __init__(self, controller):
+        super().__init__(controller)
+        self.handler = self.soul_handler
+        self.party_manager = PartyManager.instance()
+```
+
+Only remove `create_command()`, `command = None`, and any `controller.<name>_command = ...` assignment from the module body. Keep the controller injection in the class constructor so the command still has access to handlers, config, and managers.
+
+- [ ] **Step 4: Run the stateful-module regression test again**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q tests/test_stateful_command_modules_class_only.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ushareiplay/commands/album.py src/ushareiplay/commands/end.py src/ushareiplay/commands/fav.py src/ushareiplay/commands/lyrics.py src/ushareiplay/commands/mic.py src/ushareiplay/commands/play.py src/ushareiplay/commands/radio.py src/ushareiplay/commands/return.py src/ushareiplay/commands/room.py src/ushareiplay/commands/singer.py src/ushareiplay/commands/theme.py src/ushareiplay/commands/timer.py src/ushareiplay/commands/title.py src/ushareiplay/commands/topic.py tests/test_stateful_command_modules_class_only.py
+git commit -m "refactor: convert stateful commands to class-only modules"
+```
+
+## Task 4: Remove the Legacy Factory Path and Update Docs
+
+**Files:**
+- Modify: `src/ushareiplay/managers/command_manager.py`
+- Create: `tests/test_command_manager_no_legacy_factory.py`
+- Modify: `CLAUDE.md`
+- Modify: `docs/music.md`
+
+- [ ] **Step 1: Write the failing test that guards against reintroducing the old protocol**
+
+Create `tests/test_command_manager_no_legacy_factory.py` to assert that `CommandManager` no longer contains the legacy factory branch:
+
+```python
+from pathlib import Path
+
+
+def test_command_manager_has_no_legacy_create_command_branch():
+    source = (Path(__file__).resolve().parents[1] / "src" / "ushareiplay" / "managers" / "command_manager.py").read_text(encoding="utf-8")
+    assert "create_command" not in source
+    assert "does not have create_command" not in source
+```
+
+- [ ] **Step 2: Run the test to confirm the fallback still exists**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q tests/test_command_manager_no_legacy_factory.py
+```
+
+Expected: fail because `CommandManager` still includes the legacy compatibility branch.
+
+- [ ] **Step 3: Delete the legacy factory branch and update the docs**
+
+Remove the `create_command()` fallback from `src/ushareiplay/managers/command_manager.py` so the loader only accepts a concrete `BaseCommand` subclass. Keep the module attachment behavior (`module.command = ...`) and the `self.commands_path / f"{command}.py"` lookup.
+
+Update `CLAUDE.md` and `docs/music.md` so the contributor guidance reads like this:
+
+```markdown
+### Adding a New Command
+
+1. Create `src/ushareiplay/commands/<name>.py`
+2. Define exactly one `BaseCommand` subclass in that module
+3. Implement `process(self, message_info, parameters)` and any optional hooks such as `update()` or `user_return()`
+4. Do not add a `create_command()` factory or a module-level `command = None`
+5. `CommandManager` auto-discovers the class via dynamic loading, so no registration is needed
+```
+
+Also update the command extension note in `docs/music.md` to say the new command module should export a single `BaseCommand` subclass with `process()`, not `execute()`.
+
+- [ ] **Step 4: Run the targeted verification suite**
+
+Run:
+
+```bash
+source .venv/bin/activate
+uv run pytest -q \
+  tests/test_command_manager_class_loading.py \
+  tests/test_simple_command_modules_class_only.py \
+  tests/test_stateful_command_modules_class_only.py \
+  tests/test_command_manager_no_legacy_factory.py \
+  tests/test_dynamic_loading.py \
+  tests/test_paths.py \
+  tests/test_help_command_is_current.py
+python -m py_compile src/ushareiplay/managers/command_manager.py src/ushareiplay/commands/*.py
+```
+
+Expected: all targeted tests pass and every modified Python file compiles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ushareiplay/managers/command_manager.py tests/test_command_manager_no_legacy_factory.py CLAUDE.md docs/music.md
+git commit -m "refactor: remove legacy command factory protocol"
+```

--- a/src/ushareiplay/commands/acc.py
+++ b/src/ushareiplay/commands/acc.py
@@ -1,15 +1,5 @@
 from ushareiplay.core.base_command import BaseCommand
 
-
-def create_command(controller):
-    accompaniment_command = AccompanimentCommand(controller)
-    controller.accompaniment_command = accompaniment_command
-    return accompaniment_command
-
-
-command = None
-
-
 class AccompanimentCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/admin.py
+++ b/src/ushareiplay/commands/admin.py
@@ -3,16 +3,6 @@ import traceback
 from ushareiplay.core.base_command import BaseCommand
 from ushareiplay.managers.admin_manager import AdminManager
 
-
-def create_command(controller):
-    admin_command = AdminCommand(controller)
-    controller.admin_command = admin_command
-    return admin_command
-
-
-command = None
-
-
 class AdminCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/album.py
+++ b/src/ushareiplay/commands/album.py
@@ -2,17 +2,6 @@ import traceback
 
 from ushareiplay.core.base_command import BaseCommand
 from ushareiplay.helpers.playlist_info import get_playlist_text_and_first_song
-
-
-def create_command(controller):
-    album_command = AlbumCommand(controller)
-    controller.album_command = album_command
-    return album_command
-
-
-command = None
-
-
 class AlbumCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/alias.py
+++ b/src/ushareiplay/commands/alias.py
@@ -4,16 +4,6 @@ import traceback
 from ushareiplay.core.base_command import BaseCommand
 from ushareiplay.dal.user_dao import UserDAO
 
-
-def create_command(controller):
-    alias_command = AliasCommand(controller)
-    controller.alias_command = alias_command
-    return alias_command
-
-
-command = None
-
-
 class AliasCommand(BaseCommand):
     async def process(self, message_info, parameters):
         """
@@ -55,4 +45,3 @@ class AliasCommand(BaseCommand):
         except Exception:
             self.soul_handler.logger.error(f"Error in alias command: {traceback.format_exc()}")
             return {'error': '处理失败'}
-

--- a/src/ushareiplay/commands/end.py
+++ b/src/ushareiplay/commands/end.py
@@ -1,13 +1,6 @@
 import traceback
 from ushareiplay.core.base_command import BaseCommand
 
-def create_command(controller):
-    end_command = EndCommand(controller)
-    controller.end_command = end_command
-    return end_command
-
-command = None
-
 class EndCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)
@@ -35,4 +28,3 @@ class EndCommand(BaseCommand):
             self.party_manager.update()
         except Exception as e:
             self.handler.log_error(f"Error in party management update: {traceback.format_exc()}")
-

--- a/src/ushareiplay/commands/enter.py
+++ b/src/ushareiplay/commands/enter.py
@@ -3,16 +3,6 @@ import shlex
 from ushareiplay.core.base_command import BaseCommand
 from ushareiplay.dal.enter_dao import EnterDao
 
-
-def create_command(controller):
-    enter_command = EnterCommand(controller)
-    controller.enter_command = enter_command
-    return enter_command
-
-
-command = None
-
-
 class EnterCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/exit.py
+++ b/src/ushareiplay/commands/exit.py
@@ -3,16 +3,6 @@ import shlex
 from ushareiplay.core.base_command import BaseCommand
 from ushareiplay.dal.exit_dao import ExitDao
 
-
-def create_command(controller):
-    exit_command = ExitCommand(controller)
-    controller.exit_command = exit_command
-    return exit_command
-
-
-command = None
-
-
 class ExitCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/fav.py
+++ b/src/ushareiplay/commands/fav.py
@@ -7,15 +7,6 @@ import re
 import time
 
 
-def create_command(controller):
-    fav_command = FavCommand(controller)
-    controller.fav_command = fav_command
-    return fav_command
-
-
-command = None
-
-
 class FavCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/gift.py
+++ b/src/ushareiplay/commands/gift.py
@@ -4,16 +4,6 @@ import traceback
 from ushareiplay.core.base_command import BaseCommand
 from ushareiplay.managers.user_manager import UserManager
 
-
-def create_command(controller):
-    gift_command = GiftCommand(controller)
-    controller.gift_command = gift_command
-    return gift_command
-
-
-command = None
-
-
 class GiftCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/help.py
+++ b/src/ushareiplay/commands/help.py
@@ -1,14 +1,6 @@
 from __future__ import annotations
 
 from ushareiplay.core.base_command import BaseCommand
-
-def create_command(controller):
-    help_command = HelpCommand(controller)
-    controller.help_command = help_command
-    return help_command
-
-command = None
-
 class HelpCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/info.py
+++ b/src/ushareiplay/commands/info.py
@@ -1,15 +1,5 @@
 from ushareiplay.core.base_command import BaseCommand
 
-
-def create_command(controller):
-    info_command = InfoCommand(controller)
-    controller.info_command = info_command
-    return info_command
-
-
-command = None
-
-
 class InfoCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/keyword.py
+++ b/src/ushareiplay/commands/keyword.py
@@ -2,16 +2,6 @@ import traceback
 import shlex
 from ushareiplay.core.base_command import BaseCommand
 
-
-def create_command(controller):
-    keyword_command = KeywordCommand(controller)
-    controller.keyword_command = keyword_command
-    return keyword_command
-
-
-command = None
-
-
 class KeywordCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/lyrics.py
+++ b/src/ushareiplay/commands/lyrics.py
@@ -41,13 +41,6 @@ def wrap_line_at_spaces(line: str, max_width: int) -> str:
     return "\n".join(out)
 
 
-def create_command(controller):
-    lyrics_command = LyricsCommand(controller)
-    controller.lyrics_command = lyrics_command
-    return lyrics_command
-
-command = None
-
 class LyricsCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/mic.py
+++ b/src/ushareiplay/commands/mic.py
@@ -1,12 +1,5 @@
 from ushareiplay.core.base_command import BaseCommand
 
-def create_command(controller):
-    mic_command = MicCommand(controller)
-    controller.mic_command = mic_command  # Store instance in controller
-    return mic_command
-
-command = None
-
 class MicCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/mode.py
+++ b/src/ushareiplay/commands/mode.py
@@ -1,15 +1,5 @@
 from ushareiplay.core.base_command import BaseCommand
 
-
-def create_command(controller):
-    mode_command = ModeCommand(controller)
-    controller.mode_command = mode_command
-    return mode_command
-
-
-command = None
-
-
 class ModeCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/next.py
+++ b/src/ushareiplay/commands/next.py
@@ -3,13 +3,6 @@ from ushareiplay.core.base_command import BaseCommand
 from datetime import datetime, timedelta
 import time
 
-def create_command(controller):
-    next_command = NextCommand(controller)
-    controller.next_command = next_command
-    return next_command
-
-command = None
-
 class NextCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/notice.py
+++ b/src/ushareiplay/commands/notice.py
@@ -1,16 +1,6 @@
 import traceback
 from ushareiplay.core.base_command import BaseCommand
 
-
-def create_command(controller):
-    notice_command = NoticeCommand(controller)
-    controller.notice_command = notice_command
-    return notice_command
-
-
-command = None
-
-
 class NoticeCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)
@@ -72,4 +62,3 @@ class NoticeCommand(BaseCommand):
 
         except Exception:
             self.handler.log_error(f"Error in notice update: {traceback.format_exc()}")
-

--- a/src/ushareiplay/commands/pack.py
+++ b/src/ushareiplay/commands/pack.py
@@ -2,16 +2,6 @@ import traceback
 
 from ushareiplay.core.base_command import BaseCommand
 
-
-def create_command(controller):
-    pack_command = PackCommand(controller)
-    controller.pack_command = pack_command
-    return pack_command
-
-
-command = None
-
-
 class PackCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/pause.py
+++ b/src/ushareiplay/commands/pause.py
@@ -3,13 +3,6 @@ from ushareiplay.core.base_command import BaseCommand
 from datetime import datetime, timedelta
 import time
 
-def create_command(controller):
-    pause_command = PauseCommand(controller)
-    controller.pause_command = pause_command
-    return pause_command
-
-command = None
-
 class PauseCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/play.py
+++ b/src/ushareiplay/commands/play.py
@@ -3,15 +3,6 @@ from appium.webdriver.common.appiumby import AppiumBy
 from ushareiplay.core.base_command import BaseCommand
 
 
-def create_command(controller):
-    play_command = PlayCommand(controller)
-    controller.play_command = play_command
-    return play_command
-
-
-command = None
-
-
 class PlayCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/playlist.py
+++ b/src/ushareiplay/commands/playlist.py
@@ -6,16 +6,6 @@ from ushareiplay.core.base_command import BaseCommand
 from ushareiplay.helpers.playlist_info import get_playlist_text_and_first_song
 from ushareiplay.helpers.playlist_parser import PlaylistParser
 
-
-def create_command(controller):
-    playlist_command = PlaylistCommand(controller)
-    controller.playlist_command = playlist_command
-    return playlist_command
-
-
-command = None
-
-
 class PlaylistCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/radio.py
+++ b/src/ushareiplay/commands/radio.py
@@ -7,15 +7,6 @@ from ushareiplay.handlers.soul_handler import SoulHandler
 from ushareiplay.managers.title_manager import TitleManager
 from ushareiplay.managers.topic_manager import TopicManager
 
-command = None
-
-
-def create_command(controller):
-    radio_command = RadioCommand(controller)
-    controller.radio_command = radio_command
-    return radio_command
-
-
 class RadioCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/return.py
+++ b/src/ushareiplay/commands/return.py
@@ -10,15 +10,6 @@ from ushareiplay.core.base_command import BaseCommand
 from ushareiplay.dal.return_dao import ReturnDao
 
 
-def create_command(controller):
-    return_cmd = ReturnCommand(controller)
-    controller.return_command = return_cmd
-    return return_cmd
-
-
-command = None
-
-
 class ReturnCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/room.py
+++ b/src/ushareiplay/commands/room.py
@@ -2,15 +2,6 @@ import traceback
 from ushareiplay.core.base_command import BaseCommand
 
 
-def create_command(controller):
-    room_command = RoomCommand(controller)
-    controller.room_command = room_command
-    return room_command
-
-
-command = None
-
-
 class RoomCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/say.py
+++ b/src/ushareiplay/commands/say.py
@@ -1,16 +1,6 @@
 import traceback
 from ushareiplay.core.base_command import BaseCommand
 
-
-def create_command(controller):
-    say_command = SayCommand(controller)
-    controller.say_command = say_command
-    return say_command
-
-
-command = None
-
-
 class SayCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/seat.py
+++ b/src/ushareiplay/commands/seat.py
@@ -2,15 +2,6 @@ import traceback
 from ushareiplay.core.base_command import BaseCommand
 from ushareiplay.managers.seat_manager import seat_manager
 
-
-def create_command(controller):
-    seat_command = SeatCommand(controller)
-    return seat_command
-
-
-command = None
-
-
 class SeatCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/singer.py
+++ b/src/ushareiplay/commands/singer.py
@@ -4,15 +4,6 @@ from ushareiplay.core.base_command import BaseCommand
 from ushareiplay.helpers.playlist_info import get_playlist_text_and_first_song
 
 
-def create_command(controller):
-    singer_command = SingerCommand(controller)
-    controller.singer_command = singer_command
-    return singer_command
-
-
-command = None
-
-
 class SingerCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/skip.py
+++ b/src/ushareiplay/commands/skip.py
@@ -3,13 +3,6 @@ from ushareiplay.core.base_command import BaseCommand
 from datetime import datetime, timedelta
 import time
 
-def create_command(controller):
-    skip_command = SkipCommand(controller)
-    controller.skip_command = skip_command
-    return skip_command
-
-command = None
-
 class SkipCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/commands/theme.py
+++ b/src/ushareiplay/commands/theme.py
@@ -3,17 +3,6 @@
 from ushareiplay.core.base_command import BaseCommand
 from ushareiplay.managers.theme_manager import ThemeManager
 from ushareiplay.managers.title_manager import TitleManager
-
-
-def create_command(controller):
-    theme_command = ThemeCommand(controller)
-    controller.theme_command = theme_command
-    return theme_command
-
-
-command = None
-
-
 class ThemeCommand(BaseCommand):
 
     def __init__(self, controller):

--- a/src/ushareiplay/commands/timer.py
+++ b/src/ushareiplay/commands/timer.py
@@ -5,15 +5,6 @@ from ushareiplay.core.base_command import BaseCommand
 from ushareiplay.managers.timer_manager import TimerManager
 
 
-def create_command(controller):
-    timer_command = TimerCommand(controller)
-    controller.timer_command = timer_command
-    return timer_command
-
-
-command = None
-
-
 class TimerCommand(BaseCommand):
 
     def __init__(self, controller):

--- a/src/ushareiplay/commands/title.py
+++ b/src/ushareiplay/commands/title.py
@@ -6,15 +6,6 @@ from ushareiplay.managers.title_manager import TitleManager
 from ushareiplay.managers.theme_manager import ThemeManager
 
 
-def create_command(controller):
-    title_command = TitleCommand(controller)
-    controller.title_command = title_command
-    return title_command
-
-
-command = None
-
-
 class TitleCommand(BaseCommand):
 
     def __init__(self, controller):

--- a/src/ushareiplay/commands/topic.py
+++ b/src/ushareiplay/commands/topic.py
@@ -3,15 +3,6 @@ from ushareiplay.core.base_command import BaseCommand
 from ushareiplay.managers.topic_manager import TopicManager
 
 
-def create_command(controller):
-    topic_command = TopicCommand(controller)
-    controller.topic_command = topic_command
-    return topic_command
-
-
-command = None
-
-
 class TopicCommand(BaseCommand):
     """
     话题命令 - 负责参数解析和调用 TopicManager

--- a/src/ushareiplay/commands/vol.py
+++ b/src/ushareiplay/commands/vol.py
@@ -5,13 +5,6 @@ from ushareiplay.core.base_command import BaseCommand
 from datetime import datetime, timedelta
 import time
 
-def create_command(controller):
-    volume_command = VolumeCommand(controller)
-    controller.volume_command = volume_command
-    return volume_command
-
-command = None
-
 class VolumeCommand(BaseCommand):
     def __init__(self, controller):
         super().__init__(controller)

--- a/src/ushareiplay/core/app_controller.py
+++ b/src/ushareiplay/core/app_controller.py
@@ -331,6 +331,7 @@ class AppController(Singleton):
             self.recovery_manager = RecoveryManager.instance()
             self.timer_manager = TimerManager.instance()
             self.command_manager = CommandManager.instance()
+            self.command_manager.controller = self
             self.command_manager.configure_runtime(self.command_runtime_context)
             self.info_manager = InfoManager.instance()
             self.party_manager = PartyManager.instance()

--- a/src/ushareiplay/managers/command_manager.py
+++ b/src/ushareiplay/managers/command_manager.py
@@ -18,6 +18,7 @@ class CommandManager(Singleton):
         self._handler = None
         self._logger = None
         self._runtime = None
+        self.controller = None
 
         # 命令相关属性
         self.commands_path = Path(__file__).parent.parent / 'commands'
@@ -47,6 +48,28 @@ class CommandManager(Singleton):
         if self._logger is None:
             self._logger = self.handler.logger
         return self._logger
+
+    def _get_command_controller(self):
+        if self.controller is not None:
+            return self.controller
+        if self._runtime is not None and hasattr(self._runtime, "controller"):
+            return self._runtime.controller
+        return None
+
+    def _find_command_class(self, module):
+        from ushareiplay.core.base_command import BaseCommand
+
+        candidates = [
+            value
+            for value in module.__dict__.values()
+            if isinstance(value, type)
+            and issubclass(value, BaseCommand)
+            and value is not BaseCommand
+            and value.__module__ == module.__name__
+        ]
+        if len(candidates) == 1:
+            return candidates[0]
+        return None
 
     def initialize_parser(self, commands_config):
         """
@@ -78,18 +101,23 @@ class CommandManager(Singleton):
                 self.logger.error('Command module failed to load')
                 return None
 
-            if not hasattr(module, 'command'):
-                self.logger.error('Command module does not have command')
+            if hasattr(module, 'command') and module.command is not None:
+                self.command_modules[command] = module
+                return module
+
+            controller = self._get_command_controller()
+            if controller is None:
+                self.logger.error('Command manager does not have a controller reference')
                 return None
 
-            # Create command instance
-            if not hasattr(module, 'create_command'):
-                self.logger.error('Command module does not have create_command')
-                return None
+            command_cls = self._find_command_class(module)
+            if command_cls is not None:
+                module.command = command_cls(controller)
+                self.command_modules[command] = module
+                return module
 
-            module.command = module.create_command(self.runtime.controller)
-            self.command_modules[command] = module
-            return module
+            self.logger.error('Command module does not define a concrete BaseCommand subclass')
+            return None
 
         except Exception:
             self.logger.error(f"Error loading command module {command}: {traceback.format_exc()}")

--- a/tests/test_command_manager_class_loading.py
+++ b/tests/test_command_manager_class_loading.py
@@ -1,0 +1,55 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from ushareiplay.core.base_command import BaseCommand
+from ushareiplay.managers.command_manager import CommandManager
+
+
+class DummyController:
+    def __init__(self):
+        self.soul_handler = object()
+        self.music_handler = object()
+        self.marker = "ok"
+
+
+class FakeLogger:
+    def __init__(self):
+        self.messages = []
+
+    def info(self, message):
+        self.messages.append(("info", message))
+
+    def error(self, message):
+        self.messages.append(("error", message))
+
+
+def test_load_command_module_instantiates_class_without_factory(tmp_path):
+    (tmp_path / "demo.py").write_text(
+        "\n".join(
+            [
+                "from ushareiplay.core.base_command import BaseCommand",
+                "",
+                "class DemoCommand(BaseCommand):",
+                "    async def process(self, message_info, parameters):",
+                "        return {'message': self.controller.marker}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    manager = CommandManager.__new__(CommandManager)
+    manager.__init__()
+    manager.commands_path = Path(tmp_path)
+    manager.controller = DummyController()
+    manager._logger = FakeLogger()
+    manager._handler = SimpleNamespace(config={"system_users": []})
+
+    module = manager.load_command_module("demo")
+
+    assert module is not None
+    assert hasattr(module, "command")
+    assert isinstance(module.command, BaseCommand)
+    assert module.command.controller is manager.controller
+    result = asyncio.run(module.command.process(None, []))
+    assert result == {"message": "ok"}

--- a/tests/test_command_manager_no_legacy_factory.py
+++ b/tests/test_command_manager_no_legacy_factory.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def test_command_manager_no_longer_contains_legacy_factory_branch():
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "ushareiplay"
+        / "managers"
+        / "command_manager.py"
+    ).read_text(encoding="utf-8")
+
+    assert "if hasattr(module, 'create_command')" not in source
+    assert "module.command = module.create_command(controller)" not in source
+    assert "Command module does not define a concrete BaseCommand subclass or create_command" not in source

--- a/tests/test_command_manager_runtime_context.py
+++ b/tests/test_command_manager_runtime_context.py
@@ -46,7 +46,12 @@ class FakeCommand:
 
 
 def make_manager(tmp_path):
-    controller = SimpleNamespace(obs=FakeObserver())
+    controller = SimpleNamespace(
+        obs=FakeObserver(),
+        soul_handler=object(),
+        music_handler=object(),
+        marker="ok",
+    )
     runtime = FakeRuntime(controller)
     manager = CommandManager.__new__(CommandManager)
     manager.__init__()
@@ -62,10 +67,15 @@ def test_load_command_module_uses_injected_runtime_controller(tmp_path):
     command_file.write_text(
         "\n".join(
             [
-                "command = None",
-                "def create_command(controller):",
-                "    controller.loaded_by_command_manager = True",
-                "    return object()",
+                "from ushareiplay.core.base_command import BaseCommand",
+                "",
+                "class DemoCommand(BaseCommand):",
+                "    def __init__(self, controller):",
+                "        super().__init__(controller)",
+                "        self.controller.loaded_by_command_manager = True",
+                "",
+                "    async def process(self, message_info, parameters):",
+                "        return {'song': self.controller.marker}",
             ]
         ),
         encoding="utf-8",
@@ -76,7 +86,10 @@ def test_load_command_module_uses_injected_runtime_controller(tmp_path):
 
     assert module is not None
     assert module.command is not None
+    assert module.command.controller is runtime.controller
     assert controller.loaded_by_command_manager is True
+    result = asyncio.run(module.command.process(None, []))
+    assert result == {"song": "ok"}
 
 
 def test_process_command_uses_runtime_for_observability_and_ui_session():

--- a/tests/test_simple_command_modules_class_only.py
+++ b/tests/test_simple_command_modules_class_only.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+SIMPLE_COMMAND_MODULES = {
+    "acc",
+    "admin",
+    "alias",
+    "enter",
+    "exit",
+    "gift",
+    "help",
+    "info",
+    "keyword",
+    "mode",
+    "next",
+    "notice",
+    "pack",
+    "pause",
+    "playlist",
+    "say",
+    "seat",
+    "skip",
+    "vol",
+}
+
+
+def test_simple_command_modules_are_class_only():
+    commands_dir = Path(__file__).resolve().parents[1] / "src" / "ushareiplay" / "commands"
+
+    for module_name in sorted(SIMPLE_COMMAND_MODULES):
+        source = (commands_dir / f"{module_name}.py").read_text()
+
+        assert "def create_command(" not in source, module_name
+        assert "command = None" not in source, module_name

--- a/tests/test_stateful_command_modules_class_only.py
+++ b/tests/test_stateful_command_modules_class_only.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+STATEFUL_COMMAND_MODULES = [
+    "album.py",
+    "end.py",
+    "fav.py",
+    "lyrics.py",
+    "mic.py",
+    "play.py",
+    "radio.py",
+    "return.py",
+    "room.py",
+    "singer.py",
+    "theme.py",
+    "timer.py",
+    "title.py",
+    "topic.py",
+]
+
+
+def test_stateful_command_modules_are_class_only():
+    commands_dir = Path(__file__).resolve().parents[1] / "src" / "ushareiplay" / "commands"
+
+    for filename in STATEFUL_COMMAND_MODULES:
+        source = (commands_dir / filename).read_text(encoding="utf-8")
+        assert "def create_command(" not in source, filename
+        assert "command = None" not in source, filename


### PR DESCRIPTION
## Summary
- Load commands directly from their `BaseCommand` subclass instead of requiring `create_command()` factories.
- Remove module-level `command = None` boilerplate from all command modules.
- Update docs and tests to reflect the class-only command contract.

## Test Plan
- [x] `uv run pytest -q tests/test_command_manager_runtime_context.py tests/test_command_manager_class_loading.py tests/test_command_manager_no_legacy_factory.py tests/test_simple_command_modules_class_only.py tests/test_stateful_command_modules_class_only.py tests/test_help_command_is_current.py tests/test_imports.py tests/test_paths.py`
- [x] `python -m py_compile src/ushareiplay/core/app_controller.py src/ushareiplay/managers/command_manager.py src/ushareiplay/commands/*.py tests/test_command_manager_runtime_context.py tests/test_command_manager_class_loading.py tests/test_command_manager_no_legacy_factory.py tests/test_simple_command_modules_class_only.py tests/test_stateful_command_modules_class_only.py`