### PR TITLE
Add silent slash command lifecycle

### DIFF
--- a/src/ushareiplay/commands/enter.py
+++ b/src/ushareiplay/commands/enter.py
@@ -46,9 +46,8 @@ class EnterCommand(BaseCommand):
                 
                 command = params[1]
                 
-                # Validate command format (should start with ':' or '：')
-                if not command.startswith((':', '：')):
-                    return {'error': '命令必须以冒号(:/：)开头，例如 ":play 歌曲名"'}
+                if not command.startswith((':', '：', '/', '／')):
+                    return {'error': '命令必须以命令前缀(:/：或//／)开头，例如 ":play 歌曲名"'}
                 
                 # Add to database using DAO
                 await EnterDao.create(username, command)

--- a/src/ushareiplay/commands/exit.py
+++ b/src/ushareiplay/commands/exit.py
@@ -46,9 +46,8 @@ class ExitCommand(BaseCommand):
                 
                 command = params[1]
                 
-                # Validate command format (should start with ':' or '：')
-                if not command.startswith((':', '：')):
-                    return {'error': '命令必须以冒号(:/：)开头，例如 ":play 歌曲名"'}
+                if not command.startswith((':', '：', '/', '／')):
+                    return {'error': '命令必须以命令前缀(:/：或//／)开头，例如 ":play 歌曲名"'}
                 
                 # Add to database using DAO
                 await ExitDao.create(username, command)

--- a/src/ushareiplay/commands/focus.py
+++ b/src/ushareiplay/commands/focus.py
@@ -33,8 +33,8 @@ class FocusCommand(BaseCommand):
                     return {"error": '缺少命令内容。使用: :focus add "命令内容"'}
 
                 command = params[1]
-                if not command.startswith((":", "：")):
-                    return {"error": '命令必须以冒号(:/：)开头，例如 ":play 歌曲名"'}
+                if not command.startswith((":", "：", "/", "／")):
+                    return {"error": '命令必须以命令前缀(:/：或//／)开头，例如 ":play 歌曲名"'}
 
                 await FocusEventDao.create(username, command)
                 return {"message": f"已添加专注人数联动命令: {command}"}

--- a/src/ushareiplay/commands/return.py
+++ b/src/ushareiplay/commands/return.py
@@ -47,8 +47,8 @@ class ReturnCommand(BaseCommand):
                     return {'error': '缺少命令内容。使用: :return add "命令内容"'}
 
                 cmd_text = params[1]
-                if not cmd_text.startswith((':', '：')):
-                    return {'error': '命令必须以冒号(:/：)开头，例如 ":play 歌曲名"'}
+                if not cmd_text.startswith((':', '：', '/', '／')):
+                    return {'error': '命令必须以命令前缀(:/：或//／)开头，例如 ":play 歌曲名"'}
 
                 await ReturnDao.create(username, cmd_text)
                 return {'message': f'已添加返回命令: {cmd_text}'}

--- a/src/ushareiplay/core/app_controller.py
+++ b/src/ushareiplay/core/app_controller.py
@@ -439,7 +439,7 @@ class AppController(Singleton):
                                 # Allow leading whitespace and spaces after colon.
                                 # Keep the queued content in its original (colon-triggered) form.
                                 trimmed = message.lstrip()
-                                if trimmed and trimmed[0] in (':', '：') and trimmed[1:].strip():
+                                if trimmed and trimmed[0] in (':', '：', '/', '／') and trimmed[1:].strip():
                                     # Create MessageInfo for queue
                                     from ushareiplay.models.message_info import MessageInfo
                                     message_info = MessageInfo(

--- a/src/ushareiplay/core/command_silence.py
+++ b/src/ushareiplay/core/command_silence.py
@@ -1,0 +1,22 @@
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+
+_silent_depth: ContextVar[int] = ContextVar("command_silent_depth", default=0)
+
+
+def is_command_silent() -> bool:
+    return _silent_depth.get() > 0
+
+
+@contextmanager
+def command_silence(enabled: bool):
+    if not enabled:
+        yield
+        return
+
+    token = _silent_depth.set(_silent_depth.get() + 1)
+    try:
+        yield
+    finally:
+        _silent_depth.reset(token)

--- a/src/ushareiplay/core/message_queue.py
+++ b/src/ushareiplay/core/message_queue.py
@@ -1,8 +1,10 @@
 import asyncio
 import threading
 from collections import deque
+from dataclasses import replace
 from datetime import datetime
 from typing import Optional, Dict, Any, List
+from ushareiplay.core.command_silence import is_command_silent
 from ushareiplay.core.singleton import Singleton
 
 
@@ -21,6 +23,8 @@ class MessageQueue(Singleton):
         Args:
             message_info: MessageInfo 对象
         """
+        if is_command_silent():
+            message_info = replace(message_info, silent=True)
         await self._queue.put(message_info)
     
     async def get_all_messages(self) -> Dict[str, Any]:

--- a/src/ushareiplay/core/runtime_services.py
+++ b/src/ushareiplay/core/runtime_services.py
@@ -6,6 +6,10 @@ from ushareiplay.core.message_queue import MessageQueue
 from ushareiplay.models.message_info import MessageInfo
 
 
+COMMAND_PREFIXES = (":", "：", "/", "／")
+SILENT_COMMAND_PREFIXES = ("/", "／")
+
+
 class RuntimeQueueDrainer:
     """Drain MessageQueue from runtime loop (single authoritative path)."""
 
@@ -31,12 +35,21 @@ class RuntimeQueueDrainer:
                 if not part:
                     continue
                 part = part.replace("{user_name}", message_info.nickname)
-                if part.startswith((":", "：")):
+                part_silent = bool(getattr(message_info, "silent", False))
+                if part.startswith(SILENT_COMMAND_PREFIXES):
+                    part_silent = True
+                if part.startswith(COMMAND_PREFIXES):
                     command_messages.append(
-                        MessageInfo(content=part, nickname=message_info.nickname)
+                        MessageInfo(
+                            content=part,
+                            nickname=message_info.nickname,
+                            silent=part_silent,
+                        )
                     )
-                else:
+                elif not part_silent:
                     self.handler.send_message(part)
+                elif self.logger:
+                    self.logger.info(f"Silent command suppressed queued message: {part}")
 
         if command_messages:
             await self.command_manager.handle_message_commands(command_messages)

--- a/src/ushareiplay/events/message_content.py
+++ b/src/ushareiplay/events/message_content.py
@@ -131,7 +131,7 @@ class MessageContentEvent(BaseEvent):
                     continue  # 跳过后续的命令检测
 
                 # 检查是否满足命令格式
-                pattern = r"souler\[.+\]说：\s*[:：]\s*\S.+"
+                pattern = r"souler\[.+\]说：\s*[:：/／]\s*\S.+"
                 match = re.match(pattern, content)
                 if match:
                     # 标记有命令消息

--- a/src/ushareiplay/handlers/soul_handler.py
+++ b/src/ushareiplay/handlers/soul_handler.py
@@ -1,5 +1,6 @@
 import logging
 
+from ushareiplay.core.command_silence import is_command_silent
 from ushareiplay.managers.message_manager import MessageManager
 from ushareiplay.core.app_handler import AppHandler
 from ushareiplay.core.singleton import Singleton
@@ -27,6 +28,10 @@ class SoulHandler(AppHandler, Singleton):
 
     def send_message(self, message):
         """Send message"""
+        if is_command_silent():
+            self.logger.info(f"Silent command suppressed screen message: {message}")
+            return None
+
         self.switch_to_app()
 
         # Click on the input box entry first

--- a/src/ushareiplay/managers/command_manager.py
+++ b/src/ushareiplay/managers/command_manager.py
@@ -3,8 +3,13 @@ import sys
 import traceback
 from datetime import datetime
 from pathlib import Path
+from ushareiplay.core.command_silence import command_silence
 from ushareiplay.core.singleton import Singleton
 from ushareiplay.core.command_parser import CommandParser
+
+
+COMMAND_PREFIXES = (":", "：", "/", "／")
+SILENT_COMMAND_PREFIXES = ("/", "／")
 
 
 class CommandManager(Singleton):
@@ -163,6 +168,15 @@ class CommandManager(Singleton):
         module = self.load_command_module(command_name)
         return module.command if module else None
 
+    def _send_screen_message(self, message: str, silent: bool = False):
+        if silent:
+            try:
+                self.logger.info(f"Silent command suppressed screen message: {message}")
+            except Exception:
+                pass
+            return None
+        return self.handler.send_message(message)
+
     async def process_command(self, command, message_info, command_info):
         """Process command using module if available
         Args:
@@ -174,6 +188,9 @@ class CommandManager(Singleton):
         """
         try:
             parameters = command_info['parameters']
+            silent = bool(command_info.get("silent")) or bool(
+                getattr(message_info, "silent", False)
+            )
 
             try:
                 self.runtime.emit(
@@ -233,19 +250,21 @@ class CommandManager(Singleton):
             
             # UI 互斥：命令执行期间禁止 EventManager 的"未知页面自动 back"打断弹窗/子页面流程
             result = {'error': 'unknown'}
-            async with self.runtime.ui_session(f"command:{command_info.get('prefix', 'unknown')}"):
-                try:
-                    self.runtime.emit(
-                        "command.dispatch",
-                        ctx={
-                            "prefix": command_info.get("prefix"),
-                            "parameters": parameters,
-                            "nickname": message_info.nickname,
-                        },
-                    )
-                except Exception:
-                    pass
-                result = await command.process(message_info, parameters)
+            with command_silence(silent):
+                async with self.runtime.ui_session(f"command:{command_info.get('prefix', 'unknown')}"):
+                    try:
+                        self.runtime.emit(
+                            "command.dispatch",
+                            ctx={
+                                "prefix": command_info.get("prefix"),
+                                "parameters": parameters,
+                                "nickname": message_info.nickname,
+                                "silent": silent,
+                            },
+                        )
+                    except Exception:
+                        pass
+                    result = await command.process(message_info, parameters)
 
             if 'error' in result:
                 # 合并 result 中的字段（如 party_id），以便各命令的 error_template 能正确渲染
@@ -266,6 +285,7 @@ class CommandManager(Singleton):
                         "error": result.get("error") if isinstance(result, dict) else None,
                         "response": res,
                         "response_len": len(res or ""),
+                        "silent": silent,
                     },
                 )
             except Exception:
@@ -296,7 +316,8 @@ class CommandManager(Singleton):
         Accepts:
         - leading whitespace (e.g. "  : help")
         - fullwidth colon (：)
-        - whitespace after colon (e.g. ": help")
+        - silent slash prefixes (/ and ／)
+        - whitespace after trigger (e.g. ": help")
 
         Returns:
             str: cleaned command content WITHOUT the trigger colon, and with
@@ -307,9 +328,13 @@ class CommandManager(Singleton):
         s = raw.lstrip()
         if not s:
             return ""
-        if s[0] in (":", "："):
+        if s[0] in COMMAND_PREFIXES:
             s = s[1:]
         return s.lstrip()
+
+    def _is_silent_command_candidate(self, raw: str) -> bool:
+        s = (raw or "").lstrip()
+        return bool(s) and s[0] in SILENT_COMMAND_PREFIXES
 
     async def handle_message_commands(self, messages):
         """
@@ -330,6 +355,9 @@ class CommandManager(Singleton):
                 continue
 
             # Normalize command input (tolerate leading spaces and spaces after colon)
+            silent = bool(getattr(message_info, "silent", False)) or self._is_silent_command_candidate(
+                message_info.content
+            )
             content = self._normalize_command_candidate(message_info.content)
             if not content:
                 continue
@@ -337,23 +365,26 @@ class CommandManager(Singleton):
             if self.is_valid_command(content):
                 command_info = self.parse_command(content)
                 if command_info:
+                    command_info["silent"] = silent
                     # Handle different commands using match-case
                     cmd = command_info['prefix']
                     time_prefix = datetime.now().strftime('%H:%M:%S')
-
-                    self.handler.send_message(
-                        f'[{time_prefix}] {cmd} ... @{message_info.nickname}')
+                    self._send_screen_message(
+                        f'[{time_prefix}] {cmd} ... @{message_info.nickname}',
+                        silent=silent,
+                    )
 
                     command = self.get_command(cmd)
                     if command:
                         response = await self.process_command(command, message_info, command_info)
                         if response:
-                            self.handler.send_message(response)
+                            self._send_screen_message(response, silent=silent)
                         success_count += 1
                     else:
                         self.logger.error(f"Unknown command: {cmd}")
-                        self.handler.send_message(
-                            f'[{time_prefix}] Unknown command: {cmd} @{message_info.nickname}'
+                        self._send_screen_message(
+                            f'[{time_prefix}] Unknown command: {cmd} @{message_info.nickname}',
+                            silent=silent,
                         )
 
         self.logger.info(f"{success_count}/{len(messages)} commands processed")

--- a/src/ushareiplay/managers/message_manager.py
+++ b/src/ushareiplay/managers/message_manager.py
@@ -16,6 +16,8 @@ from ushareiplay.core.singleton import Singleton
 from ushareiplay.managers.recovery_manager import RecoveryManager
 from ushareiplay.models.message_info import MessageInfo
 
+COMMAND_PREFIX_CHARS = ":：/／"
+
 # Global chat logger - will be initialized when needed
 chat_logger = None
 
@@ -166,7 +168,7 @@ class MessageManager(Singleton):
                 continue
 
             # Parse message content using pattern
-            pattern = r'souler\[(.+)\]说：\s*[:：]\s*(.+)'
+            pattern = r'souler\[(.+)\]说：\s*([:：/／])\s*(.+)'
 
             match = re.match(pattern, chat)
             if not match:
@@ -174,11 +176,12 @@ class MessageManager(Singleton):
 
             # Extract actual message content
             nickname = match.group(1).strip()
-            command = match.group(2).strip()
-            # Re-add trigger colon so downstream queue path remains consistent.
+            trigger = match.group(2)
+            command = match.group(3).strip()
+            # Re-add the original trigger so slash commands remain silent downstream.
             # CommandManager will normalize whitespace/colon later.
-            command = f":{command}" if command else ""
-            if not command.strip(":：").strip():
+            command = f"{trigger}{command}" if command else ""
+            if not command.strip(COMMAND_PREFIX_CHARS).strip():
                 continue
             command_set.add(command)
             nickname_map[command] = nickname
@@ -198,7 +201,7 @@ class MessageManager(Singleton):
 
         messages = []
         for chat in self.latest_chats:
-            pattern = r'souler\[(.+)\]说：\s*[:：]\s*(.+)'
+            pattern = r'souler\[(.+)\]说：\s*([:：/／])\s*(.+)'
 
             match = re.match(pattern, chat)
             if not match:
@@ -206,10 +209,11 @@ class MessageManager(Singleton):
 
             # Extract actual message content
             nickname = match.group(1).strip()
-            message_content = match.group(2).strip()
-            # Re-add trigger colon to keep MessageInfo.content consistent with queue/console conventions.
-            message_content = f":{message_content}" if message_content else ""
-            if not message_content.strip(":：").strip():
+            trigger = match.group(2)
+            message_content = match.group(3).strip()
+            # Re-add trigger to keep MessageInfo.content consistent with queue/console conventions.
+            message_content = f"{trigger}{message_content}" if message_content else ""
+            if not message_content.strip(COMMAND_PREFIX_CHARS).strip():
                 continue
             message = MessageInfo(message_content, nickname)
             messages.append(message)

--- a/src/ushareiplay/models/message_info.py
+++ b/src/ushareiplay/models/message_info.py
@@ -6,4 +6,4 @@ class MessageInfo:
     """Data class for message information"""
     content: str
     nickname: str
-
+    silent: bool = False

--- a/tests/test_command_manager_silent_commands.py
+++ b/tests/test_command_manager_silent_commands.py
@@ -1,0 +1,202 @@
+import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+from ushareiplay.managers.command_manager import CommandManager
+
+
+class _Logger:
+    def __init__(self):
+        self.messages = []
+
+    def info(self, message):
+        self.messages.append(("info", message))
+
+    def error(self, message):
+        self.messages.append(("error", message))
+
+
+class _Runtime:
+    def __init__(self):
+        self.events = []
+        self.session_reasons = []
+
+    def emit(self, event, **kwargs):
+        self.events.append((event, kwargs))
+
+    @asynccontextmanager
+    async def ui_session(self, reason):
+        self.session_reasons.append(reason)
+        yield
+
+
+class _Handler:
+    def __init__(self):
+        self.sent = []
+        self.config = {"system_users": ["Console"]}
+        self.logger = _Logger()
+
+    def send_message(self, message):
+        from ushareiplay.core.command_silence import is_command_silent
+
+        if is_command_silent():
+            return None
+        self.sent.append(message)
+
+
+class _Command:
+    async def process(self, message_info, parameters):
+        return {"message": f"processed {' '.join(parameters)}".strip()}
+
+
+class _DirectSendCommand:
+    def __init__(self, handler):
+        self.handler = handler
+
+    async def process(self, message_info, parameters):
+        self.handler.send_message("inside command")
+        return {"message": "done"}
+
+
+class _QueueingCommand:
+    async def process(self, message_info, parameters):
+        from ushareiplay.core.message_queue import MessageQueue
+        from ushareiplay.models.message_info import MessageInfo
+
+        await MessageQueue.instance().put_message(
+            MessageInfo(content="queued text;:demo queued", nickname=message_info.nickname)
+        )
+        return {"message": "queued"}
+
+
+def _make_manager(commands=None):
+    runtime = _Runtime()
+    handler = _Handler()
+    controller = SimpleNamespace(soul_handler=handler, music_handler=object())
+    runtime.controller = controller
+
+    manager = CommandManager.__new__(CommandManager)
+    manager.__init__()
+    manager.configure_runtime(runtime)
+    manager.controller = controller
+    manager._handler = handler
+    manager._logger = handler.logger
+    manager.initialize_parser(
+        commands
+        or [
+            {
+                "prefix": "demo",
+                "level": 1,
+                "response_template": "{message}",
+                "error_template": "{error}",
+            }
+        ]
+    )
+    return manager, runtime, handler
+
+
+def test_slash_command_suppresses_screen_messages_but_still_executes(monkeypatch):
+    manager, runtime, handler = _make_manager()
+    command = _Command()
+    monkeypatch.setattr(manager, "get_command", lambda _cmd: command)
+
+    processed = asyncio.run(
+        manager.handle_message_commands(
+            [SimpleNamespace(content="/demo abc", nickname="Console")]
+        )
+    )
+
+    assert processed == 1
+    assert handler.sent == []
+    assert [event[0] for event in runtime.events] == [
+        "command.received",
+        "command.dispatch",
+        "command.result",
+    ]
+
+
+def test_fullwidth_slash_command_suppresses_screen_messages(monkeypatch):
+    manager, _runtime, handler = _make_manager()
+    command = _Command()
+    monkeypatch.setattr(manager, "get_command", lambda _cmd: command)
+
+    processed = asyncio.run(
+        manager.handle_message_commands(
+            [SimpleNamespace(content="／demo abc", nickname="Console")]
+        )
+    )
+
+    assert processed == 1
+    assert handler.sent == []
+
+
+def test_colon_command_keeps_existing_screen_messages(monkeypatch):
+    manager, _runtime, handler = _make_manager()
+    command = _Command()
+    monkeypatch.setattr(manager, "get_command", lambda _cmd: command)
+
+    processed = asyncio.run(
+        manager.handle_message_commands(
+            [SimpleNamespace(content=":demo abc", nickname="Console")]
+        )
+    )
+
+    assert processed == 1
+    assert len(handler.sent) == 2
+    assert handler.sent[0].endswith("demo ... @Console")
+    assert handler.sent[1] == "processed abc @Console"
+
+
+def test_silent_lifecycle_suppresses_direct_command_send_message():
+    manager, _runtime, handler = _make_manager()
+    message_info = SimpleNamespace(content="/demo", nickname="Console")
+    command_info = {
+        "parameters": [],
+        "prefix": "demo",
+        "silent": True,
+        "level": 1,
+        "response_template": "{message}",
+        "error_template": "{error}",
+    }
+
+    response = asyncio.run(
+        manager.process_command(_DirectSendCommand(handler), message_info, command_info)
+    )
+
+    assert response == "done @Console"
+    assert handler.sent == []
+
+
+def test_silent_lifecycle_marks_queued_keyword_commands_silent(monkeypatch):
+    from ushareiplay.core.message_queue import MessageQueue
+    from ushareiplay.core.runtime_services import RuntimeQueueDrainer
+
+    queue = MessageQueue.instance()
+    asyncio.run(queue.clear_queue())
+
+    manager, _runtime, handler = _make_manager()
+    monkeypatch.setattr(manager, "get_command", lambda _cmd: _Command())
+    message_info = SimpleNamespace(content="/keyword exec demo", nickname="Console")
+    command_info = {
+        "parameters": ["exec", "demo"],
+        "prefix": "keyword",
+        "silent": True,
+        "level": 1,
+        "response_template": "{message}",
+        "error_template": "{error}",
+    }
+
+    response = asyncio.run(
+        manager.process_command(_QueueingCommand(), message_info, command_info)
+    )
+    drained, command_count = asyncio.run(
+        RuntimeQueueDrainer(
+            handler=handler,
+            command_manager=manager,
+        ).drain()
+    )
+
+    assert response == "queued @Console"
+    assert drained == 1
+    assert command_count == 1
+    assert handler.sent == []

--- a/tests/test_runtime_queue_pipeline.py
+++ b/tests/test_runtime_queue_pipeline.py
@@ -59,6 +59,58 @@ def test_runtime_queue_drainer_routes_commands_and_plain_messages():
     assert [e[0] for e in obs.events] == ["queue.drain.start", "queue.drain.end"]
 
 
+def test_runtime_queue_drainer_propagates_silent_commands_and_suppresses_plain_messages():
+    from ushareiplay.core.message_queue import MessageQueue
+    from ushareiplay.core.runtime_services import RuntimeQueueDrainer
+    from ushareiplay.models.message_info import MessageInfo
+
+    queue = MessageQueue.instance()
+    _run(queue.clear_queue())
+    _run(
+        queue.put_message(
+            MessageInfo(content="hello {user_name};:timer list", nickname="Alice", silent=True)
+        )
+    )
+
+    handler = _FakeHandler()
+    command_manager = _FakeCommandManager()
+    drainer = RuntimeQueueDrainer(
+        handler=handler, command_manager=command_manager, logger=handler.logger
+    )
+
+    drained, command_count = _run(drainer.drain())
+
+    assert drained == 1
+    assert command_count == 1
+    assert handler.sent == []
+    assert [m.content for m in command_manager.received] == [":timer list"]
+    assert [m.silent for m in command_manager.received] == [True]
+
+
+def test_runtime_queue_drainer_treats_slash_parts_as_silent_commands():
+    from ushareiplay.core.message_queue import MessageQueue
+    from ushareiplay.core.runtime_services import RuntimeQueueDrainer
+    from ushareiplay.models.message_info import MessageInfo
+
+    queue = MessageQueue.instance()
+    _run(queue.clear_queue())
+    _run(queue.put_message(MessageInfo(content="hello;/timer list", nickname="Alice")))
+
+    handler = _FakeHandler()
+    command_manager = _FakeCommandManager()
+    drainer = RuntimeQueueDrainer(
+        handler=handler, command_manager=command_manager, logger=handler.logger
+    )
+
+    drained, command_count = _run(drainer.drain())
+
+    assert drained == 1
+    assert command_count == 1
+    assert handler.sent == ["hello"]
+    assert [m.content for m in command_manager.received] == ["/timer list"]
+    assert [m.silent for m in command_manager.received] == [True]
+
+
 def test_message_content_update_logic_does_not_drain_runtime_queue():
     from ushareiplay.core.message_queue import MessageQueue
     from ushareiplay.events.message_content import MessageContentEvent


### PR DESCRIPTION
## Summary
- Add silent command lifecycle support for `/` and `／` prefixes while keeping `:` and `：` behavior unchanged.
- Suppress only Soul screen `send_message` output during silent command execution, including nested keyword-driven commands and queued follow-up commands.
- Preserve internal runtime events, logs, and command processing.

## Verification
- `uv run pytest -q`
- `python -m py_compile src/ushareiplay/core/app_controller.py src/ushareiplay/managers/command_manager.py src/ushareiplay/core/command_silence.py src/ushareiplay/core/message_queue.py src/ushareiplay/core/runtime_services.py src/ushareiplay/handlers/soul_handler.py src/ushareiplay/managers/message_manager.py src/ushareiplay/events/message_content.py src/ushareiplay/commands/enter.py src/ushareiplay/commands/return.py src/ushareiplay/commands/exit.py src/ushareiplay/commands/focus.py src/ushareiplay/models/message_info.py
- `git diff --check`
