### PR TITLE
feat: sleep mode blocks playback commands in quiet hours

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -419,6 +419,24 @@ commands:
     level: 5
     response_template: "{success}"
     error_template: "送礼失败: {error}"
+
+  - prefix: "sleep"
+    level: 4
+    response_template: "{message}"
+    error_template: "{error}"
+
+sleep:
+  enabled: true
+  start: "23:00"
+  end: "06:00"
+  blocked_commands:
+    - play
+    - next
+    - fav
+    - singer
+    - album
+    - playlist
+    - radio
 appium:
   host: "192.168.8.103"
   port: 4723

--- a/docs/superpowers/plans/2026-05-08-sleep-guardian.md
+++ b/docs/superpowers/plans/2026-05-08-sleep-guardian.md
@@ -1,0 +1,453 @@
+# Sleep Guardian（睡眠守护模式）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在配置的夜间时段内，当睡眠守护开启时，禁止用户触发“开始播放/点歌类”命令；允许 `:skip` / `:pause` 等控制类命令；系统用户（含 `Timer`）始终放行；支持 `:sleep on/off/status` 临时切换。
+
+**Architecture:** 在 `CommandManager.process_command()` 统一拦截被禁用的点歌类命令；新增 `SleepGuardianManager` 负责读取配置、时间窗判断、临时开关覆盖与提示文案；新增 `:sleep` 命令管理临时覆盖。
+
+**Tech Stack:** Python 3.x、pytest、现有 `Singleton` 单例模式、`ConfigLoader`（`config.yaml` + `config.local.yaml` 深度合并）。
+
+---
+
+## File Structure (Create/Modify Map)
+
+**Create**
+- `src/ushareiplay/managers/sleep_guardian_manager.py`：守护规则/时间窗/临时覆盖的唯一入口
+- `src/ushareiplay/commands/sleep.py`：`:sleep on/off/status` 命令实现
+- `tests/test_sleep_guardian_manager.py`：时间窗与开关优先级的单测
+- `tests/test_command_manager_sleep_guardian_block.py`：验证拦截发生在 `CommandManager.process_command()` 且对 system_users 放行
+
+**Modify**
+- `src/ushareiplay/managers/command_manager.py`：在 dispatch 前增加拦截
+- `config.yaml`：新增 `sleep_guardian:` 配置段；新增 `commands:` 中的 `sleep` 命令项
+- `README.md`（可选）：在 Command Reference / Music 部分补充 `:sleep`
+
+---
+
+### Task 1: Add `SleepGuardianManager` (core policy + time window)
+
+**Files:**
+- Create: `src/ushareiplay/managers/sleep_guardian_manager.py`
+- Test: `tests/test_sleep_guardian_manager.py`
+
+- [ ] **Step 1: Write failing tests for time-window logic**
+
+```python
+from datetime import datetime
+
+import pytest
+
+from ushareiplay.managers.sleep_guardian_manager import SleepGuardianManager
+
+
+def _dt(hhmm: str) -> datetime:
+    # Fixed date; only time matters.
+    return datetime.fromisoformat(f"2026-05-08 {hhmm}:00")
+
+
+def test_is_in_window_non_cross_day():
+    cfg = {"sleep_guardian": {"enabled": True, "start": "09:00", "end": "18:00"}}
+    g = SleepGuardianManager.instance(cfg)
+    assert g.is_in_guard_window(_dt("09:00")) is True
+    assert g.is_in_guard_window(_dt("12:00")) is True
+    assert g.is_in_guard_window(_dt("18:00")) is False  # end is exclusive
+
+
+def test_is_in_window_cross_day():
+    cfg = {"sleep_guardian": {"enabled": True, "start": "23:00", "end": "06:00"}}
+    g = SleepGuardianManager.instance(cfg)
+    assert g.is_in_guard_window(_dt("22:59")) is False
+    assert g.is_in_guard_window(_dt("23:00")) is True
+    assert g.is_in_guard_window(_dt("00:00")) is True
+    assert g.is_in_guard_window(_dt("05:59")) is True
+    assert g.is_in_guard_window(_dt("06:00")) is False
+
+
+def test_is_in_window_all_day_when_start_equals_end():
+    cfg = {"sleep_guardian": {"enabled": True, "start": "00:00", "end": "00:00"}}
+    g = SleepGuardianManager.instance(cfg)
+    assert g.is_in_guard_window(_dt("00:00")) is True
+    assert g.is_in_guard_window(_dt("12:00")) is True
+    assert g.is_in_guard_window(_dt("23:59")) is True
+```
+
+- [ ] **Step 2: Run tests to verify FAIL**
+
+Run:
+- `uv run pytest -q tests/test_sleep_guardian_manager.py -q`
+
+Expected:
+- FAIL with `ModuleNotFoundError: No module named ...sleep_guardian_manager`
+
+- [ ] **Step 3: Implement minimal manager to pass tests**
+
+```python
+# src/ushareiplay/managers/sleep_guardian_manager.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, time
+from typing import Iterable, Optional
+
+from ushareiplay.core.singleton import Singleton
+
+
+def _parse_hhmm(value: str) -> Optional[time]:
+    if not value or not isinstance(value, str):
+        return None
+    parts = value.strip().split(":")
+    if len(parts) != 2:
+        return None
+    try:
+        hh = int(parts[0])
+        mm = int(parts[1])
+    except Exception:
+        return None
+    if hh < 0 or hh > 23 or mm < 0 or mm > 59:
+        return None
+    return time(hour=hh, minute=mm)
+
+
+@dataclass(frozen=True)
+class SleepGuardianConfig:
+    enabled: bool
+    start: time
+    end: time
+    blocked_commands: tuple[str, ...]
+
+
+class SleepGuardianManager(Singleton):
+    def __init__(self, config: dict | None = None):
+        self._config_dict = config or {}
+        self._override_enabled: Optional[bool] = None  # None = no override, else on/off
+
+        sg = (self._config_dict.get("sleep_guardian") or {}) if isinstance(self._config_dict, dict) else {}
+        enabled = bool(sg.get("enabled", True))
+        start = _parse_hhmm(str(sg.get("start", "23:00")))
+        end = _parse_hhmm(str(sg.get("end", "06:00")))
+        blocked = sg.get(
+            "blocked_commands",
+            ["play", "next", "fav", "singer", "album", "playlist", "radio"],
+        )
+        if not isinstance(blocked, list):
+            blocked = ["play", "next", "fav", "singer", "album", "playlist", "radio"]
+
+        # Fallback parsing: if invalid, use safe defaults (do not block due to misconfig)
+        # Window parsing failures will be handled in is_in_guard_window.
+        self._cfg = SleepGuardianConfig(
+            enabled=enabled,
+            start=start or time(0, 0),
+            end=end or time(0, 0),
+            blocked_commands=tuple(str(x) for x in blocked),
+        )
+
+        self._start_valid = start is not None
+        self._end_valid = end is not None
+
+    @classmethod
+    def instance(cls, config: dict | None = None) -> "SleepGuardianManager":
+        # singleton supports passing config on first call; later calls ignore
+        return super().instance(config)
+
+    def set_override(self, enabled: Optional[bool]) -> None:
+        self._override_enabled = enabled
+
+    def get_effective_enabled(self) -> bool:
+        if self._override_enabled is None:
+            return self._cfg.enabled
+        return bool(self._override_enabled)
+
+    def is_in_guard_window(self, now: datetime) -> bool:
+        # If time parsing failed, be safe: do not block.
+        if not self._start_valid or not self._end_valid:
+            return False
+        start = self._cfg.start
+        end = self._cfg.end
+        t = now.time().replace(second=0, microsecond=0)
+
+        # start == end => all day
+        if start == end:
+            return True
+
+        if start < end:
+            return start <= t < end
+
+        # Cross-day: [start, 24h) U [00:00, end)
+        return t >= start or t < end
+
+    def is_blocked_command(self, prefix: str) -> bool:
+        return (prefix or "") in set(self._cfg.blocked_commands)
+```
+
+- [ ] **Step 4: Run tests to verify PASS**
+
+Run:
+- `uv run pytest -q tests/test_sleep_guardian_manager.py -q`
+
+Expected:
+- PASS
+
+- [ ] **Step 5: Add tests for override priority (write failing, then pass)**
+
+```python
+def test_override_enabled_takes_precedence():
+    cfg = {"sleep_guardian": {"enabled": True, "start": "23:00", "end": "06:00"}}
+    g = SleepGuardianManager.instance(cfg)
+    g.set_override(False)
+    assert g.get_effective_enabled() is False
+    g.set_override(True)
+    assert g.get_effective_enabled() is True
+    g.set_override(None)
+    assert g.get_effective_enabled() is True
+```
+
+Run:
+- `uv run pytest -q tests/test_sleep_guardian_manager.py -q`
+
+Expected:
+- PASS
+
+- [ ] **Step 6 (Optional): Commit**
+
+Only if you want a commit now:
+- `git add src/ushareiplay/managers/sleep_guardian_manager.py tests/test_sleep_guardian_manager.py`
+- `git commit -m "feat: add sleep guardian policy manager"`
+
+---
+
+### Task 2: Add `:sleep` command (on/off/status)
+
+**Files:**
+- Create: `src/ushareiplay/commands/sleep.py`
+- Modify: `config.yaml` (commands entry)
+- Test: `tests/test_command_manager_sleep_guardian_block.py` (status path can be unit-tested via manager; command itself verified via CommandManager integration-ish test)
+
+- [ ] **Step 1: Create `SleepCommand` skeleton**
+
+```python
+# src/ushareiplay/commands/sleep.py
+from ushareiplay.core.base_command import BaseCommand
+
+
+class SleepCommand(BaseCommand):
+    async def process(self, message_info, parameters):
+        if not parameters:
+            return {"error": "Missing parameter: on/off/status"}
+        sub = str(parameters[0]).lower()
+
+        from ushareiplay.managers.sleep_guardian_manager import SleepGuardianManager
+        guardian = SleepGuardianManager.instance(self.soul_handler.config)
+
+        if sub == "on":
+            guardian.set_override(True)
+            return {"message": "睡眠守护已开启（临时）"}
+        if sub == "off":
+            guardian.set_override(False)
+            return {"message": "睡眠守护已关闭（临时）"}
+        if sub == "status":
+            # best-effort status text; kept simple for templates
+            enabled = guardian.get_effective_enabled()
+            return {"message": f"睡眠守护状态: {'ON' if enabled else 'OFF'}"}
+
+        return {"error": "Invalid parameter: on/off/status"}
+```
+
+- [ ] **Step 2: Add `sleep` command entry to `config.yaml`**
+
+Add under top-level `commands:` list:
+
+```yaml
+  - prefix: "sleep"
+    level: 4
+    response_template: "{message}"
+    error_template: "{error}"
+```
+
+Notes:
+- `level` can be raised later (e.g. 9) without code change.
+
+- [ ] **Step 3: Run existing command loading tests**
+
+Run:
+- `uv run pytest -q tests/test_command_manager_class_loading.py -q`
+
+Expected:
+- PASS (ensures one BaseCommand subclass per module and loadability)
+
+- [ ] **Step 4 (Optional): Update README command table**
+
+Add a row:
+- `:sleep` | (level per config) | `on/off/status` | Sleep guardian toggle
+
+- [ ] **Step 5 (Optional): Commit**
+
+Only if you want a commit now:
+- `git add src/ushareiplay/commands/sleep.py config.yaml README.md`
+- `git commit -m "feat: add :sleep command to toggle sleep guardian"`
+
+---
+
+### Task 3: Enforce sleep guardian in `CommandManager.process_command()`
+
+**Files:**
+- Modify: `src/ushareiplay/managers/command_manager.py`
+- Create/Modify: `tests/test_command_manager_sleep_guardian_block.py`
+
+- [ ] **Step 1: Write failing test that blocks `play` but allows system user `Timer`**
+
+```python
+import types
+import pytest
+
+from ushareiplay.managers.command_manager import CommandManager
+
+
+class _DummyCommand:
+    def __init__(self):
+        self.called = False
+
+    async def process(self, message_info, parameters):
+        self.called = True
+        return {"song": "x", "singer": "y", "album": "z"}
+
+
+class _Msg:
+    def __init__(self, nickname: str, content: str = ":play x"):
+        self.nickname = nickname
+        self.content = content
+
+
+@pytest.mark.asyncio
+async def test_sleep_guardian_blocks_play_for_normal_user(monkeypatch):
+    cm = CommandManager.instance()
+    # Minimal runtime stub for process_command
+    cm.configure_runtime(
+        types.SimpleNamespace(
+            emit=lambda *a, **k: None,
+            ui_session=lambda *a, **k: _NullAsyncContext(),
+            controller=None,
+        )
+    )
+    # minimal handler config including system_users + sleep_guardian
+    cm._handler = types.SimpleNamespace(config={"system_users": ["Timer"], "sleep_guardian": {"enabled": True, "start": "00:00", "end": "00:00", "blocked_commands": ["play"]}})
+    cm._logger = types.SimpleNamespace(info=lambda *a, **k: None, error=lambda *a, **k: None, warning=lambda *a, **k: None)
+
+    cmd = _DummyCommand()
+    res = await cm.process_command(cmd, _Msg("Alice"), {"prefix": "play", "parameters": [], "error_template": "{error}", "response_template": "{song}"})
+    assert "睡眠守护" in res
+    assert cmd.called is False
+
+
+@pytest.mark.asyncio
+async def test_sleep_guardian_allows_timer_system_user(monkeypatch):
+    cm = CommandManager.instance()
+    cmd = _DummyCommand()
+    res = await cm.process_command(cmd, _Msg("Timer"), {"prefix": "play", "parameters": [], "error_template": "{error}", "response_template": "{song}"})
+    # should call through (template may differ, but command must run)
+    assert cmd.called is True
+
+
+class _NullAsyncContext:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+```
+
+Run:
+- `uv run pytest -q tests/test_command_manager_sleep_guardian_block.py -q`
+
+Expected:
+- FAIL (no blocking yet / singleton reuse issues will require test isolation fixes in implementation)
+
+- [ ] **Step 2: Implement guard check in `CommandManager.process_command()`**
+
+Pseudo-code to insert near the top of `process_command` (after `cmd` is known and before `await command.process(...)`):
+
+```python
+prefix = command_info.get("prefix")
+system_users = self.handler.config.get("system_users", [])
+is_system_user = message_info.nickname in system_users
+
+if not is_system_user:
+    from ushareiplay.managers.sleep_guardian_manager import SleepGuardianManager
+    guardian = SleepGuardianManager.instance(self.handler.config)
+    if guardian.get_effective_enabled() and guardian.is_blocked_command(prefix) and guardian.is_in_guard_window(datetime.now()):
+        return f"睡眠守护已开启（{start}-{end}），当前时段禁止点歌。如需临时关闭：:sleep off"
+```
+
+Implementation notes:
+- Use `datetime.now()` (local time) to match operator expectations.
+- Message should be returned as a **string response** (consistent with other early returns in `process_command`).
+
+- [ ] **Step 3: Run guard tests; fix singleton test isolation**
+
+Run:
+- `uv run pytest -q tests/test_command_manager_sleep_guardian_block.py -q`
+
+Expected:
+- PASS
+
+If singleton reuse across tests causes leakage:
+- add a `SleepGuardianManager.reset_for_tests()` method OR construct `SleepGuardianManager` without singleton (less aligned with codebase).
+- prefer adding a tiny test-only reset hook guarded by name (e.g. method exists but not used in prod).
+
+- [ ] **Step 4: Add `sleep_guardian:` section to `config.yaml`**
+
+Append near top-level (location doesn’t matter; keep near other feature configs):
+
+```yaml
+sleep_guardian:
+  enabled: true
+  start: "23:00"
+  end: "06:00"
+  blocked_commands:
+    - play
+    - next
+    - fav
+    - singer
+    - album
+    - playlist
+    - radio
+```
+
+- [ ] **Step 5: Run focused regression tests**
+
+Run:
+- `uv run pytest -q tests/test_command_manager_class_loading.py tests/test_help_command_is_current.py -q`
+
+Expected:
+- PASS
+
+- [ ] **Step 6 (Optional): Commit**
+
+Only if you want a commit now:
+- `git add src/ushareiplay/managers/command_manager.py config.yaml tests/test_command_manager_sleep_guardian_block.py`
+- `git commit -m "feat: enforce sleep guardian during command dispatch"`
+
+---
+
+## Plan Self-Review (against spec)
+
+- Spec requirement “默认开启 + 时间可配 + 跨天窗口”：Task 1 tests + config section cover
+- “除非主动关闭否则一直生效”：配置默认启用；临时覆盖只在进程内，重启回默认
+- “命令临时关闭”：Task 2 `:sleep off/on/status`
+- “B：所有开始播放命令禁用；切歌允许；pause 允许”：blocked list + explicit allow list
+- “定时器允许触发”：system_users（含 Timer）在 Task 3 放行
+- “radio 子命令一起禁用”：blocked prefix=radio covers all `:radio <keyword>`
+
+No placeholders; every task includes runnable code/commands.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-08-sleep-guardian.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+2. **Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?
+

--- a/docs/superpowers/specs/2026-05-08-sleep-guardian-design.md
+++ b/docs/superpowers/specs/2026-05-08-sleep-guardian-design.md
@@ -1,0 +1,137 @@
+---
+covers: [commands, config, sleep-guardian]
+created: 2026-05-08
+status: draft
+---
+
+## 背景与目标
+
+在指定时段内（例如 23:00-06:00，支持跨天），当“睡眠守护模式”开启时，系统**不允许点歌/开始新的播放源**，以避免夜间被用户指令打断休息或引发噪音。
+
+需求约束：
+- **默认开启**，且时间窗可配置。
+- **除非主动关闭，否则限制一直生效**（跨重启默认恢复为开启）。
+- 可通过命令**临时关闭/开启**（进程内生效；重启后回到默认配置）。
+- **切歌允许**（`:skip` 允许）。
+- `:pause` **允许**。
+
+## 非目标
+
+- 不做跨进程持久化开关（例如写 DB）。本次仅在内存中支持临时切换；重启后使用配置默认值。
+- 不做复杂的多时段规则（仅单一 start/end）。
+
+## 术语
+
+- **点歌/开始播放**：任何会“启动播放/开始新的播放源/将新歌加入队列”的命令集合。
+- **守护时段**：配置的 `start` 与 `end` 形成的时间窗；若 `start > end` 视为跨天（例如 23:00-06:00）。
+
+## 用户体验
+
+### 被拦截时的提示
+
+当用户在守护时段执行被禁止的点歌类命令时，返回统一错误提示：
+
+- 示例文案（可在实现里作为默认模板，必要时可配置）：
+  - `睡眠守护已开启（23:00-06:00），当前时段禁止点歌。如需临时关闭：:sleep off`
+
+### 模式切换命令
+
+新增命令：`:sleep`
+
+- `:sleep on`：开启睡眠守护（临时状态 = on）
+- `:sleep off`：关闭睡眠守护（临时状态 = off）
+- `:sleep status`：展示当前睡眠守护状态（默认/临时覆盖）、配置的时间窗、以及“此刻是否在守护时段”
+
+备注：
+- `:radio sleep` 已存在且含义为 QQ 音乐电台的“疗愈/睡眠频道”。本设计新增的 `:sleep` 是**独立命令前缀**，二者在命令解析层面不冲突（前者的 prefix 是 `radio`，`sleep` 仅作为参数；后者的 prefix 是 `sleep`）。
+- 但在“睡眠守护拦截”层面，若 `radio` 被列入 `blocked_commands`，则守护时段内会一并拦截 `:radio <keyword>` 的所有子命令（包括 `:radio sleep`），不会做参数级别的特殊放行。
+
+## 权限与豁免
+
+- 继续沿用现有 `soul.system_users` 逻辑：系统用户（例如机器人/定时器账号）**不受睡眠守护限制**。
+  - 现有配置中已包含 `Timer`，因此**定时器触发的命令允许执行**（即使是点歌类命令）。
+- `:sleep` 命令本身的等级要求在 `config.yaml -> commands` 中配置（建议设置为 `level: 9` 或 `level: 4`，以避免普通用户随意关闭；最终以产品/运营需求为准）。
+
+## 功能范围：哪些命令会被阻止/允许
+
+### 默认阻止（点歌/开始播放）
+
+以下命令在守护时段 + 守护开启时将被拦截（默认集合，可配置）：
+- `play`（立即点歌）
+- `next`（加到播放队列）
+- `fav`（播放收藏/筛选后播放/收藏搜索播放）
+- `singer`（歌手歌单）
+- `album`（专辑）
+- `playlist`（歌单）
+- `radio`（电台）
+
+### 明确允许
+
+- `skip`：允许（切歌）
+- `pause`：允许
+- `mode`：允许
+- `vol`：允许
+- 其他非音乐类命令：不受影响
+
+## 技术设计（推荐方案）
+
+### 拦截点
+
+在 `CommandManager.process_command()` 中，在执行 `await command.process(...)` 之前统一检查：
+
+1. `message_info.nickname` 是否为 `soul.system_users`（是则直接放行）
+2. 当前命令 `cmd` 是否在 `sleep_guardian.blocked_commands` 中
+3. 睡眠守护是否开启：
+   - 若存在临时覆盖状态（由 `:sleep on/off` 设置），优先使用覆盖状态
+   - 否则使用配置默认值 `sleep_guardian.enabled`
+4. 当前时间是否落在守护时段内（依据 `sleep_guardian.start/end`）
+
+满足 2+3+4 时，直接返回错误响应，不进入命令实现层，避免触发 QQ 音乐 UI 操作。
+
+### 状态存储
+
+新增一个轻量的守护状态组件（例如 `SleepGuardianManager` 或 `SleepGuardian`），职责：
+- 读取配置（enabled/start/end/blocked_commands）
+- 维护**进程内**临时开关覆盖（None/on/off）
+- 提供 `should_block(command_prefix, nickname, now)` 与 `format_block_message(...)`
+
+### 配置结构
+
+在 `config.yaml` 增加：
+
+```yaml
+sleep_guardian:
+  enabled: true
+  start: "23:00"
+  end: "06:00"
+  blocked_commands:
+    - play
+    - next
+    - fav
+    - singer
+    - album
+    - playlist
+    - radio
+```
+
+同时在 `config.yaml -> commands:` 列表中增加 `sleep` 命令项（`prefix: "sleep"`），并设置合适的 `level` 与模板。
+
+### 边界条件
+
+- `start == end`：视为全天守护（24h 都算在守护时段内）
+- 时间解析失败：以安全为先，默认**不阻止**点歌，但在日志里记录配置错误（避免因配置错误导致系统不可用）；实现时需清晰可观测
+
+## 测试计划（单元测试）
+
+无需连接真机/Appium，重点验证拦截逻辑：
+
+- 时间窗判断：
+  - 非跨天（例如 09:00-18:00）
+  - 跨天（23:00-06:00）
+  - `start == end` 全天
+- 允许/禁止命令集合生效（`blocked_commands`）
+- `system_users` 豁免
+- 临时覆盖优先级：
+  - 默认 enabled=true，但 `:sleep off` 后放行
+  - 默认 enabled=false，但 `:sleep on` 后阻止
+

--- a/src/ushareiplay/commands/sleep.py
+++ b/src/ushareiplay/commands/sleep.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from ushareiplay.core.base_command import BaseCommand
+from ushareiplay.managers.sleep_manager import SleepManager
+
+
+class SleepCommand(BaseCommand):
+    async def process(self, message_info, parameters):
+        keyword = (parameters[0].strip().lower() if parameters else "status")
+
+        # Prefer the controller's root config (contains `sleep`). Fall back to handler config.
+        config = getattr(self.controller, "config", None)
+        if not isinstance(config, dict):
+            config = getattr(self.soul_handler, "config", {}) or {}
+
+        manager = SleepManager.instance(config)
+
+        if keyword == "on":
+            manager.set_override(True)
+            return {"message": "Sleep: ON (override)"}
+
+        if keyword == "off":
+            manager.set_override(False)
+            return {"message": "Sleep: OFF (override)"}
+
+        if keyword != "status":
+            return {"error": "Usage: :sleep on|off|status"}
+
+        default_enabled = manager.get_default_enabled()
+        override = manager.get_override()
+        effective_enabled = manager.effective_enabled
+
+        override_text = "None"
+        if override is True:
+            override_text = "on"
+        elif override is False:
+            override_text = "off"
+
+        effective = "ON" if effective_enabled else "OFF"
+        in_window = "YES" if manager.is_in_configured_window() else "NO"
+        window_text = manager.get_window_display()
+
+        return {
+            "message": (
+                f"Sleep: {effective} | window: {window_text} | in_window_now: {in_window} | "
+                f"default_enabled: {default_enabled} | override: {override_text} | effective_enabled: {effective_enabled}"
+            )
+        }

--- a/src/ushareiplay/managers/command_manager.py
+++ b/src/ushareiplay/managers/command_manager.py
@@ -218,11 +218,9 @@ class CommandManager(Singleton):
                         cfg = self.handler.config
                     sg = SleepManager.instance(cfg)
                     if sg.is_blocked_command(prefix):
-                        window_text = sg.get_window_display()
                         result = {
                             "error": (
-                                f"睡眠守护已开启（{window_text}），当前时段禁止使用 :{prefix}。"
-                                f"如需关闭请输入 :sleep off"
+                                "休息中（11pm-6am）"
                             )
                         }
                         format_kwargs = {"user": message_info.nickname, **result}

--- a/src/ushareiplay/managers/command_manager.py
+++ b/src/ushareiplay/managers/command_manager.py
@@ -205,6 +205,33 @@ class CommandManager(Singleton):
                         format_kwargs['party_id'] = parameters[0]
                     res = command_info['error_template'].format(**format_kwargs)
                     return res
+
+                # Sleep mode: non-system users may be blocked in sleep window
+                try:
+                    from ushareiplay.managers.sleep_manager import SleepManager
+
+                    prefix = command_info.get("prefix") or ""
+                    # Prefer root config (controller.config) so `sleep` can live at top-level.
+                    controller = self._get_command_controller()
+                    cfg = getattr(controller, "config", None) if controller is not None else None
+                    if not isinstance(cfg, dict):
+                        cfg = self.handler.config
+                    sg = SleepManager.instance(cfg)
+                    if sg.is_blocked_command(prefix):
+                        window_text = sg.get_window_display()
+                        result = {
+                            "error": (
+                                f"睡眠守护已开启（{window_text}），当前时段禁止使用 :{prefix}。"
+                                f"如需关闭请输入 :sleep off"
+                            )
+                        }
+                        format_kwargs = {"user": message_info.nickname, **result}
+                        if parameters:
+                            format_kwargs["party_id"] = parameters[0]
+                        return command_info["error_template"].format(**format_kwargs)
+                except Exception:
+                    # Guard should never break command execution.
+                    pass
             
             # UI 互斥：命令执行期间禁止 EventManager 的"未知页面自动 back"打断弹窗/子页面流程
             result = {'error': 'unknown'}

--- a/src/ushareiplay/managers/sleep_manager.py
+++ b/src/ushareiplay/managers/sleep_manager.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Iterable
+
+from ushareiplay.core.singleton import Singleton
+
+
+def _parse_hhmm(value: object) -> dt.time | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parts = value.strip().split(":")
+        if len(parts) != 2:
+            return None
+        hour = int(parts[0])
+        minute = int(parts[1])
+        return dt.time(hour=hour, minute=minute)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_enabled(value: object, default: bool) -> bool:
+    """
+    Parse a config value into a boolean without Python's `bool(x)` pitfalls.
+
+    Supported:
+    - bool: returned as-is
+    - int: 0 -> False, non-zero -> True
+    - str: common true/false spellings (case-insensitive, surrounding whitespace ignored)
+    """
+    if value is None:
+        return default
+
+    # bool is a subclass of int; check it first.
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, int):
+        return value != 0
+
+    if isinstance(value, str):
+        s = value.strip().lower()
+        if s in {"true", "1", "yes", "y", "on"}:
+            return True
+        if s in {"false", "0", "no", "n", "off"}:
+            return False
+        return default
+
+    return default
+
+
+@dataclass(frozen=True)
+class _Window:
+    start: dt.time
+    end: dt.time
+
+
+class SleepManager(Singleton):
+    """
+    SleepManager (睡眠模式)
+
+    - Reads config from a merged dict (config.yaml + config.local.yaml result).
+    - Provides a guard window check and command blocking decision.
+    """
+
+    DEFAULT_ENABLED = True
+    DEFAULT_WINDOW_START = dt.time(23, 0)
+    DEFAULT_WINDOW_END = dt.time(6, 0)
+    DEFAULT_BLOCKED_COMMANDS = (
+        "play",
+        "next",
+        "fav",
+        "singer",
+        "album",
+        "playlist",
+        "radio",
+    )
+
+    def __init__(self, config: dict | None = None):
+        self._config = config or {}
+
+        sleep_cfg = self._config.get("sleep")
+        if not isinstance(sleep_cfg, dict):
+            sleep_cfg = {}
+
+        self._enabled = _parse_enabled(sleep_cfg.get("enabled"), self.DEFAULT_ENABLED)
+        self._override_enabled: bool | None = None
+
+        # Spec prefers sleep.start/end. Keep sleep.window.start/end as a compatible fallback.
+        window = sleep_cfg.get("window") or {}
+        if not isinstance(window, dict):
+            window = {}
+
+        start_raw = sleep_cfg.get("start")
+        if start_raw is None:
+            start_raw = window.get("start")
+        if start_raw is None:
+            start_raw = self.DEFAULT_WINDOW_START.strftime("%H:%M")
+
+        end_raw = sleep_cfg.get("end")
+        if end_raw is None:
+            end_raw = window.get("end")
+        if end_raw is None:
+            end_raw = self.DEFAULT_WINDOW_END.strftime("%H:%M")
+
+        self._window_start_str = (
+            start_raw if isinstance(start_raw, str) else self.DEFAULT_WINDOW_START.strftime("%H:%M")
+        )
+        self._window_end_str = end_raw if isinstance(end_raw, str) else self.DEFAULT_WINDOW_END.strftime("%H:%M")
+
+        start = _parse_hhmm(start_raw)
+        end = _parse_hhmm(end_raw)
+        self._window: _Window | None = _Window(start, end) if start and end else None
+
+        blocked = sleep_cfg.get("blocked_commands", self.DEFAULT_BLOCKED_COMMANDS)
+        self._blocked_commands = self._normalize_commands(blocked)
+
+    @staticmethod
+    def _normalize_commands(value: object) -> set[str]:
+        if value is None:
+            return set()
+        if isinstance(value, (list, tuple, set)):
+            items: Iterable[object] = value
+        elif isinstance(value, str):
+            # Allow comma-separated strings defensively
+            items = [s.strip() for s in value.split(",")]
+        else:
+            return set()
+
+        out: set[str] = set()
+        for item in items:
+            if isinstance(item, str):
+                s = item.strip().lower()
+                if s:
+                    out.add(s)
+        return out
+
+    @classmethod
+    def reset_for_tests(cls) -> None:
+        """
+        Official singleton reset hook for tests.
+
+        Do not use in production code.
+        """
+        if hasattr(cls, "_instance"):
+            delattr(cls, "_instance")
+
+    def set_override(self, enabled: bool | None) -> None:
+        if enabled is None:
+            self._override_enabled = None
+        else:
+            self._override_enabled = bool(enabled)
+
+    def get_default_enabled(self) -> bool:
+        return self._enabled
+
+    def get_override(self) -> bool | None:
+        return self._override_enabled
+
+    @property
+    def effective_enabled(self) -> bool:
+        if self._override_enabled is not None:
+            return self._override_enabled
+        return self._enabled
+
+    def _resolve_time(self, now: dt.time | dt.datetime | None) -> dt.time | None:
+        if now is None:
+            return dt.datetime.now().time()
+        if isinstance(now, dt.datetime):
+            return now.time()
+        if isinstance(now, dt.time):
+            return now
+        return None
+
+    def is_in_configured_window(self, now: dt.time | dt.datetime | None = None) -> bool:
+        """
+        Check whether `now` is inside the configured sleep window only.
+
+        This method MUST NOT be affected by enabled/override; it answers purely
+        "is the time within the configured window?"
+        """
+        if self._window is None:
+            # Parse failure: safe default is "do not block"
+            return False
+
+        t = self._resolve_time(now)
+        if t is None:
+            return False
+
+        start = self._window.start
+        end = self._window.end
+
+        # start == end means "all day"
+        if start == end:
+            return True
+
+        # Non-cross-midnight window: start <= t < end
+        if start < end:
+            return start <= t < end
+
+        # Cross-midnight window: [start, 24:00) U [00:00, end)
+        return (t >= start) or (t < end)
+
+    def is_in_sleep_window(self, now: dt.time | dt.datetime | None = None) -> bool:
+        if not self.effective_enabled:
+            return False
+        return self.is_in_configured_window(now)
+
+    # Backwards-compatible alias: older code/tests used "guard window".
+    def is_in_guard_window(self, now: dt.time | dt.datetime | None = None) -> bool:
+        return self.is_in_sleep_window(now)
+
+    def get_window_start_str(self) -> str:
+        return self._window_start_str
+
+    def get_window_end_str(self) -> str:
+        return self._window_end_str
+
+    def get_window_display(self) -> str:
+        return f"{self._window_start_str}-{self._window_end_str}"
+
+    def is_blocked_command(self, command: str, now: dt.time | dt.datetime | None = None) -> bool:
+        if not isinstance(command, str):
+            return False
+        cmd = command.strip().lower()
+        if not cmd:
+            return False
+        if cmd not in self._blocked_commands:
+            return False
+        return self.is_in_sleep_window(now)
+

--- a/tests/test_command_manager_sleep_block.py
+++ b/tests/test_command_manager_sleep_block.py
@@ -1,0 +1,231 @@
+import datetime as dt
+from contextlib import asynccontextmanager
+
+import pytest
+
+
+class RuntimeStub:
+    def emit(self, *args, **kwargs):
+        return None
+
+    @asynccontextmanager
+    async def ui_session(self, *_args, **_kwargs):
+        yield
+
+
+class HandlerStub:
+    def __init__(self, config: dict):
+        self.config = config
+
+        class _Logger:
+            def info(self, *_a, **_k):
+                return None
+
+            def error(self, *_a, **_k):
+                return None
+
+        self.logger = _Logger()
+
+
+class MessageInfoStub:
+    def __init__(self, nickname: str, content: str = ":play"):
+        self.nickname = nickname
+        self.content = content
+
+
+class DummyCommand:
+    def __init__(self):
+        self.called = False
+
+    async def process(self, *_args, **_kwargs):
+        self.called = True
+        return {"message": "OK"}
+
+
+@pytest.fixture(autouse=True)
+def _reset_sleep_singleton():
+    from ushareiplay.managers.sleep_manager import SleepManager
+
+    SleepManager.reset_for_tests()
+    yield
+    SleepManager.reset_for_tests()
+
+
+@pytest.fixture
+def _patch_user_dao(monkeypatch):
+    from ushareiplay.dal import user_dao as user_dao_module
+
+    class _User:
+        level = 1
+
+    async def _get_or_create(_nickname: str):
+        return _User()
+
+    monkeypatch.setattr(user_dao_module.UserDAO, "get_or_create", staticmethod(_get_or_create))
+
+
+def _make_command_manager(config: dict):
+    from ushareiplay.managers.command_manager import CommandManager
+
+    cm = CommandManager.instance()
+    cm._handler = HandlerStub(config)
+    cm.configure_runtime(RuntimeStub())
+    return cm
+
+
+@pytest.mark.asyncio
+async def test_normal_user_all_day_window_blocked_play_is_intercepted(_patch_user_dao):
+    cm = _make_command_manager(
+        {
+            "system_users": ["Timer"],
+            "sleep": {
+                "enabled": True,
+                "start": "00:00",
+                "end": "00:00",  # all day
+                "blocked_commands": ["play"],
+            },
+        }
+    )
+    cmd = DummyCommand()
+    msg = MessageInfoStub("alice", ":play")
+    command_info = {
+        "prefix": "play",
+        "parameters": [],
+        "level": 1,
+        "error_template": "{error}",
+        "response_template": "{message}",
+    }
+
+    res = await cm.process_command(cmd, msg, command_info)
+
+    assert cmd.called is False
+    assert "睡眠守护已开启" in (res or "")
+    assert "00:00-00:00" in res
+    assert ":sleep off" in res
+
+
+@pytest.mark.asyncio
+async def test_timer_user_is_allowed_even_when_blocked(_patch_user_dao):
+    cm = _make_command_manager(
+        {
+            "system_users": ["Timer"],
+            "sleep": {
+                "enabled": True,
+                "start": "00:00",
+                "end": "00:00",  # all day
+                "blocked_commands": ["play"],
+            },
+        }
+    )
+    cmd = DummyCommand()
+    msg = MessageInfoStub("Timer", ":play")
+    command_info = {
+        "prefix": "play",
+        "parameters": [],
+        "level": 1,
+        "error_template": "{error}",
+        "response_template": "{message}",
+    }
+
+    res = await cm.process_command(cmd, msg, command_info)
+
+    assert cmd.called is True
+    assert "OK @Timer" == res
+
+
+@pytest.mark.asyncio
+async def test_normal_user_prefix_not_blocked_is_allowed(_patch_user_dao):
+    cm = _make_command_manager(
+        {
+            "system_users": ["Timer"],
+            "sleep": {
+                "enabled": True,
+                "start": "00:00",
+                "end": "00:00",  # all day
+                "blocked_commands": ["play"],
+            },
+        }
+    )
+    cmd = DummyCommand()
+    msg = MessageInfoStub("alice", ":pause")
+    command_info = {
+        "prefix": "pause",
+        "parameters": [],
+        "level": 1,
+        "error_template": "{error}",
+        "response_template": "{message}",
+    }
+
+    res = await cm.process_command(cmd, msg, command_info)
+
+    assert cmd.called is True
+    assert "OK @alice" == res
+
+
+@pytest.mark.asyncio
+async def test_enabled_false_does_not_intercept(_patch_user_dao):
+    cm = _make_command_manager(
+        {
+            "system_users": ["Timer"],
+            "sleep": {
+                "enabled": False,
+                "start": "00:00",
+                "end": "00:00",  # all day, but disabled
+                "blocked_commands": ["play"],
+            },
+        }
+    )
+    cmd = DummyCommand()
+    msg = MessageInfoStub("alice", ":play")
+    command_info = {
+        "prefix": "play",
+        "parameters": [],
+        "level": 1,
+        "error_template": "{error}",
+        "response_template": "{message}",
+    }
+
+    res = await cm.process_command(cmd, msg, command_info)
+
+    assert cmd.called is True
+    assert "OK @alice" == res
+
+
+@pytest.mark.asyncio
+async def test_outside_window_does_not_intercept(_patch_user_dao, monkeypatch):
+    # Window 23:00-06:00; freeze "now" at 12:00 so it is outside window.
+    from ushareiplay.managers import sleep_manager as sg_module
+
+    class _FixedDatetime(dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 5, 8, 12, 0, 0, tzinfo=tz)
+
+    monkeypatch.setattr(sg_module.dt, "datetime", _FixedDatetime)
+
+    cm = _make_command_manager(
+        {
+            "system_users": ["Timer"],
+            "sleep": {
+                "enabled": True,
+                "start": "23:00",
+                "end": "06:00",
+                "blocked_commands": ["play"],
+            },
+        }
+    )
+    cmd = DummyCommand()
+    msg = MessageInfoStub("alice", ":play")
+    command_info = {
+        "prefix": "play",
+        "parameters": [],
+        "level": 1,
+        "error_template": "{error}",
+        "response_template": "{message}",
+    }
+
+    res = await cm.process_command(cmd, msg, command_info)
+
+    assert cmd.called is True
+    assert "OK @alice" == res
+

--- a/tests/test_command_manager_sleep_block.py
+++ b/tests/test_command_manager_sleep_block.py
@@ -99,9 +99,7 @@ async def test_normal_user_all_day_window_blocked_play_is_intercepted(_patch_use
     res = await cm.process_command(cmd, msg, command_info)
 
     assert cmd.called is False
-    assert "睡眠守护已开启" in (res or "")
-    assert "00:00-00:00" in res
-    assert ":sleep off" in res
+    assert "休息中（11pm-6am）" in (res or "")
 
 
 @pytest.mark.asyncio

--- a/tests/test_sleep_manager.py
+++ b/tests/test_sleep_manager.py
@@ -1,0 +1,213 @@
+import datetime as dt
+
+
+def _fresh_manager(config: dict):
+    from ushareiplay.managers.sleep_manager import SleepManager
+
+    # Singleton test isolation (official hook)
+    SleepManager.reset_for_tests()
+    return SleepManager.instance(config)
+
+
+def test_non_cross_midnight_window_start_inclusive_end_exclusive():
+    mgr = _fresh_manager(
+        {
+            "sleep": {
+                "enabled": True,
+                "start": "09:00",
+                "end": "18:00",
+            }
+        }
+    )
+
+    assert mgr.is_in_guard_window(dt.time(9, 0)) is True
+    assert mgr.is_in_guard_window(dt.time(17, 59)) is True
+    assert mgr.is_in_guard_window(dt.time(18, 0)) is False
+    assert mgr.is_in_guard_window(dt.time(8, 59)) is False
+
+    assert mgr.is_in_configured_window(dt.time(9, 0)) is True
+    assert mgr.is_in_configured_window(dt.time(18, 0)) is False
+
+
+def test_cross_midnight_window():
+    mgr = _fresh_manager(
+        {
+            "sleep": {
+                "enabled": True,
+                "start": "23:00",
+                "end": "06:00",
+            }
+        }
+    )
+
+    assert mgr.is_in_guard_window(dt.time(22, 59)) is False
+    assert mgr.is_in_guard_window(dt.time(23, 0)) is True
+    assert mgr.is_in_guard_window(dt.time(23, 59)) is True
+    assert mgr.is_in_guard_window(dt.time(0, 0)) is True
+    assert mgr.is_in_guard_window(dt.time(5, 59)) is True
+    assert mgr.is_in_guard_window(dt.time(6, 0)) is False
+
+    assert mgr.is_in_configured_window(dt.time(23, 0)) is True
+    assert mgr.is_in_configured_window(dt.time(6, 0)) is False
+
+
+def test_start_equals_end_means_all_day_guard():
+    mgr = _fresh_manager(
+        {
+            "sleep": {
+                "enabled": True,
+                "start": "00:00",
+                "end": "00:00",
+            }
+        }
+    )
+
+    assert mgr.is_in_guard_window(dt.time(0, 0)) is True
+    assert mgr.is_in_guard_window(dt.time(12, 0)) is True
+    assert mgr.is_in_guard_window(dt.time(23, 59)) is True
+
+    assert mgr.is_in_configured_window(dt.time(0, 0)) is True
+    assert mgr.is_in_configured_window(dt.time(12, 0)) is True
+
+
+def test_override_priority():
+    mgr = _fresh_manager(
+        {
+            "sleep": {
+                "enabled": True,
+                "start": "09:00",
+                "end": "18:00",
+            }
+        }
+    )
+
+    # default: enabled from config
+    assert mgr.effective_enabled is True
+
+    mgr.set_override(False)
+    assert mgr.effective_enabled is False
+
+    mgr.set_override(True)
+    assert mgr.effective_enabled is True
+
+    mgr.set_override(None)
+    assert mgr.effective_enabled is True
+
+    assert mgr.get_default_enabled() is True
+    assert mgr.get_override() is None
+
+
+def test_enabled_parsing_accepts_bool_int_and_str_without_bool_pitfalls():
+    mgr_false_str = _fresh_manager(
+        {
+            "sleep": {
+                "enabled": "false",
+                "start": "00:00",
+                "end": "00:00",
+            }
+        }
+    )
+    assert mgr_false_str.effective_enabled is False
+
+    mgr_false_int = _fresh_manager(
+        {
+            "sleep": {
+                "enabled": 0,
+                "start": "00:00",
+                "end": "00:00",
+            }
+        }
+    )
+    assert mgr_false_int.effective_enabled is False
+
+    mgr_true_str = _fresh_manager(
+        {
+            "sleep": {
+                "enabled": "TRUE",
+                "start": "00:00",
+                "end": "00:00",
+            }
+        }
+    )
+    assert mgr_true_str.effective_enabled is True
+
+
+def test_enabled_false_can_be_overridden_true():
+    mgr = _fresh_manager(
+        {
+            "sleep": {
+                "enabled": False,
+                "start": "00:00",
+                "end": "00:00",
+            }
+        }
+    )
+
+    assert mgr.effective_enabled is False
+    mgr.set_override(True)
+    assert mgr.effective_enabled is True
+
+    # Window checks must be purely time-based (independent of enabled/override)
+    mgr.set_override(False)
+    assert mgr.is_in_configured_window(dt.time(12, 0)) is True
+    assert mgr.is_in_guard_window(dt.time(12, 0)) is False
+
+
+def test_parse_failure_defaults_to_not_blocking():
+    mgr1 = _fresh_manager(
+        {
+            "sleep": {
+                "enabled": True,
+                "start": "xx",
+                "end": "06:00",
+            }
+        }
+    )
+    assert mgr1.is_in_guard_window(dt.time(0, 0)) is False
+    assert mgr1.is_in_configured_window(dt.time(0, 0)) is False
+
+    mgr2 = _fresh_manager(
+        {
+            "sleep": {
+                "enabled": True,
+                "start": "23:00",
+                "end": "99:99",
+            }
+        }
+    )
+    assert mgr2.is_in_guard_window(dt.time(23, 0)) is False
+    assert mgr2.is_in_configured_window(dt.time(23, 0)) is False
+
+
+def test_window_key_is_supported_as_fallback():
+    mgr = _fresh_manager(
+        {
+            "sleep": {
+                "enabled": True,
+                "window": {"start": "09:00", "end": "18:00"},
+            }
+        }
+    )
+
+    assert mgr.is_in_guard_window(dt.time(9, 0)) is True
+    assert mgr.is_in_guard_window(dt.time(18, 0)) is False
+    assert mgr.is_in_configured_window(dt.time(9, 0)) is True
+    assert mgr.is_in_configured_window(dt.time(18, 0)) is False
+
+
+def test_default_blocked_commands_contains_required_minimum_set():
+    mgr = _fresh_manager(
+        {
+            "sleep": {
+                "enabled": True,
+                # all-day guard window so is_blocked_command reflects membership
+                "start": "00:00",
+                "end": "00:00",
+            }
+        }
+    )
+
+    required = ("play", "next", "fav", "singer", "album", "playlist", "radio")
+    for cmd in required:
+        assert mgr.is_blocked_command(cmd, dt.time(12, 0)) is True
+


### PR DESCRIPTION
## Summary
- Add configurable `sleep` mode (time window + blocked command prefixes) to prevent users from starting playback during quiet hours.
- Add `:sleep on/off/status` to temporarily override sleep mode.
- Enforce blocking in `CommandManager` before dispatch; system users (e.g. `Timer`) bypass.

## Test Plan
- [x] `uv run pytest -q`

Made with [Cursor](https://cursor.com)