### PR TITLE
feat: 专注人数变动可配置 :focus 联动命令

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -411,6 +411,10 @@ commands:
     level: 1
     response_template: "{message}"
     error_template: "离开命令操作失败: {error}"
+  - prefix: "focus"
+    level: 1
+    response_template: "{message}"
+    error_template: "专注人数命令操作失败: {error}"
   - prefix: "say"
     level: 1
     response_template: "{message}"

--- a/src/ushareiplay/commands/focus.py
+++ b/src/ushareiplay/commands/focus.py
@@ -1,0 +1,101 @@
+import shlex
+import traceback
+
+from ushareiplay.core.base_command import BaseCommand
+from ushareiplay.dal.focus_event_dao import FocusEventDao
+
+
+class FocusCommand(BaseCommand):
+    def __init__(self, controller):
+        super().__init__(controller)
+        self.handler = self.soul_handler
+
+    async def process(self, message_info, parameters):
+        try:
+            try:
+                original_content = message_info.content
+                parts = original_content.split(None, 1)
+                if len(parts) < 2:
+                    return {"error": "缺少参数。使用: :focus [add|del|list|clear]"}
+
+                params = shlex.split(parts[1])
+            except ValueError:
+                return {"error": "参数格式错误，带空格的参数请使用引号包裹"}
+
+            if not params:
+                return {"error": "缺少参数。使用: :focus [add|del|list|clear]"}
+
+            operation = params[0]
+            username = message_info.nickname
+
+            if operation == "add":
+                if len(params) < 2:
+                    return {"error": '缺少命令内容。使用: :focus add "命令内容"'}
+
+                command = params[1]
+                if not command.startswith((":", "：")):
+                    return {"error": '命令必须以冒号(:/：)开头，例如 ":play 歌曲名"'}
+
+                await FocusEventDao.create(username, command)
+                return {"message": f"已添加专注人数联动命令: {command}"}
+
+            if operation == "del":
+                if len(params) < 2:
+                    return {"error": "缺少命令ID。使用: :focus del <id>"}
+                try:
+                    command_id = int(params[1])
+                except ValueError:
+                    return {"error": "命令ID必须是数字"}
+
+                deleted = await FocusEventDao.delete_by_id(command_id)
+                if deleted:
+                    return {"message": f"已删除命令 ID: {command_id}"}
+                return {"error": f"未找到命令 ID: {command_id}"}
+
+            if operation == "list":
+                commands = await FocusEventDao.get_by_username(username)
+                if not commands:
+                    return {"message": "您还没有设置任何专注人数联动命令"}
+
+                lines = ["您的专注人数联动命令列表:"]
+                for cmd in commands:
+                    lines.append(f"  [{cmd.id}] {cmd.command}")
+                return {"message": "\n".join(lines)}
+
+            if operation == "clear":
+                count = await FocusEventDao.delete_all_by_username(username)
+                if count > 0:
+                    return {"message": f"已清除 {count} 个专注人数联动命令"}
+                return {"message": "您没有任何专注人数联动命令需要清除"}
+
+            return {"error": f"未知操作: {operation}。使用: :focus [add|del|list|clear]"}
+
+        except Exception:
+            self.handler.log_error(f"Error processing focus command: {traceback.format_exc()}")
+            return {"error": "处理专注人数命令时出错"}
+
+    async def focus_count_change(self, before: int | None, after: int):
+        """专注人数变化时执行：谁 :focus add 的配置，就用谁的 nickname 入队执行。"""
+        try:
+            from ushareiplay.core.message_queue import MessageQueue
+            from ushareiplay.models.message_info import MessageInfo
+
+            commands = await FocusEventDao.get_all_ordered()
+            if not commands:
+                return
+
+            self.handler.logger.info(
+                f"Focus count {before} -> {after}, queuing {len(commands)} focus command(s) "
+                f"across {len({c.user_id for c in commands})} user(s)"
+            )
+
+            message_queue = MessageQueue.instance()
+            for cmd in commands:
+                username = cmd.user.username
+                message_info = MessageInfo(content=cmd.command, nickname=username)
+                await message_queue.put_message(message_info)
+                self.handler.logger.info(
+                    f"Queued focus event command [{cmd.id}] for {username}: {cmd.command}"
+                )
+        except Exception:
+            self.handler.log_error(f"Error in focus_count_change: {traceback.format_exc()}")

--- a/src/ushareiplay/core/db_manager.py
+++ b/src/ushareiplay/core/db_manager.py
@@ -28,6 +28,25 @@ class DatabaseManager:
         await self._ensure_user_canonical_column()
         await self._ensure_keyword_mode_column()
         await self._ensure_keyword_allowed_users_column()
+        await self._ensure_focus_events_created_at()
+
+    async def _ensure_focus_events_created_at(self) -> None:
+        """
+        既有 focus_events 表若 created_at 为 NULL（早期 null=True 模型），回填为当前时间；
+        新插入由 Tortoise auto_now_add 写入。
+        """
+        conn = connections.get("default")
+        try:
+            tables = await conn.execute_query_dict(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='focus_events'"
+            )
+            if not tables:
+                return
+        except Exception:
+            return
+        await conn.execute_script(
+            "UPDATE focus_events SET created_at = datetime('now') WHERE created_at IS NULL;"
+        )
 
     async def _ensure_user_canonical_column(self) -> None:
         """

--- a/src/ushareiplay/dal/focus_event_dao.py
+++ b/src/ushareiplay/dal/focus_event_dao.py
@@ -1,0 +1,38 @@
+from typing import List, Optional
+
+from ushareiplay.dal.user_dao import UserDAO
+from ushareiplay.models.focus_event import FocusEvent
+
+
+class FocusEventDao:
+    @staticmethod
+    async def create(username: str, command: str) -> FocusEvent:
+        user = await UserDAO.get_or_create(username=username)
+        return await FocusEvent.create(user=user, command=command)
+
+    @staticmethod
+    async def get_by_username(username: str) -> List[FocusEvent]:
+        effective_user = await UserDAO.get_or_create(username=username)
+        return await FocusEvent.filter(user__id=effective_user.id).order_by("id").prefetch_related("user")
+
+    @staticmethod
+    async def get_all_ordered() -> List[FocusEvent]:
+        """全部专注人数联动命令（按 id），用于人数变化时按配置用户分别入队。"""
+        return await FocusEvent.all().order_by("id").prefetch_related("user")
+
+    @staticmethod
+    async def get_by_id(command_id: int) -> Optional[FocusEvent]:
+        return await FocusEvent.get_or_none(id=command_id).prefetch_related("user")
+
+    @staticmethod
+    async def delete_by_id(command_id: int) -> bool:
+        command = await FocusEvent.get_or_none(id=command_id)
+        if command:
+            await command.delete()
+            return True
+        return False
+
+    @staticmethod
+    async def delete_all_by_username(username: str) -> int:
+        effective_user = await UserDAO.get_or_create(username=username)
+        return await FocusEvent.filter(user__id=effective_user.id).delete()

--- a/src/ushareiplay/events/focus_count.py
+++ b/src/ushareiplay/events/focus_count.py
@@ -1,7 +1,8 @@
 """
-专注数事件 - 监控专注人数变化
+专注人数事件 - 监控 tvStudyRoomDesc（配置 key: focus_count）文案变化。
 
-当检测到专注数变化时，自动为群主找座位。
+人数变化时更新 InfoManager.focus_count，并通知 CommandManager 以执行
+数据库 focus_events 中的联动命令（:focus add 者各自一条记录，按配置用户入队）。
 """
 
 import re
@@ -10,48 +11,43 @@ from ushareiplay.core.base_event import BaseEvent
 
 
 class FocusCountEvent(BaseEvent):
-    """专注数事件处理器"""
+    """专注人数事件处理器"""
 
-    # 类变量，维护上一次的专注数
     previous_focus_count = None
 
     async def handle(self, key: str, element_wrapper):
         """
-        处理专注数事件
-        
-        检查专注数是否变化，如果变化则调用 find_owner_seat()
-        
-        Args:
-            key: 触发事件的元素 key，这里是 'focus_count'
-            element_wrapper: ElementWrapper 实例，包装了专注数元素
-            
+        解析专注人数；变化时更新 InfoManager、notify_focus_count_change。
+
         Returns:
-            bool: 默认返回 False，不中断后续处理
+            False：不中断同轮其它事件处理。
         """
         try:
-            # 获取元素文本
             current_focus_count_text = element_wrapper.text
             if not current_focus_count_text:
                 return False
 
-            # 使用正则表达式提取专注数
-            match = re.search(r'(\d+)人专注中', current_focus_count_text)
+            match = re.search(r"(\d+)人专注中", current_focus_count_text)
             if not match:
                 return False
 
             current_focus_count = int(match.group(1))
 
-            # 如果专注数没有变化，直接返回
             if self.previous_focus_count == current_focus_count:
                 return False
 
-            # 专注数变化，更新
+            before = self.previous_focus_count
             self.previous_focus_count = current_focus_count
 
-            # 自动找陪伴功能已关闭，只能通过执行命令(如: :seat)主动触发
-            self.logger.debug(f"Focus count changed to: {current_focus_count}, automatic accompaniment is disabled")
+            from ushareiplay.managers.info_manager import InfoManager
+            from ushareiplay.managers.command_manager import CommandManager
 
-            return True
+            info_manager = InfoManager.instance()
+            info_manager.focus_count = current_focus_count
+
+            await CommandManager.instance().notify_focus_count_change(before, current_focus_count)
+
+            return False
 
         except Exception as e:
             self.logger.error(f"Error processing focus count event: {str(e)}")

--- a/src/ushareiplay/managers/command_manager.py
+++ b/src/ushareiplay/managers/command_manager.py
@@ -435,3 +435,18 @@ class CommandManager(Singleton):
                     await module.command.user_return(username)
             except Exception:
                 self.logger.error(f"Error in command user_return: {traceback.format_exc()}")
+
+    async def notify_focus_count_change(self, before: int | None, after: int):
+        """
+        Notify all commands when 专注人数 (focus_count / tvStudyRoomDesc) changes.
+
+        Args:
+            before: Previous parsed count, or None on first observation
+            after: New parsed count
+        """
+        for module in self.get_command_modules().values():
+            try:
+                if hasattr(module.command, "focus_count_change"):
+                    await module.command.focus_count_change(before, after)
+            except Exception:
+                self.logger.error(f"Error in command focus_count_change: {traceback.format_exc()}")

--- a/src/ushareiplay/managers/info_manager.py
+++ b/src/ushareiplay/managers/info_manager.py
@@ -19,6 +19,7 @@ class InfoManager(Singleton):
         self._party_manager = None
         self._online_users: Set[str] = set()
         self._user_count: Optional[int] = None  # 在线人数（上次记录的值）
+        self._focus_count: Optional[int] = None  # 专注人数（tvStudyRoomDesc 解析值）
         self._room_id: Optional[str] = None  # 房间ID
         self._player_name: str = "Joyer"  # 默认播放器名称
         self._current_playlist_name: str = None  # 当前歌单名称（完整原始名称）
@@ -182,6 +183,17 @@ class InfoManager(Singleton):
             self.logger.info(f"User count updated: {self._user_count} -> {value}")
         self._user_count = value
 
+    @property
+    def focus_count(self) -> Optional[int]:
+        """专注人数（与 config elements 的 key 同名；此处为缓存整型）。"""
+        return self._focus_count
+
+    @focus_count.setter
+    def focus_count(self, value: int):
+        if self._focus_count != value:
+            self.logger.info(f"Focus count updated: {self._focus_count} -> {value}")
+        self._focus_count = value
+
     async def set_user_count(self, value: int):
         """异步设置在线人数：人数变化时同步刷新在线用户列表 + 用户等级（不使用 create_task）。"""
         if self._user_count == value:
@@ -217,6 +229,7 @@ class InfoManager(Singleton):
         """清空在线用户列表"""
         self._online_users.clear()
         self._user_count = None
+        self._focus_count = None
         self._room_id = None
         self.logger.info("Cleared online users list")
 

--- a/src/ushareiplay/models/__init__.py
+++ b/src/ushareiplay/models/__init__.py
@@ -5,6 +5,7 @@ from ushareiplay.models.keyword import Keyword
 from ushareiplay.models.enter_event import EnterEvent
 from ushareiplay.models.return_event import ReturnEvent
 from ushareiplay.models.exit_event import ExitEvent
+from ushareiplay.models.focus_event import FocusEvent
 from ushareiplay.models.timer import Timer
 
-__all__ = ['User', 'SeatReservation', 'MessageInfo', 'Keyword', 'EnterEvent', 'ReturnEvent', 'ExitEvent', 'Timer'] 
+__all__ = ['User', 'SeatReservation', 'MessageInfo', 'Keyword', 'EnterEvent', 'ReturnEvent', 'ExitEvent', 'FocusEvent', 'Timer'] 

--- a/src/ushareiplay/models/focus_event.py
+++ b/src/ushareiplay/models/focus_event.py
@@ -1,0 +1,15 @@
+from tortoise import fields
+from tortoise.models import Model
+
+
+class FocusEvent(Model):
+    id = fields.IntField(pk=True)
+    user = fields.ForeignKeyField("models.User", related_name="focus_events")
+    command = fields.TextField()
+    created_at = fields.DatetimeField(auto_now_add=True, null=True)
+
+    class Meta:
+        table = "focus_events"
+
+    def __str__(self):
+        return f"FocusEvent(id={self.id}, user={self.user_id}, command={self.command})"

--- a/src/ushareiplay/models/focus_event.py
+++ b/src/ushareiplay/models/focus_event.py
@@ -6,7 +6,7 @@ class FocusEvent(Model):
     id = fields.IntField(pk=True)
     user = fields.ForeignKeyField("models.User", related_name="focus_events")
     command = fields.TextField()
-    created_at = fields.DatetimeField(auto_now_add=True, null=True)
+    created_at = fields.DatetimeField(auto_now_add=True)
 
     class Meta:
         table = "focus_events"

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -39,3 +39,17 @@ async def test_db_models_registered():
     )
 
     await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_focus_event_created_at_auto_set():
+    """FocusEvent 创建时应自动写入 created_at（非 NULL）。"""
+    from ushareiplay.core.db_manager import DatabaseManager
+    from ushareiplay.dal.focus_event_dao import FocusEventDao
+
+    manager = DatabaseManager(db_url="sqlite://:memory:")
+    await manager.init()
+    ev = await FocusEventDao.create("alice", ":play x")
+    await ev.refresh_from_db()
+    assert ev.created_at is not None
+    await manager.close()

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -32,7 +32,7 @@ async def test_db_models_registered():
     # 获取已注册的模型（Tortoise.apps 支持 __getitem__ 但不是 dict）
     registered_names = set(Tortoise.apps["models"].keys())
     expected_models = {"User", "SeatReservation", "Keyword",
-                       "EnterEvent", "ExitEvent", "ReturnEvent", "Timer"}
+                       "EnterEvent", "ExitEvent", "ReturnEvent", "FocusEvent", "Timer"}
 
     assert expected_models.issubset(registered_names), (
         f"以下模型未注册: {expected_models - registered_names}"


### PR DESCRIPTION
## 摘要

当派对房内 `tvStudyRoomDesc`（配置元素 `focus_count`）解析出的专注人数发生变化时，除更新 `InfoManager.focus_count` 外，会按数据库 `focus_events` 中的配置，将联动命令逐条写入消息队列执行。

## 主要改动

- **数据**：新增 `FocusEvent` 模型，物理表 `focus_events`；`FocusEventDao` 提供与进房命令类似的 CRUD；`:focus add|del|list|clear` 由 `FocusCommand` 实现。
- **事件**：扩展 `FocusCountEvent`，人数变化时调用 `CommandManager.notify_focus_count_change`；事件处理始终 `return False`，避免打断同轮其它事件。
- **分发**：`focus_count_change` 拉取全部 `focus_events` 记录，每条使用 **配置该条命令的用户**（`:focus add` 时的发言者对应 `User`）作为 `MessageInfo.nickname` 入队。
- **配置**：在 `config.yaml` 的 `commands` 中注册 `prefix: focus`；**未修改** `elements` 下 `focus_count` 行及其注释。

## 验证

- `uv run pytest -q`（117 passed）

Made with [Cursor](https://cursor.com)