### PR TITLE
feat: robustly parse user count with regex

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -118,7 +118,7 @@ soul:
     title_edit_confirm: "cn.soulapp.android:id/tv_confirm"
     go_back: "cn.soulapp.android:id/iv_back"
     go_back_1: '//android.widget.ImageButton[@content-desc="返回"]'
-    user_count: "cn.soulapp.android:id/tvUserCount" # 6人
+    user_count: "cn.soulapp.android:id/tvOnlineCount" # 6人在线
     seat_desk: "cn.soulapp.android:id/userRoot" #  > left_seat, right_seat
     left_seat: "cn.soulapp.android:id/leftUserView" # > left_state
     left_state: "cn.soulapp.android:id/leftClState" # > left_label

--- a/docs/superpowers/plans/2026-05-19-user-count-parsing.md
+++ b/docs/superpowers/plans/2026-05-19-user-count-parsing.md
@@ -1,0 +1,138 @@
+# User Count Parsing Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update user count parsing to handle "x人在线" format robustly using regex.
+
+**Architecture:** Update `UserCountEvent.handle` with regex-based parsing and add a comprehensive unit test.
+
+**Tech Stack:** Python, `re` module, `pytest`.
+
+---
+
+### Task 1: Create Unit Test for User Count Parsing
+
+**Files:**
+- Create: `tests/test_user_count_event.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from ushareiplay.events.user_count import UserCountEvent
+
+@pytest.mark.asyncio
+async def test_user_count_parsing_formats():
+    event = UserCountEvent()
+    mock_wrapper = MagicMock()
+    
+    test_cases = [
+        ("6人", 6),
+        ("6人在线", 6), # This will fail with current implementation
+        ("123", 123),
+        ("在线 10 人", 10),
+    ]
+    
+    with patch("ushareiplay.managers.info_manager.InfoManager.instance") as mock_instance:
+        mock_info = MagicMock()
+        mock_info.user_count = 0
+        mock_info.refresh_online_users = AsyncMock()
+        mock_instance.return_value = mock_info
+        
+        for input_text, expected_count in test_cases:
+            mock_wrapper.text = input_text
+            mock_info.user_count = -1 # Reset to ensure update
+            await event.handle("user_count", mock_wrapper)
+            assert mock_info.user_count == expected_count, f"Failed to parse '{input_text}'"
+
+@pytest.mark.asyncio
+async def test_user_count_parsing_failure():
+    event = UserCountEvent()
+    mock_wrapper = MagicMock()
+    
+    failure_cases = ["", "无数据", "unknown"]
+    
+    with patch("ushareiplay.managers.info_manager.InfoManager.instance") as mock_instance:
+        mock_info = MagicMock()
+        mock_info.user_count = 0
+        mock_instance.return_value = mock_info
+        
+        for input_text in failure_cases:
+            mock_wrapper.text = input_text
+            result = await event.handle("user_count", mock_wrapper)
+            assert result is False
+            assert mock_info.user_count == 0 # Should not change
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_user_count_event.py`
+Expected: FAIL with "Failed to parse '6人在线'"
+
+---
+
+### Task 2: Implement Robust Regex Parsing
+
+**Files:**
+- Modify: `src/ushareiplay/events/user_count.py`
+
+- [ ] **Step 1: Update `handle` method**
+
+```python
+    async def handle(self, key: str, element_wrapper):
+        """
+        处理在线人数事件
+        
+        解析人数文本并更新到 InfoManager
+        
+        Args:
+            key: 触发事件的元素 key，这里是 'user_count'
+            element_wrapper: ElementWrapper 实例，包装了在线人数元素
+            
+        Returns:
+            bool: 默认返回 False，不中断后续处理
+        """
+        try:
+            # 获取元素文本
+            user_count_text = element_wrapper.text
+            if not user_count_text:
+                return False
+
+            # 使用正则提取第一个数字序列，例如 "6人", "6人在线", "在线 10 人" -> 6, 6, 10
+            match = re.search(r'(\d+)', user_count_text)
+            if not match:
+                self.logger.warning(f"无法解析人数文本: {user_count_text}")
+                return False
+
+            try:
+                user_count = int(match.group(1))
+            except ValueError:
+                self.logger.warning(f"无法将提取的文本转换为整数: {match.group(1)}")
+                return False
+
+            # 更新 InfoManager 中的在线人数
+            from ushareiplay.managers.info_manager import InfoManager
+            info_manager = InfoManager.instance()
+            if user_count != info_manager.user_count:
+                info_manager.user_count = user_count
+                await info_manager.refresh_online_users()
+
+            return False
+
+        except Exception as e:
+            self.logger.error(f"Error processing user count event: {str(e)}")
+            return False
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `pytest tests/test_user_count_event.py`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/ushareiplay/events/user_count.py tests/test_user_count_event.py
+git commit -m "feat: robustly parse user count with regex to support 'x人在线' format"
+```

--- a/docs/superpowers/specs/2026-05-19-user-count-parsing-design.md
+++ b/docs/superpowers/specs/2026-05-19-user-count-parsing-design.md
@@ -1,0 +1,38 @@
+# Design Spec: User Count Parsing Fix
+
+**Date:** 2026-05-19
+**Status:** Approved
+**Topic:** Handle change in online user count text format
+
+## 1. Problem Description
+The online user count text in the UI has changed from "x人" (e.g., "6人") to "x人在线" (e.g., "6人在线"). The current parsing logic in `UserCountEvent` fails to parse the new format because it tries to convert "6在线" to an integer after replacing "人" with an empty string.
+
+## 2. Proposed Solution
+Switch to a robust regex-based extraction of digits. This will handle both the old and new formats, as well as potential future variations.
+
+### 2.1. Logic Update
+- Use `re.search(r'(\d+)', user_count_text)` to find the first sequence of digits.
+- Extract the matched group and convert it to `int`.
+
+### 2.2. Implementation Details
+- File: `src/ushareiplay/events/user_count.py`
+- Method: `UserCountEvent.handle`
+
+## 3. Testing Strategy
+A new unit test will be created to verify the parsing logic.
+
+### 3.1. Test Cases
+- "6人" -> 6
+- "6人在线" -> 6
+- "123" -> 123
+- "在线 10 人" -> 10
+- Empty string -> Fail (return False)
+- "无数据" -> Fail (log warning, return False)
+
+### 3.2. Test File
+- `tests/test_user_count_event.py`
+
+## 4. Design Review
+- **Architecture:** Simple logic update in an existing event handler.
+- **Robustness:** High, regex handles various string formats.
+- **Safety:** Logging preserved for troubleshooting.

--- a/src/ushareiplay/events/user_count.py
+++ b/src/ushareiplay/events/user_count.py
@@ -31,27 +31,18 @@ class UserCountEvent(BaseEvent):
             if not user_count_text:
                 return False
 
-            # 解析人数文本，例如 "6人" -> 6
-            user_count = None
-            if '人' in user_count_text:
-                count_str = user_count_text.replace('人', '').strip()
-                try:
-                    user_count = int(count_str)
-                except ValueError:
-                    self.logger.warning(f"无法解析人数文本: {user_count_text}")
-                    return False
-            else:
-                # 尝试提取所有数字
-                match = re.search(r'(\d+)', user_count_text)
-                if match:
-                    try:
-                        user_count = int(match.group(1))
-                    except ValueError:
-                        self.logger.warning(f"无法解析人数文本: {user_count_text}")
-                        return False
-                else:
-                    self.logger.warning(f"人数文本格式异常: {user_count_text}")
-                    return False
+            # 使用正则提取第一个数字序列，例如 "6人", "6人在线", "在线 10 人" -> 6, 6, 10
+            match = re.search(r'(\d+)', user_count_text)
+            if not match:
+                self.logger.warning(f"无法解析人数文本: {user_count_text}")
+                return False
+
+            try:
+                user_count = int(match.group(1))
+            except ValueError:
+                # 理论上正则匹配到 \d+ 应该不会转换失败，但为了严谨增加异常处理
+                self.logger.warning(f"无法将提取的文本转换为整数: {match.group(1)}")
+                return False
 
             # 更新 InfoManager 中的在线人数
             from ushareiplay.managers.info_manager import InfoManager

--- a/tests/test_user_count_event.py
+++ b/tests/test_user_count_event.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from ushareiplay.events.user_count import UserCountEvent
+
+@pytest.mark.asyncio
+async def test_user_count_parsing_formats():
+    mock_handler = MagicMock()
+    mock_handler.logger = MagicMock()
+    event = UserCountEvent(handler=mock_handler)
+    mock_wrapper = MagicMock()
+    
+    test_cases = [
+        ("6人", 6),
+        ("6人在线", 6), # This will fail with current implementation
+        ("123", 123),
+        ("在线 10 人", 10),
+    ]
+    
+    with patch("ushareiplay.managers.info_manager.InfoManager.instance") as mock_instance:
+        mock_info = MagicMock()
+        mock_info.user_count = 0
+        mock_info.refresh_online_users = AsyncMock()
+        mock_instance.return_value = mock_info
+        
+        for input_text, expected_count in test_cases:
+            mock_wrapper.text = input_text
+            mock_info.user_count = -1 # Reset to ensure update
+            await event.handle("user_count", mock_wrapper)
+            assert mock_info.user_count == expected_count, f"Failed to parse '{input_text}'"
+
+@pytest.mark.asyncio
+async def test_user_count_parsing_failure():
+    mock_handler = MagicMock()
+    mock_handler.logger = MagicMock()
+    event = UserCountEvent(handler=mock_handler)
+    mock_wrapper = MagicMock()
+    
+    failure_cases = ["", "无数据", "unknown"]
+    
+    with patch("ushareiplay.managers.info_manager.InfoManager.instance") as mock_instance:
+        mock_info = MagicMock()
+        mock_info.user_count = 0
+        mock_instance.return_value = mock_info
+        
+        for input_text in failure_cases:
+            mock_wrapper.text = input_text
+            result = await event.handle("user_count", mock_wrapper)
+            assert result is False
+            assert mock_info.user_count == 0 # Should not change


### PR DESCRIPTION
## Summary
- Updated `UserCountEvent` to use regex for parsing online user count, supporting both 'x人' and 'x人在线' formats.
- Updated `config.yaml` with the correct `user_count` selector ID (`tvOnlineCount`).
- Added unit tests in `tests/test_user_count_event.py` to verify parsing logic.

## Test Plan
- [x] Ran `PYTHONPATH=src pytest tests/test_user_count_event.py` (PASSED)
- [x] Verified parsing for '6人', '6人在线', '123', and '在线 10 人' formats.
