### PR TITLE
fix: update soul mic button selector and suppress qqmusic stale element logs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,7 +69,7 @@ soul:
     grab_mic: "cn.soulapp.android:id/ivUpSeat"
     confirm_mic: "//android.widget.TextView[@resource-id='cn.soulapp.android:id/tv_btn' and @text='确认']"
     confirm_close: "//android.widget.TextView[@resource-id='cn.soulapp.android:id/tv_btn' and @text='确定']"
-    toggle_mic: "cn.soulapp.android:id/ivMicButton"
+    toggle_mic: "cn.soulapp.android:id/micBtn" # 开麦按钮/闭麦按钮
     square_tab: "cn.soulapp.android:id/main_tab_square"
     party_tab: "//android.widget.LinearLayout[@content-desc='派对']"
     no_party_from_home: "cn.soulapp.android:id/tvEmptyContent"

--- a/src/ushareiplay/handlers/qq_music_handler.py
+++ b/src/ushareiplay/handlers/qq_music_handler.py
@@ -574,7 +574,7 @@ class QQMusicHandler(AppHandler, Singleton):
                     self.logger.info(f"Scrolled playlist from y={start_y} to y={end_y}")
 
         except StaleElementReferenceException as e:
-            self.logger.warning(f"Playing indicator invisible in playlist playing, {traceback.format_exc()}")
+            self.logger.warning("Playing indicator invisible in playlist playing")
 
         # Get all songs and singers
 
@@ -605,8 +605,7 @@ class QQMusicHandler(AppHandler, Singleton):
                 continue
 
         if not playlist_info:
-            self.logger.error("No songs found in playlist")
-            return {'error': 'No songs found in playlist'}
+            self.logger.warning("No songs found in playlist")
 
         self.logger.info(f"Found {len(playlist_info)} songs in playlist")
         return {'playlist': '\n'.join(playlist_info)}


### PR DESCRIPTION
Update the selector for the mic button in Soul and reduce log noise in QQMusic handler by suppressing stale element reference tracebacks and downgrading empty playlist errors to warnings.