### PR TITLE
feat(party): support configurable new/restore create mode

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ soul:
 #  default_party_id: "FM15321640"
   default_notice: "U Share I Play\n分享音乐 享受快乐"
   broadcast_playing_info: false
-  
+
   # 系统用户列表，这些用户不受等级限制
   system_users:
     - "Timer"
@@ -24,6 +24,8 @@ soul:
 
   # 派对智能重启配置
   party_restart_minutes: 60 # 触发重启的时间（分钟），默认20小时
+  # 派对创建模式：new_party_entry(新建) / restore_party(恢复)
+  party_create_mode: "restore_party"
 
   # 新建派对成功后的自动化（仅投递命令到 MessageQueue）
   post_party_create:

--- a/src/ushareiplay/managers/party_manager.py
+++ b/src/ushareiplay/managers/party_manager.py
@@ -272,147 +272,16 @@ class PartyManager(Singleton):
         处理其他可能的异常情况
         返回True表示执行了操作，False表示没有找到需要处理的情况
         """
-
-        # 检测是否在首页（非派对页面）
         try:
-            planet_tab = self.handler.try_find_element_plus('planet_tab', log=False)
-            if not planet_tab:
-                return False
-            self.logger.info("发现首页，尝试进入派对")
-            planet_tab.click()
-
-            party_hall_entry = self.handler.wait_for_element_clickable_plus('party_hall_entry')
-            if not party_hall_entry:
-                self.logger.warning("未找到派对大厅入口")
-                return False
-            party_hall_entry.click()
-            self.logger.info("Clicked party hall entry")
-
-            key, element = self.handler.wait_for_any_element_plus(
-                ['party_back', 'search_entry'])
-            if not element:
-                self.logger.warning("未找到派对入口")
+            if not self._enter_party_hall_from_home():
                 return False
 
-            if key == 'party_back':
-                element.click()
-                self.logger.info("Clicked back to party")
+            if self._search_and_try_enter_existing_party():
                 return True
 
-            if key == 'search_entry':
-                search_entry = element
-                search_entry.click()
-                self.logger.info("Clicked search entry")
-                search_box = self.handler.wait_for_element_plus('search_box')
-                if not search_box:
-                    self.logger.warning("未找到搜索框")
-                    return False
-                party_id = self.handler.party_id or self.handler.config['default_party_id']
-                search_box.send_keys(party_id)
-                self.logger.info(f"Entered party ID: {party_id}")
-                search_button = self.handler.wait_for_element_plus('search_button')
-                if not search_button:
-                    self.logger.warning("未找到搜索按钮")
-                    return False
-                search_button.click()
-                self.logger.info("Clicked search button")
-
-                room_card = self.handler.wait_for_element_plus('room_card')
-                if not room_card:
-                    self.logger.warning("未找到派对房间，视为派对关闭，准备重建派对")
-                    search_back = self.handler.wait_for_element_plus('search_back')
-                    if search_back:
-                        search_back.click()
-                        self.logger.info("Clicked search back")
-                    else:
-                        self.logger.warning("未找到搜索返回按钮，尝试系统返回")
-                        self.handler.press_back()
-                else:
-                    party_online = self.handler.try_find_element_plus('party_online')
-                    if party_online:
-                        party_online.click()
-                        self.logger.info("Clicked party online")
-                        return True
-                    else:
-                        self.logger.warning("派对关闭了")
-                        search_back = self.handler.wait_for_element_plus('search_back')
-                        if search_back:
-                            search_back.click()
-                            self.logger.info("Clicked search back")
-                        else:
-                            self.logger.warning("未找到搜索返回按钮，尝试系统返回")
-                            self.handler.press_back()
-
-            key, element = self.handler.wait_for_any_element_plus(
-                ['create_party_entry', 'create_room_entry'])
-            if not element:
-                self.logger.warning("未找到派对入口")
+            if not self._create_party_flow():
                 return False
-            element.click()
-            self.logger.info("Clicked create party entry")
-
-            key, element = self.handler.wait_for_any_element_plus(
-                ['confirm_party', 'new_party_entry', 'party_state_entry'])
-            if not element:
-                self.logger.warning("未找到派对创建或恢复按钮")
-
-            party_state_entry = None
-            if key == 'new_party_entry' or key == 'confirm_party':
-                element.click()
-                self.logger.info(f"Clicked new party entry: {key}")
-                party_state_entry = self.handler.wait_for_element_plus('party_state_entry')
-            elif key == 'party_state_entry':
-                party_state_entry = element
-
-            if not party_state_entry:
-                self.logger.warning("未找到创建派对屏幕")
-                return False
-
-            party_state_entry.click()
-            self.logger.info("Clicked party state entry")
-
-            close_party_notification = self.handler.wait_for_element_plus('close_party_notification')
-            if not close_party_notification:
-                self.logger.warning("未找到关闭派对推荐")
-                return False
-            close_party_notification.click()
-            self.logger.info("Clicked close party notification")
-
-            create_party_button = self.handler.wait_for_element_plus('create_party_button')
-            if not create_party_button:
-                self.logger.warning("<UNK>")
-            create_party_button.click()
-            self.logger.info("Clicked create party button")
-
-            # 派对创建成功后，重置派对时间
-            self.reset_party_time()
-
-            # 派对创建成功后，设置默认notice
-            self.logger.info("派对创建成功，准备设置默认notice")
-
-            notice_manager = self.handler.controller.notice_manager
-            result = await notice_manager.set_default_notice()
-
-            if 'success' in result:
-                self.logger.info("默认notice设置成功")
-            else:
-                self.logger.warning(f"默认notice设置失败: {result.get('error', 'Unknown error')}")
-
-            seat_manager = self.handler.controller.seat_manager
-            self.logger.info("Attempting to seat owner after party creation")
-            result = await seat_manager.seating.find_owner_seat()
-
-            if 'success' in result:
-                self.logger.info("Owner successfully seated")
-            else:
-                self.logger.warning(f"Failed to seat owner: {result.get('error', 'Unknown error')}")
-
-            automation = getattr(self.handler.controller, "post_party_create_automation", None)
-            if automation:
-                await automation.on_party_created_new()
-            else:
-                self.logger.warning("post_party_create_automation not initialized; skip auto commands")
-
+            await self._after_party_created()
             return True
 
 
@@ -420,3 +289,157 @@ class PartyManager(Singleton):
             self.logger.debug(f"检测首页时出错: {str(e)}")
 
         return False
+
+    def _enter_party_hall_from_home(self) -> bool:
+        planet_tab = self.handler.try_find_element_plus('planet_tab', log=False)
+        if not planet_tab:
+            return False
+        self.logger.info("发现首页，尝试进入派对")
+        planet_tab.click()
+
+        party_hall_entry = self.handler.wait_for_element_clickable_plus('party_hall_entry')
+        if not party_hall_entry:
+            self.logger.warning("未找到派对大厅入口")
+            return False
+        party_hall_entry.click()
+        self.logger.info("Clicked party hall entry")
+        return True
+
+    def _search_and_try_enter_existing_party(self) -> bool:
+        key, element = self.handler.wait_for_any_element_plus(['party_back', 'search_entry'])
+        if not element:
+            self.logger.warning("未找到派对入口")
+            return False
+
+        if key == 'party_back':
+            element.click()
+            self.logger.info("Clicked back to party")
+            return True
+
+        search_entry = element
+        search_entry.click()
+        self.logger.info("Clicked search entry")
+        search_box = self.handler.wait_for_element_plus('search_box')
+        if not search_box:
+            self.logger.warning("未找到搜索框")
+            return False
+
+        party_id = self.handler.party_id or self.handler.config['default_party_id']
+        search_box.send_keys(party_id)
+        self.logger.info(f"Entered party ID: {party_id}")
+        search_button = self.handler.wait_for_element_plus('search_button')
+        if not search_button:
+            self.logger.warning("未找到搜索按钮")
+            return False
+        search_button.click()
+        self.logger.info("Clicked search button")
+
+        room_card = self.handler.wait_for_element_plus('room_card')
+        if not room_card:
+            self.logger.warning("未找到派对房间，视为派对关闭，准备重建派对")
+            self._go_back_from_search()
+            return False
+
+        party_online = self.handler.try_find_element_plus('party_online')
+        if party_online:
+            party_online.click()
+            self.logger.info("Clicked party online")
+            return True
+
+        self.logger.warning("派对关闭了")
+        self._go_back_from_search()
+        return False
+
+    def _go_back_from_search(self) -> None:
+        search_back = self.handler.wait_for_element_plus('search_back')
+        if search_back:
+            search_back.click()
+            self.logger.info("Clicked search back")
+            return
+        self.logger.warning("未找到搜索返回按钮，尝试系统返回")
+        self.handler.press_back()
+
+    def _create_party_flow(self) -> bool:
+        key, element = self.handler.wait_for_any_element_plus(['create_party_entry', 'create_room_entry'])
+        if not element:
+            self.logger.warning("未找到派对入口")
+            return False
+        element.click()
+        self.logger.info("Clicked create party entry")
+
+        mode = self._party_create_mode()
+        if mode == 'restore_party':
+            wait_keys = ['restore_party', 'confirm_party', 'party_state_entry']
+        else:
+            wait_keys = ['new_party_entry', 'confirm_party', 'party_state_entry']
+        key, element = self.handler.wait_for_any_element_plus(wait_keys)
+        if not element:
+            self.logger.warning("未找到派对创建或恢复按钮")
+            return False
+
+        if key == 'restore_party':
+            element.click()
+            self.logger.info("Clicked restore party entry")
+            return True
+
+        party_state_entry = None
+        if key == 'new_party_entry' or key == 'confirm_party':
+            element.click()
+            self.logger.info(f"Clicked new party entry: {key}")
+            party_state_entry = self.handler.wait_for_element_plus('party_state_entry')
+        elif key == 'party_state_entry':
+            party_state_entry = element
+
+        if not party_state_entry:
+            self.logger.warning("未找到创建派对屏幕")
+            return False
+
+        party_state_entry.click()
+        self.logger.info("Clicked party state entry")
+
+        close_party_notification = self.handler.wait_for_element_plus('close_party_notification')
+        if not close_party_notification:
+            self.logger.warning("未找到关闭派对推荐")
+            return False
+        close_party_notification.click()
+        self.logger.info("Clicked close party notification")
+
+        create_party_button = self.handler.wait_for_element_plus('create_party_button')
+        if not create_party_button:
+            self.logger.warning("<UNK>")
+            return False
+        create_party_button.click()
+        self.logger.info("Clicked create party button")
+        return True
+
+    def _party_create_mode(self) -> str:
+        mode = self.handler.config.get('party_create_mode', 'new_party_entry')
+        if mode in ('new_party_entry', 'restore_party'):
+            return mode
+        self.logger.warning(f"未知 party_create_mode={mode}，回退 new_party_entry")
+        return 'new_party_entry'
+
+    async def _after_party_created(self) -> None:
+        self.reset_party_time()
+        self.logger.info("派对创建成功，准备设置默认notice")
+
+        notice_manager = self.handler.controller.notice_manager
+        result = await notice_manager.set_default_notice()
+        if 'success' in result:
+            self.logger.info("默认notice设置成功")
+        else:
+            self.logger.warning(f"默认notice设置失败: {result.get('error', 'Unknown error')}")
+
+        seat_manager = self.handler.controller.seat_manager
+        self.logger.info("Attempting to seat owner after party creation")
+        result = await seat_manager.seating.find_owner_seat()
+        if 'success' in result:
+            self.logger.info("Owner successfully seated")
+        else:
+            self.logger.warning(f"Failed to seat owner: {result.get('error', 'Unknown error')}")
+
+        automation = getattr(self.handler.controller, "post_party_create_automation", None)
+        if automation:
+            await automation.on_party_created_new()
+        else:
+            self.logger.warning("post_party_create_automation not initialized; skip auto commands")

--- a/tests/test_party_manager_create_mode.py
+++ b/tests/test_party_manager_create_mode.py
@@ -1,0 +1,105 @@
+from ushareiplay.managers.party_manager import PartyManager
+
+
+class _Logger:
+    def info(self, *_args, **_kwargs):
+        pass
+
+    def warning(self, *_args, **_kwargs):
+        pass
+
+    def debug(self, *_args, **_kwargs):
+        pass
+
+    def error(self, *_args, **_kwargs):
+        pass
+
+
+class _Element:
+    def __init__(self):
+        self.clicked = False
+
+    def click(self):
+        self.clicked = True
+
+
+class _Handler:
+    def __init__(self, config, any_results=None):
+        self.config = config
+        self.logger = _Logger()
+        self._any_results = any_results or []
+
+    def wait_for_any_element_plus(self, _keys):
+        return self._any_results.pop(0)
+
+    def wait_for_element_plus(self, key):
+        if key == 'party_state_entry':
+            return _Element()
+        if key == 'close_party_notification':
+            return _Element()
+        if key == 'create_party_button':
+            return _Element()
+        return None
+
+
+def test_party_create_mode_restore_clicks_restore_only():
+    manager = PartyManager.instance()
+    create_entry = _Element()
+    restore_entry = _Element()
+    handler = _Handler(
+        config={"party_create_mode": "restore_party"},
+        any_results=[
+            ("create_party_entry", create_entry),
+            ("restore_party", restore_entry),
+        ],
+    )
+    manager._handler = handler
+    manager._logger = handler.logger
+
+    ok = manager._create_party_flow()
+
+    assert ok is True
+    assert create_entry.clicked is True
+    assert restore_entry.clicked is True
+
+
+def test_party_create_mode_default_keeps_new_flow():
+    manager = PartyManager.instance()
+    create_entry = _Element()
+    new_entry = _Element()
+    handler = _Handler(
+        config={},
+        any_results=[
+            ("create_party_entry", create_entry),
+            ("new_party_entry", new_entry),
+        ],
+    )
+    manager._handler = handler
+    manager._logger = handler.logger
+
+    ok = manager._create_party_flow()
+
+    assert ok is True
+    assert create_entry.clicked is True
+    assert new_entry.clicked is True
+
+
+def test_restore_mode_with_confirm_party_keeps_legacy_flow():
+    manager = PartyManager.instance()
+    create_entry = _Element()
+    confirm_entry = _Element()
+    handler = _Handler(
+        config={"party_create_mode": "restore_party"},
+        any_results=[
+            ("create_party_entry", create_entry),
+            ("confirm_party", confirm_entry),
+        ],
+    )
+    manager._handler = handler
+    manager._logger = handler.logger
+
+    ok = manager._create_party_flow()
+
+    assert ok is True
+    assert create_entry.clicked is True
+    assert confirm_entry.clicked is True


### PR DESCRIPTION
## Summary
- refactor PartyManager.join_party() into smaller focused private methods
- add `soul.party_create_mode` config (`new_party_entry`/`restore_party`)
- in restore mode, wait keys: `['restore_party','confirm_party','party_state_entry']`
- in new mode, wait keys: `['new_party_entry','confirm_party','party_state_entry']`
- if `restore_party` is found, click restore and enter party directly
- keep legacy flow when `confirm_party` or `party_state_entry` appears
- add tests for create-mode branching behavior

## Test Plan
- `uv run pytest -q tests/test_party_manager_create_mode.py tests/test_post_party_create_automation_latch.py`

## Note
- repository pre-push full-suite currently has an unrelated existing failure in `tests/test_timer_add.py` under system python environment
