### PR TITLE
fix: ensure Soul app is active before checking mic status

### DIFF
--- a/src/ushareiplay/handlers/soul_handler.py
+++ b/src/ushareiplay/handlers/soul_handler.py
@@ -90,6 +90,7 @@ class SoulHandler(AppHandler, Singleton):
     def ensure_mic_active(self):
         """Ensure the microphone is active"""
         try:
+            self.switch_to_app()
             # Check if the grab mic button is present
             grab_mic_button = self.try_find_element_plus('grab_mic', log=False)
 


### PR DESCRIPTION
## Summary

- 在 `SoulHandler.ensure_mic_active()` 开头调用 `switch_to_app()`，确保检查/抢麦前 Soul 已在前台，避免在 QQ 音乐等其它 App 前台时误判 UI 状态。

## Test plan

- [ ] 在 QQ 音乐前台时触发 ensure mic，确认会先切回 Soul 再查找抢麦/开麦按钮
- [ ] Soul 已在前台时行为与改前一致

Made with [Cursor](https://cursor.com)