### PR TITLE
feat: add dollar-prefix private command reply flow

### DIFF
--- a/docs/superpowers/plans/2026-05-21-private-reply-command.md
+++ b/docs/superpowers/plans/2026-05-21-private-reply-command.md
@@ -1,0 +1,261 @@
+# Private Reply Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `$` command prefix support so command execution output is delivered via Soul private chat to the triggering user, while default command confirmation stays in public chat.
+
+**Architecture:** Extend command message metadata with a private-reply flag, detect and normalize `$` in command parsing flow, and route command output through a dedicated private sender helper. Keep existing command modules unchanged and enforce silent-stop behavior when private delivery setup/send fails.
+
+**Tech Stack:** Python, Appium/Selenium wrappers in existing handlers, `pytest`, `unittest.mock`.
+
+---
+
+### Task 1: Add Private-Reply Metadata and Prefix Normalization
+
+**Files:**
+- Modify: `src/ushareiplay/models/message_info.py`
+- Modify: `src/ushareiplay/managers/command_manager.py`
+- Modify: `src/ushareiplay/managers/message_manager.py`
+- Test: `tests/test_command_manager_runtime_context.py`
+
+- [ ] **Step 1: Write failing tests for `$` normalization and routing metadata**
+
+```python
+def test_normalize_command_candidate_private_prefix():
+    manager = CommandManager.instance()
+    private_reply, normalized = manager._extract_private_reply_and_normalize("  $play abc")
+    assert private_reply is True
+    assert normalized == "play abc"
+
+def test_normalize_command_candidate_regular_prefix():
+    manager = CommandManager.instance()
+    private_reply, normalized = manager._extract_private_reply_and_normalize(" :help")
+    assert private_reply is False
+    assert normalized == "help"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest -q tests/test_command_manager_runtime_context.py -k private_prefix`
+Expected: FAIL because `_extract_private_reply_and_normalize` does not exist.
+
+- [ ] **Step 3: Implement metadata and normalization**
+
+```python
+@dataclass
+class MessageInfo:
+    content: str
+    nickname: str
+    silent: bool = False
+    private_reply: bool = False
+```
+
+```python
+def _extract_private_reply_and_normalize(self, raw: str) -> tuple[bool, str]:
+    s = (raw or "").lstrip()
+    private_reply = bool(s) and s[0] == "$"
+    if private_reply:
+        s = s[1:].lstrip()
+    if s and s[0] in COMMAND_PREFIXES:
+        s = s[1:]
+    return private_reply, s.lstrip()
+```
+
+- [ ] **Step 4: Wire parser flow to preserve `private_reply` on each invocation**
+
+Use `_extract_private_reply_and_normalize` in `handle_message_commands` and combine with existing `message_info.private_reply` if already set upstream.
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest -q tests/test_command_manager_runtime_context.py`
+Expected: PASS for new private-prefix tests and no regression in existing tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ushareiplay/models/message_info.py src/ushareiplay/managers/command_manager.py src/ushareiplay/managers/message_manager.py tests/test_command_manager_runtime_context.py
+git commit -m "feat: add private-reply command metadata and prefix normalization"
+```
+
+---
+
+### Task 2: Implement Private Message Sender for Soul UI Flow
+
+**Files:**
+- Modify: `src/ushareiplay/managers/user_manager.py`
+- Test: `tests/test_private_reply_sender.py`
+
+- [ ] **Step 1: Write failing tests for private send sequence**
+
+```python
+def test_send_private_message_success_uses_avatar_chat_input_send_and_return(...):
+    ...
+
+def test_send_private_message_fallback_to_floating_entry_when_lottie_missing(...):
+    ...
+
+def test_send_private_message_failure_returns_false_without_raise(...):
+    ...
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `uv run pytest -q tests/test_private_reply_sender.py`
+Expected: FAIL because `send_private_message_to_user` is not implemented.
+
+- [ ] **Step 3: Implement private sender in `UserManager`**
+
+Add `send_private_message_to_user(nickname: str, message: str) -> bool`:
+- Reuse `open_user_profile_from_online_list`.
+- Click `cn.soulapp.android:id/ivAvatar`.
+- Click `cn.soulapp.android:id/tv_chat_secret`.
+- Input at `cn.soulapp.android:id/et_sendmessage`.
+- Click `cn.soulapp.android:id/btn_send`.
+- Return by clicking `cn.soulapp.android:id/lottie_in_party` or `floating_entry`.
+- Return `False` on any failure, log details, never throw.
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest -q tests/test_private_reply_sender.py`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ushareiplay/managers/user_manager.py tests/test_private_reply_sender.py
+git commit -m "feat: add Soul private message sender with room-return fallback"
+```
+
+---
+
+### Task 3: Route `$` Command Outputs to Private Sender
+
+**Files:**
+- Modify: `src/ushareiplay/managers/command_manager.py`
+- Test: `tests/test_command_manager_runtime_context.py`
+
+- [ ] **Step 1: Write failing tests for output routing**
+
+```python
+@pytest.mark.asyncio
+async def test_private_reply_keeps_public_confirmation_and_private_result(...):
+    # confirmation -> handler.send_message called
+    # result -> user_manager.send_private_message_to_user called
+    ...
+
+@pytest.mark.asyncio
+async def test_private_reply_routes_error_output_to_private(...):
+    ...
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `uv run pytest -q tests/test_command_manager_runtime_context.py -k private_reply`
+Expected: FAIL because output routing still uses only public sender.
+
+- [ ] **Step 3: Implement routing helpers in `CommandManager`**
+
+Add focused helpers:
+- `_send_confirmation_message(...)` always public (respect existing silent command behavior).
+- `_send_command_output(...)` routes to private sender if `private_reply=True`; otherwise public.
+- When private sender returns `False`, stop additional output attempts for current command flow.
+
+- [ ] **Step 4: Keep compatibility with silent slash commands**
+
+Ensure `/` behavior remains unchanged and does not regress; only `$` changes output channel.
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest -q tests/test_command_manager_runtime_context.py tests/test_command_manager_silent_commands.py`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ushareiplay/managers/command_manager.py tests/test_command_manager_runtime_context.py
+git commit -m "feat: route dollar-prefixed command output to private chat"
+```
+
+---
+
+### Task 4: Ensure Missed/Realtime Message Parsing Accepts `$`
+
+**Files:**
+- Modify: `src/ushareiplay/managers/message_manager.py`
+- Test: `tests/test_runtime_queue_pipeline.py`
+
+- [ ] **Step 1: Write failing tests for `$` messages entering command pipeline**
+
+```python
+@pytest.mark.asyncio
+async def test_process_new_messages_accepts_dollar_prefix(...):
+    ...
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `uv run pytest -q tests/test_runtime_queue_pipeline.py -k dollar`
+Expected: FAIL because regex only accepts `[:：/／]`.
+
+- [ ] **Step 3: Expand prefix parsing to include `$`**
+
+Update regex/prefix handling in `process_new_messages` and `process_missed_messages` so `$` commands are accepted and preserve content for downstream normalization.
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest -q tests/test_runtime_queue_pipeline.py tests/test_message_manager*.py`
+Expected: PASS (or run the closest existing message-manager test module names in repo).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ushareiplay/managers/message_manager.py tests/test_runtime_queue_pipeline.py
+git commit -m "feat: accept dollar-prefixed commands in message ingestion"
+```
+
+---
+
+### Task 5: Regression Verification and Documentation Sync
+
+**Files:**
+- Modify: `docs/users.md` (only if command prefix behavior is documented there)
+- Modify: `README.md` (only if command prefix behavior is documented there)
+
+- [ ] **Step 1: Run focused regression suite**
+
+Run:
+- `uv run pytest -q tests/test_command_manager_runtime_context.py`
+- `uv run pytest -q tests/test_command_manager_silent_commands.py`
+- `uv run pytest -q tests/test_runtime_queue_pipeline.py`
+- `uv run pytest -q tests/test_private_reply_sender.py`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run broader command pipeline sanity**
+
+Run: `uv run pytest -q tests/test_command_manager_*.py tests/test_simple_command_modules_class_only.py tests/test_stateful_command_modules_class_only.py`
+Expected: PASS.
+
+- [ ] **Step 3: Update docs if needed**
+
+Document `$` prefix semantics:
+- Public confirmation remains public.
+- Execution outputs are private.
+- Private setup/send failure is silent (no public fallback).
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add docs/users.md README.md
+git commit -m "docs: document dollar-prefix private reply behavior"
+```
+
+Only include files actually changed.
+
+---
+
+## Notes for Implementers
+- Keep changes scoped to routing and sender helper; avoid refactoring unrelated command architecture.
+- Preserve existing logging style and resilience patterns.
+- Do not introduce public fallback output on private-send failures.
+- Ensure selector usage is centralized and consistent with existing handler conventions.

--- a/docs/superpowers/specs/2026-05-21-private-reply-command-design.md
+++ b/docs/superpowers/specs/2026-05-21-private-reply-command-design.md
@@ -1,0 +1,134 @@
+# Design Spec: Private Reply Command Prefix
+
+**Date:** 2026-05-21
+**Status:** Draft
+**Topic:** Route command output to private chat with `$` prefix
+
+## 1. Problem Description
+Soul public chat risk controls are strict enough that normal command results can fail to send or contribute to account risk even when the content is not sensitive. Existing command replies go to the public room by default, which creates avoidable public-message volume and makes command results less reliable.
+
+The system needs a way for a user to request command results privately while keeping the command execution path efficient and avoiding unnecessary public fallback messages.
+
+## 2. Proposed Solution
+Add `$` as a command prefix modifier that routes command output to the triggering user through Soul private chat.
+
+`$` is not a new command namespace. `$play song` should execute the existing `play` command and mark that command invocation as requiring private replies.
+
+### 2.1. Public Confirmation Behavior
+- The default command confirmation message remains public for efficiency and operational visibility.
+- Only command execution output is private in `$` mode.
+- Command output includes success responses, error responses, parameter validation messages, and help-style command responses that would otherwise be sent to the public room.
+
+### 2.2. Private Reply Behavior
+For each private output message:
+
+1. Open the online user list.
+2. Open the triggering user's info page using the existing online-user lookup flow.
+3. Click the user avatar: `cn.soulapp.android:id/ivAvatar`.
+4. Click the private chat button: `cn.soulapp.android:id/tv_chat_secret`.
+5. Click the message input: `cn.soulapp.android:id/et_sendmessage`.
+6. Enter the output message.
+7. Click send: `cn.soulapp.android:id/btn_send`.
+8. Return to the chat room by clicking either:
+   - `cn.soulapp.android:id/lottie_in_party`
+   - existing `floating_entry`
+
+The system should attempt this full lookup and navigation sequence for each private output message. If the user leaves between multiple outputs, the first failed private send stops any later private sends for that command flow.
+
+### 2.3. Failure Behavior
+- If the system cannot enter private chat before sending the first private output, it should stop silently.
+- It must not send a public error fallback for private-reply setup failures.
+- Failures should be logged for troubleshooting.
+- If one private output fails, later outputs in the same command flow should not continue.
+
+This follows the product principle for this change: if a message is not necessary for public chat, do not send it publicly.
+
+### 2.4. Prefix Semantics
+- Existing public prefixes remain unchanged: `:` and `：`.
+- Existing silent slash prefixes remain unchanged: `/` and `／`.
+- `$` marks the invocation as private reply mode and strips the `$` before normal command parsing.
+- The first version supports `$command` only. Combined forms such as `$/command` are intentionally out of scope to keep command routing predictable.
+
+## 3. Implementation Details
+
+### 3.1. Data Model
+Extend `MessageInfo` with a private-reply flag, for example:
+
+```python
+private_reply: bool = False
+```
+
+This keeps routing metadata attached to the message without changing command modules.
+
+### 3.2. Command Parsing and Dispatch
+Update command ingestion and dispatch so messages beginning with `$` are accepted as command candidates.
+
+Expected flow:
+
+1. Detect `$` at message ingestion or command-manager normalization.
+2. Set `MessageInfo.private_reply = True`.
+3. Strip `$`.
+4. Continue parsing the remaining content through the existing command parser.
+5. Send the normal public confirmation message.
+6. Route command result output through the private sender instead of `handler.send_message`.
+
+### 3.3. Private Sender
+Add a focused manager/helper for private chat output. It should use existing Soul UI helper methods and existing `UserManager.open_user_profile_from_online_list()` for user lookup.
+
+The helper should return a boolean success indicator. `False` means no more private outputs should be attempted for that command flow.
+
+### 3.4. UI Selectors
+The private sender needs selectors for:
+
+- Avatar: `cn.soulapp.android:id/ivAvatar`
+- Private chat button: `cn.soulapp.android:id/tv_chat_secret`
+- Message input: `cn.soulapp.android:id/et_sendmessage`
+- Send button: `cn.soulapp.android:id/btn_send`
+- In-party return button: `cn.soulapp.android:id/lottie_in_party`
+- Existing floating return entry: `floating_entry`
+
+Selectors should be configured consistently with the existing `config.yaml` selector structure when possible.
+
+## 4. Testing Strategy
+
+### 4.1. Unit Tests
+Add focused tests around command routing:
+
+- `$play song` is recognized as a valid command invocation.
+- `$play song` parses and dispatches as `play` with `private_reply=True`.
+- Public confirmation is still sent for `$` commands.
+- Command result output uses the private sender instead of public `send_message`.
+- Command errors use the private sender instead of public `send_message`.
+- If the private sender returns `False`, later private outputs are not attempted.
+- Existing `:`, `：`, `/`, and `／` behavior remains unchanged.
+
+### 4.2. UI Helper Tests
+Use mocks around the handler and user manager to verify the private sender sequence:
+
+- Opens target user from the online list.
+- Clicks avatar.
+- Opens private chat.
+- Sends text through the private input and send button.
+- Returns to the room using `lottie_in_party` when available.
+- Falls back to `floating_entry` when `lottie_in_party` is unavailable.
+- Returns `False` without public fallback when any required step fails.
+
+### 4.3. Manual/E2E Validation
+Real-device validation is required because this feature depends on Soul UI navigation:
+
+- Trigger a `$` command from an online user and verify the public room only shows the confirmation.
+- Verify the command result appears in private chat.
+- Trigger a command that returns an error and verify the error appears in private chat.
+- Have the user leave before output sends and verify no public fallback is posted.
+
+## 5. Out of Scope
+- Supporting combined prefix forms such as `$/play`.
+- Making all command progress messages private if they bypass `CommandManager` and call `handler.send_message` directly from inside a command.
+- Retrying private sends after user lookup fails.
+- Publicly notifying other users that private delivery failed.
+
+## 6. Design Review Notes
+- **Architecture:** Keep the behavior in command routing and a private sender helper so existing command modules remain mostly unchanged.
+- **Risk Control:** Public chat volume is minimized. Failure paths avoid public fallback messages.
+- **Reliability:** Each private send revalidates online presence through the online user list, so later outputs stop when the user leaves.
+- **Observability:** Failures are logged instead of posted publicly.

--- a/scripts/agent_e2e.py
+++ b/scripts/agent_e2e.py
@@ -168,11 +168,12 @@ def start_service() -> subprocess.Popen[bytes]:
     return proc
 
 
-def write_spool_command(line: str) -> Path:
+def write_spool_command(line: str, *, nickname: str = "Console") -> Path:
     COMMAND_SPOOL_DIR.mkdir(parents=True, exist_ok=True)
     target = COMMAND_SPOOL_DIR / f"{int(_now() * 1000)}-{uuid.uuid4().hex[:8]}.cmd"
     tmp = target.with_suffix(".tmp")
-    tmp.write_text(line.rstrip("\n") + "\n", encoding="utf-8")
+    payload = {"content": line.rstrip("\n"), "nickname": nickname}
+    tmp.write_text(json.dumps(payload, ensure_ascii=False) + "\n", encoding="utf-8")
     tmp.replace(target)
     return target
 
@@ -321,11 +322,35 @@ def inject(proc: subprocess.Popen[bytes], line: str) -> None:
     proc.stdin.flush()
 
 
-def inject_via_channel(proc: Optional[subprocess.Popen[bytes]], line: str) -> Tuple[str, Optional[Path]]:
-    if proc is not None:
+def inject_via_channel(
+    proc: Optional[subprocess.Popen[bytes]],
+    line: str,
+    *,
+    nickname: str = "Console",
+) -> Tuple[str, Optional[Path]]:
+    if proc is not None and nickname == "Console":
         inject(proc, line)
         return "stdin", None
-    return "agent_spool", write_spool_command(line)
+    try:
+        return "agent_spool", write_spool_command(line, nickname=nickname)
+    except TypeError:
+        return "agent_spool", write_spool_command(line)
+
+
+def resolve_injection_nickname(command: str, nickname: str) -> str:
+    """
+    Dollar-prefixed command tests should simulate a real online user.
+
+    The injected command source is typically the group owner, but the owner
+    cannot private-message themselves. For `$` / `＄` command flows we default
+    the sender to `Outlier` unless the caller explicitly overrides it.
+    """
+    if nickname != "Console":
+        return nickname
+    trimmed = (command or "").lstrip()
+    if trimmed.startswith(("$", "＄")):
+        return "Outlier"
+    return nickname
 
 
 def choose_lifecycle(
@@ -590,6 +615,7 @@ def run_db_queries(db_path: Path, queries: List[str]) -> List[Tuple[str, List[Tu
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Agent-friendly E2E runner for UShareIPlay (closed loop).")
     parser.add_argument("--command", default="", help="Injected console command, e.g. ':help'. If empty, will prompt in TTY.")
+    parser.add_argument("--nickname", default="Console", help="Nickname attached to injected command messages")
     parser.add_argument("--startup-timeout", type=float, default=120.0, help="Seconds to wait artifacts appear")
     parser.add_argument("--ready-timeout", type=float, default=180.0, help="Seconds to wait CommandReady")
     parser.add_argument("--assert-timeout", type=float, default=90.0, help="Seconds to wait command result events")
@@ -694,7 +720,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         if args.mode == "full" and run is not None:
             last_status = wait_command_ready(run.status_json, timeout_s=args.ready_timeout)
             event_offset = run.events_jsonl.stat().st_size if run.events_jsonl.exists() else 0
-            injection_channel, _spool_path = inject_via_channel(proc, args.command)
+            injection_nickname = resolve_injection_nickname(args.command, args.nickname)
+            injection_channel, _spool_path = inject_via_channel(
+                proc,
+                args.command,
+                nickname=injection_nickname,
+            )
             assertion = assert_command_flow(
                 run.events_jsonl,
                 injected=args.command,
@@ -703,10 +734,10 @@ def main(argv: Optional[List[str]] = None) -> int:
             )
             needs_dump = args.dump_after_command or bool(args.expect_page_source_text) or args.require_screenshot
             if needs_dump:
-                inject_via_channel(proc, "!dump")
+                inject_via_channel(proc, "!dump", nickname="Console")
                 time.sleep(1.0)
             if (not assertion.get("ok")) and args.dump_on_fail:
-                inject_via_channel(proc, "!dump")
+                inject_via_channel(proc, "!dump", nickname="Console")
                 # give it a little time to flush to disk
                 time.sleep(1.0)
 

--- a/src/ushareiplay/core/app_controller.py
+++ b/src/ushareiplay/core/app_controller.py
@@ -410,10 +410,16 @@ class AppController(Singleton):
                 try:
                     while not self.input_queue.empty():
                         item = self.input_queue.get_nowait()
-                        if isinstance(item, tuple):
+                        if isinstance(item, dict):
+                            message = item.get("content", "")
+                            input_source = item.get("source", "console")
+                            nickname = item.get("nickname", "Console")
+                        elif isinstance(item, tuple):
                             message, input_source = item
+                            nickname = "Console"
                         else:
                             message, input_source = item, "console"
+                            nickname = "Console"
                         # Only send non-empty messages
                         if message.strip():
                             if message == '!stop':
@@ -439,12 +445,12 @@ class AppController(Singleton):
                                 # Allow leading whitespace and spaces after colon.
                                 # Keep the queued content in its original (colon-triggered) form.
                                 trimmed = message.lstrip()
-                                if trimmed and trimmed[0] in (':', '：', '/', '／') and trimmed[1:].strip():
+                                if trimmed and trimmed[0] in (':', '：', '/', '／', '$', '＄') and trimmed[1:].strip():
                                     # Create MessageInfo for queue
                                     from ushareiplay.models.message_info import MessageInfo
                                     message_info = MessageInfo(
                                         content=trimmed,
-                                        nickname="Console"
+                                        nickname=nickname
                                     )
 
                                     # Add message to queue

--- a/src/ushareiplay/core/runtime_services.py
+++ b/src/ushareiplay/core/runtime_services.py
@@ -1,6 +1,7 @@
 import re
 import traceback
 from pathlib import Path
+import json
 
 from ushareiplay.core.message_queue import MessageQueue
 from ushareiplay.models.message_info import MessageInfo
@@ -74,7 +75,7 @@ class AgentCommandSpool:
             self.command_dir.mkdir(parents=True, exist_ok=True)
             for path in sorted(self.command_dir.glob("*.cmd")):
                 try:
-                    message = path.read_text(encoding="utf-8").rstrip("\r\n")
+                    raw = path.read_text(encoding="utf-8").rstrip("\r\n")
                     path.unlink(missing_ok=True)
                 except Exception:
                     if self.obs:
@@ -84,13 +85,34 @@ class AgentCommandSpool:
                             ctx={"path": str(path), "error": traceback.format_exc()},
                         )
                     continue
-                if message and message.strip():
-                    self.input_queue.put((message, "agent_spool"))
-                    if self.obs:
-                        self.obs.emit(
-                            "agent.inject.received",
-                            ctx={"source": "agent_spool", "content": message},
-                        )
+                if not raw or not raw.strip():
+                    continue
+
+                payload = None
+                try:
+                    parsed = json.loads(raw)
+                except Exception:
+                    parsed = None
+
+                if isinstance(parsed, dict) and parsed.get("content"):
+                    payload = {
+                        "content": str(parsed.get("content")),
+                        "source": "agent_spool",
+                        "nickname": str(parsed.get("nickname") or "Console"),
+                    }
+                else:
+                    payload = {"content": raw, "source": "agent_spool", "nickname": "Console"}
+
+                self.input_queue.put(payload)
+                if self.obs:
+                    self.obs.emit(
+                        "agent.inject.received",
+                        ctx={
+                            "source": "agent_spool",
+                            "content": payload["content"],
+                            "nickname": payload["nickname"],
+                        },
+                    )
         except Exception:
             if self.obs:
                 self.obs.emit(

--- a/src/ushareiplay/managers/command_manager.py
+++ b/src/ushareiplay/managers/command_manager.py
@@ -10,7 +10,7 @@ from ushareiplay.core.command_parser import CommandParser
 
 COMMAND_PREFIXES = (":", "：", "/", "／")
 SILENT_COMMAND_PREFIXES = ("/", "／")
-PRIVATE_REPLY_PREFIX = "$"
+PRIVATE_REPLY_PREFIXES = ("$", "＄")
 
 
 class CommandManager(Singleton):
@@ -367,14 +367,14 @@ class CommandManager(Singleton):
         s = (raw or "").lstrip()
         if not s:
             return False, ""
-        private_reply = s.startswith(PRIVATE_REPLY_PREFIX)
+        private_reply = s.startswith(PRIVATE_REPLY_PREFIXES)
         if private_reply:
             s = s[1:]
         return private_reply, self._normalize_command_candidate(s)
 
     def _is_silent_command_candidate(self, raw: str) -> bool:
         s = (raw or "").lstrip()
-        if s.startswith(PRIVATE_REPLY_PREFIX):
+        if s.startswith(PRIVATE_REPLY_PREFIXES):
             s = s[1:].lstrip()
         return bool(s) and s[0] in SILENT_COMMAND_PREFIXES
 

--- a/src/ushareiplay/managers/command_manager.py
+++ b/src/ushareiplay/managers/command_manager.py
@@ -10,6 +10,7 @@ from ushareiplay.core.command_parser import CommandParser
 
 COMMAND_PREFIXES = (":", "：", "/", "／")
 SILENT_COMMAND_PREFIXES = ("/", "／")
+PRIVATE_REPLY_PREFIX = "$"
 
 
 class CommandManager(Singleton):
@@ -177,6 +178,30 @@ class CommandManager(Singleton):
             return None
         return self.handler.send_message(message)
 
+    def _send_command_output(self, message_info, response: str, silent: bool = False):
+        """Route command execution output to private chat or screen."""
+        if not response:
+            return None
+        if getattr(message_info, "private_reply", False):
+            try:
+                from ushareiplay.managers.user_manager import UserManager
+
+                sent = UserManager.instance().send_private_message_to_user(
+                    message_info.nickname,
+                    response,
+                )
+                if not sent:
+                    self.logger.warning(
+                        f"Private reply dropped for {message_info.nickname}: send failed"
+                    )
+                return sent
+            except Exception:
+                self.logger.error(
+                    f"Private reply failed for {message_info.nickname}: {traceback.format_exc()}"
+                )
+                return False
+        return self._send_screen_message(response, silent=silent)
+
     async def process_command(self, command, message_info, command_info):
         """Process command using module if available
         Args:
@@ -332,8 +357,25 @@ class CommandManager(Singleton):
             s = s[1:]
         return s.lstrip()
 
+    def _extract_private_reply_and_normalize(self, raw: str) -> tuple[bool, str]:
+        """
+        Extract private-reply marker and normalize command candidate.
+
+        Returns:
+            tuple[bool, str]: (private_reply, normalized_command_content)
+        """
+        s = (raw or "").lstrip()
+        if not s:
+            return False, ""
+        private_reply = s.startswith(PRIVATE_REPLY_PREFIX)
+        if private_reply:
+            s = s[1:]
+        return private_reply, self._normalize_command_candidate(s)
+
     def _is_silent_command_candidate(self, raw: str) -> bool:
         s = (raw or "").lstrip()
+        if s.startswith(PRIVATE_REPLY_PREFIX):
+            s = s[1:].lstrip()
         return bool(s) and s[0] in SILENT_COMMAND_PREFIXES
 
     async def handle_message_commands(self, messages):
@@ -355,10 +397,15 @@ class CommandManager(Singleton):
                 continue
 
             # Normalize command input (tolerate leading spaces and spaces after colon)
+            extracted_private_reply, content = self._extract_private_reply_and_normalize(
+                message_info.content
+            )
+            message_info.private_reply = bool(
+                getattr(message_info, "private_reply", False)
+            ) or extracted_private_reply
             silent = bool(getattr(message_info, "silent", False)) or self._is_silent_command_candidate(
                 message_info.content
             )
-            content = self._normalize_command_candidate(message_info.content)
             if not content:
                 continue
 
@@ -378,7 +425,7 @@ class CommandManager(Singleton):
                     if command:
                         response = await self.process_command(command, message_info, command_info)
                         if response:
-                            self._send_screen_message(response, silent=silent)
+                            self._send_command_output(message_info, response, silent=silent)
                         success_count += 1
                     else:
                         self.logger.error(f"Unknown command: {cmd}")

--- a/src/ushareiplay/managers/message_manager.py
+++ b/src/ushareiplay/managers/message_manager.py
@@ -16,7 +16,7 @@ from ushareiplay.core.singleton import Singleton
 from ushareiplay.managers.recovery_manager import RecoveryManager
 from ushareiplay.models.message_info import MessageInfo
 
-COMMAND_PREFIX_CHARS = ":：/／"
+COMMAND_PREFIX_CHARS = ":：/／$"
 
 # Global chat logger - will be initialized when needed
 chat_logger = None
@@ -168,7 +168,7 @@ class MessageManager(Singleton):
                 continue
 
             # Parse message content using pattern
-            pattern = r'souler\[(.+)\]说：\s*([:：/／])\s*(.+)'
+            pattern = r'souler\[(.+)\]说：\s*([:：/／$])\s*(.+)'
 
             match = re.match(pattern, chat)
             if not match:
@@ -201,7 +201,7 @@ class MessageManager(Singleton):
 
         messages = []
         for chat in self.latest_chats:
-            pattern = r'souler\[(.+)\]说：\s*([:：/／])\s*(.+)'
+            pattern = r'souler\[(.+)\]说：\s*([:：/／$])\s*(.+)'
 
             match = re.match(pattern, chat)
             if not match:

--- a/src/ushareiplay/managers/user_manager.py
+++ b/src/ushareiplay/managers/user_manager.py
@@ -1,4 +1,6 @@
 """用户管理器：在在线列表中查找用户并打开其信息页等"""
+from appium.webdriver.common.appiumby import AppiumBy
+
 from ushareiplay.core.singleton import Singleton
 
 YELLOW_DUCK_NAME = "小黄鸭"  # 礼物列表兜底礼物，固定为列表首位，点击即送无需点赠送
@@ -144,6 +146,93 @@ class UserManager(Singleton):
         # self.handler.press_back()
         self._close_online_drawer()
         return {'success': f'{gift_name} 送你啦'}
+
+    def send_private_message_to_user(self, nickname: str, message: str) -> bool:
+        """
+        向指定用户发送私聊消息。
+
+        流程：
+        1. 在线列表打开用户信息页
+        2. 点击头像进入主页
+        3. 点击私聊按钮进入私聊页
+        4. 输入并发送消息
+        5. 返回聊天室（优先 lottie_in_party，兜底 floating_entry）
+
+        任意一步失败返回 False，不抛异常。
+        """
+        try:
+            open_result = self.open_user_profile_from_online_list(nickname)
+            if 'error' in open_result:
+                self.logger.warning(f"打开用户资料页失败: {nickname}, error={open_result['error']}")
+                return False
+
+            avatar = self.handler.wait_for_element_clickable(
+                AppiumBy.ID,
+                'cn.soulapp.android:id/ivAvatar',
+                timeout=5,
+            )
+            if not avatar:
+                self.logger.warning(f"未找到头像入口: {nickname}")
+                return False
+            avatar.click()
+
+            private_chat_btn = self.handler.wait_for_element_clickable(
+                AppiumBy.ID,
+                'cn.soulapp.android:id/tv_chat_secret',
+                timeout=5,
+            )
+            if not private_chat_btn:
+                self.logger.warning(f"未找到私聊按钮: {nickname}")
+                return False
+            private_chat_btn.click()
+
+            input_box = self.handler.wait_for_element_clickable(
+                AppiumBy.ID,
+                'cn.soulapp.android:id/et_sendmessage',
+                timeout=5,
+            )
+            if not input_box:
+                self.logger.warning(f"未找到私聊输入框: {nickname}")
+                return False
+            input_box.send_keys(message)
+
+            send_button = self.handler.wait_for_element_clickable(
+                AppiumBy.ID,
+                'cn.soulapp.android:id/btn_send',
+                timeout=5,
+            )
+            if not send_button:
+                self.logger.warning(f"未找到私聊发送按钮: {nickname}")
+                return False
+            send_button.click()
+
+            return self._return_to_room_after_private_chat(nickname)
+        except Exception as e:
+            self.logger.error(f"私聊发送失败: {nickname}, error={e}")
+            return False
+
+    def _return_to_room_after_private_chat(self, nickname: str) -> bool:
+        """私聊发送后返回聊天室。"""
+        try:
+            room_entry = self.handler.wait_for_element_clickable(
+                AppiumBy.ID,
+                'cn.soulapp.android:id/lottie_in_party',
+                timeout=3,
+            )
+            if room_entry:
+                room_entry.click()
+                return True
+
+            floating_entry = self.handler.wait_for_element_clickable_plus('floating_entry', timeout=3)
+            if floating_entry:
+                floating_entry.click()
+                return True
+
+            self.logger.warning(f"未找到返回聊天室入口: {nickname}")
+            return False
+        except Exception as e:
+            self.logger.error(f"返回聊天室失败: {nickname}, error={e}")
+            return False
 
     def _close_online_drawer(self):
         """关闭在线用户抽屉"""

--- a/src/ushareiplay/models/message_info.py
+++ b/src/ushareiplay/models/message_info.py
@@ -7,3 +7,4 @@ class MessageInfo:
     content: str
     nickname: str
     silent: bool = False
+    private_reply: bool = False

--- a/tests/test_agent_e2e_runner_lifecycle.py
+++ b/tests/test_agent_e2e_runner_lifecycle.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import os
 import sys
 from pathlib import Path
@@ -106,3 +107,39 @@ def test_reused_process_injection_failure_is_explicit(monkeypatch):
         assert "spool unavailable" in str(exc)
     else:
         raise AssertionError("expected injection failure")
+
+
+def test_inject_via_channel_carries_nickname_into_spool(tmp_path, monkeypatch):
+    runner = _load_runner()
+    monkeypatch.setattr(runner, "COMMAND_SPOOL_DIR", tmp_path / ".agent" / "commands")
+    runner._ensure_agent_dir()
+
+    channel, path = runner.inject_via_channel(None, ":help", nickname="Outlier")
+
+    assert channel == "agent_spool"
+    assert path is not None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload == {"content": ":help", "nickname": "Outlier"}
+
+
+def test_inject_via_channel_forces_spool_for_non_console_nickname(tmp_path, monkeypatch):
+    runner = _load_runner()
+    monkeypatch.setattr(runner, "COMMAND_SPOOL_DIR", tmp_path / ".agent" / "commands")
+    runner._ensure_agent_dir()
+
+    class _Proc:
+        stdin = object()
+
+    channel, path = runner.inject_via_channel(_Proc(), ":help", nickname="Outlier")
+
+    assert channel == "agent_spool"
+    assert path is not None
+
+
+def test_resolve_injection_nickname_uses_outlier_for_dollar_commands():
+    runner = _load_runner()
+
+    assert runner.resolve_injection_nickname("$info", "Console") == "Outlier"
+    assert runner.resolve_injection_nickname("＄info", "Console") == "Outlier"
+    assert runner.resolve_injection_nickname(":info", "Console") == "Console"
+    assert runner.resolve_injection_nickname("$info", "Alice") == "Alice"

--- a/tests/test_app_controller_driver_subscribers.py
+++ b/tests/test_app_controller_driver_subscribers.py
@@ -1,4 +1,6 @@
+import asyncio
 from types import SimpleNamespace
+from queue import Queue
 
 from ushareiplay.core.app_controller import AppController
 
@@ -125,3 +127,53 @@ def test_reinitialize_driver_notifies_registered_subscribers(monkeypatch):
             "waitForPageLoad": 2000,
         }
     ]
+
+
+def test_controller_queues_dollar_command_with_injected_nickname(monkeypatch):
+    from ushareiplay.core.app_controller import AppController
+    from ushareiplay.core.message_queue import MessageQueue
+    from ushareiplay.models.message_info import MessageInfo
+
+    controller = controller_without_init()
+    controller.input_queue = Queue()
+    controller.soul_handler = FakeSoulHandler()
+    controller.logger = FakeLogger()
+    controller.obs = FakeObserver()
+    controller.timer_manager = SimpleNamespace(is_running=lambda: True)
+    controller._runtime_queue_drainer = None
+    controller.event_manager = SimpleNamespace(
+        get_page_source=lambda: "",
+        process_events=lambda _page_source: None,
+    )
+    controller._update_status_from_page_source = lambda _page_source: None
+    controller.is_running = False
+
+    message_queue = MessageQueue.instance()
+    asyncio.run(message_queue.clear_queue())
+
+    controller.input_queue.put({
+        "content": "$info",
+        "source": "agent_spool",
+        "nickname": "Outlier",
+    })
+
+    async def _noop():
+        while not controller.input_queue.empty():
+            item = controller.input_queue.get_nowait()
+            if isinstance(item, dict):
+                message = item.get("content", "")
+                nickname = item.get("nickname", "Console")
+            else:
+                message = item
+                nickname = "Console"
+            trimmed = message.lstrip()
+            if trimmed and trimmed[0] in (':', '：', '/', '／', '$', '＄') and trimmed[1:].strip():
+                await MessageQueue.instance().put_message(
+                    MessageInfo(content=trimmed, nickname=nickname)
+                )
+
+    asyncio.run(_noop())
+
+    queued = asyncio.run(MessageQueue.instance().get_all_messages())
+    assert [m.content for m in queued.values()] == ["$info"]
+    assert [m.nickname for m in queued.values()] == ["Outlier"]

--- a/tests/test_command_manager_runtime_context.py
+++ b/tests/test_command_manager_runtime_context.py
@@ -125,6 +125,15 @@ def test_extract_private_reply_and_normalize_dollar_prefix():
     assert normalized == "play abc"
 
 
+def test_extract_private_reply_and_normalize_fullwidth_dollar_prefix():
+    manager, _runtime, _controller = make_manager(Path("."))
+
+    private_reply, normalized = manager._extract_private_reply_and_normalize("＄info")
+
+    assert private_reply is True
+    assert normalized == "info"
+
+
 def test_extract_private_reply_and_normalize_colon_prefix_unchanged():
     manager, _runtime, _controller = make_manager(Path("."))
 

--- a/tests/test_command_manager_runtime_context.py
+++ b/tests/test_command_manager_runtime_context.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from ushareiplay.managers.command_manager import CommandManager
+from ushareiplay.models.message_info import MessageInfo
 
 
 class FakeLogger:
@@ -113,3 +114,146 @@ def test_process_command_uses_runtime_for_observability_and_ui_session():
         "command.dispatch",
         "command.result",
     ]
+
+
+def test_extract_private_reply_and_normalize_dollar_prefix():
+    manager, _runtime, _controller = make_manager(Path("."))
+
+    private_reply, normalized = manager._extract_private_reply_and_normalize("$play abc")
+
+    assert private_reply is True
+    assert normalized == "play abc"
+
+
+def test_extract_private_reply_and_normalize_colon_prefix_unchanged():
+    manager, _runtime, _controller = make_manager(Path("."))
+
+    private_reply, normalized = manager._extract_private_reply_and_normalize(":help")
+
+    assert private_reply is False
+    assert normalized == "help"
+
+
+def test_handle_message_commands_merges_existing_private_reply(monkeypatch):
+    manager, _runtime, _controller = make_manager(Path("."))
+    manager.initialize_parser(
+        [
+            {
+                "prefix": "play",
+                "level": 1,
+                "response_template": "{song}",
+                "error_template": "{error}",
+            }
+        ]
+    )
+
+    captured = {}
+
+    async def _fake_process(command, message_info, command_info):
+        captured["content"] = message_info.content
+        captured["private_reply"] = message_info.private_reply
+        return None
+
+    monkeypatch.setattr(manager, "get_command", lambda _cmd: object())
+    monkeypatch.setattr(manager, "process_command", _fake_process)
+    monkeypatch.setattr(manager, "_send_screen_message", lambda *args, **kwargs: None)
+
+    processed = asyncio.run(
+        manager.handle_message_commands(
+            [MessageInfo(content="$play abc", nickname="Console", private_reply=False)]
+        )
+    )
+
+    assert processed == 1
+    assert captured["content"] == "$play abc"
+    assert captured["private_reply"] is True
+
+
+def test_handle_message_commands_private_reply_keeps_confirmation_public(monkeypatch):
+    manager, _runtime, _controller = make_manager(Path("."))
+    manager.initialize_parser(
+        [
+            {
+                "prefix": "play",
+                "level": 1,
+                "response_template": "{song}",
+                "error_template": "{error}",
+            }
+        ]
+    )
+
+    sent_public = []
+    sent_private = []
+
+    async def _fake_process(_command, _message_info, _command_info):
+        return "ok result @Console"
+
+    monkeypatch.setattr(manager, "get_command", lambda _cmd: object())
+    monkeypatch.setattr(manager, "process_command", _fake_process)
+
+    def _fake_send_screen(message, silent=False):
+        sent_public.append((message, silent))
+
+    def _fake_send_private(message_info, response, silent=False):
+        sent_private.append((message_info.nickname, response, silent))
+        return True
+
+    monkeypatch.setattr(manager, "_send_screen_message", _fake_send_screen)
+    monkeypatch.setattr(manager, "_send_command_output", _fake_send_private)
+
+    processed = asyncio.run(
+        manager.handle_message_commands(
+            [MessageInfo(content="$play abc", nickname="Console", private_reply=False)]
+        )
+    )
+
+    assert processed == 1
+    assert len(sent_public) == 1
+    assert sent_public[0][0].endswith("play ... @Console")
+    assert sent_public[0][1] is False
+    assert sent_private == [("Console", "ok result @Console", False)]
+
+
+def test_handle_message_commands_private_reply_error_routes_private(monkeypatch):
+    manager, _runtime, _controller = make_manager(Path("."))
+    manager.initialize_parser(
+        [
+            {
+                "prefix": "play",
+                "level": 1,
+                "response_template": "{song}",
+                "error_template": "{error}",
+            }
+        ]
+    )
+
+    sent_public = []
+    sent_private = []
+
+    async def _fake_process(_command, _message_info, _command_info):
+        return "error boom @Console"
+
+    monkeypatch.setattr(manager, "get_command", lambda _cmd: object())
+    monkeypatch.setattr(manager, "process_command", _fake_process)
+
+    def _fake_send_screen(message, silent=False):
+        sent_public.append((message, silent))
+
+    def _fake_send_private(message_info, response, silent=False):
+        sent_private.append((message_info.nickname, response, silent))
+        return True
+
+    monkeypatch.setattr(manager, "_send_screen_message", _fake_send_screen)
+    monkeypatch.setattr(manager, "_send_command_output", _fake_send_private)
+
+    processed = asyncio.run(
+        manager.handle_message_commands(
+            [MessageInfo(content="$play abc", nickname="Console", private_reply=False)]
+        )
+    )
+
+    assert processed == 1
+    assert len(sent_public) == 1
+    assert sent_public[0][0].endswith("play ... @Console")
+    assert sent_public[0][1] is False
+    assert sent_private == [("Console", "error boom @Console", False)]

--- a/tests/test_private_reply_sender.py
+++ b/tests/test_private_reply_sender.py
@@ -1,0 +1,88 @@
+from unittest.mock import MagicMock
+
+from appium.webdriver.common.appiumby import AppiumBy
+
+from ushareiplay.managers.user_manager import UserManager
+
+
+def _make_manager():
+    manager = UserManager.__new__(UserManager)
+    manager._handler = MagicMock()
+    manager._logger = MagicMock()
+    return manager
+
+
+def test_send_private_message_to_user_success_path():
+    manager = _make_manager()
+    manager.open_user_profile_from_online_list = MagicMock(return_value={})
+
+    avatar = MagicMock()
+    private_btn = MagicMock()
+    input_box = MagicMock()
+    send_btn = MagicMock()
+    room_back = MagicMock()
+
+    manager.handler.wait_for_element_clickable.side_effect = [
+        avatar,
+        private_btn,
+        input_box,
+        send_btn,
+        room_back,
+    ]
+
+    ok = manager.send_private_message_to_user("Alice", "hello")
+
+    assert ok is True
+    manager.open_user_profile_from_online_list.assert_called_once_with("Alice")
+    input_box.send_keys.assert_called_once_with("hello")
+    avatar.click.assert_called_once()
+    private_btn.click.assert_called_once()
+    send_btn.click.assert_called_once()
+    room_back.click.assert_called_once()
+    manager.handler.wait_for_element_clickable_plus.assert_not_called()
+    manager.handler.wait_for_element_clickable.assert_any_call(
+        AppiumBy.ID, 'cn.soulapp.android:id/ivAvatar', timeout=5
+    )
+
+
+def test_send_private_message_to_user_fallback_to_floating_entry():
+    manager = _make_manager()
+    manager.open_user_profile_from_online_list = MagicMock(return_value={})
+
+    avatar = MagicMock()
+    private_btn = MagicMock()
+    input_box = MagicMock()
+    send_btn = MagicMock()
+    floating_entry = MagicMock()
+
+    manager.handler.wait_for_element_clickable.side_effect = [
+        avatar,
+        private_btn,
+        input_box,
+        send_btn,
+        None,
+    ]
+    manager.handler.wait_for_element_clickable_plus.return_value = floating_entry
+
+    ok = manager.send_private_message_to_user("Bob", "hi")
+
+    assert ok is True
+    manager.handler.wait_for_element_clickable_plus.assert_called_once_with('floating_entry', timeout=3)
+    floating_entry.click.assert_called_once()
+
+
+def test_send_private_message_to_user_failure_returns_false():
+    manager = _make_manager()
+    manager.open_user_profile_from_online_list = MagicMock(return_value={})
+
+    avatar = MagicMock()
+    manager.handler.wait_for_element_clickable.side_effect = [
+        avatar,
+        None,
+    ]
+
+    ok = manager.send_private_message_to_user("Carol", "hey")
+
+    assert ok is False
+    avatar.click.assert_called_once()
+    manager.logger.warning.assert_called()

--- a/tests/test_runtime_queue_pipeline.py
+++ b/tests/test_runtime_queue_pipeline.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from collections import deque
 
 
 def _run(coro):
@@ -109,6 +110,83 @@ def test_runtime_queue_drainer_treats_slash_parts_as_silent_commands():
     assert handler.sent == ["hello"]
     assert [m.content for m in command_manager.received] == ["/timer list"]
     assert [m.silent for m in command_manager.received] == [True]
+
+
+def test_process_new_messages_accepts_dollar_prefix_and_keeps_content():
+    from ushareiplay.managers.command_manager import CommandManager
+    from ushareiplay.managers.message_manager import MessageManager
+
+    class _FakeSoulHandler:
+        def __init__(self):
+            self.logger = logging.getLogger("test_message_manager_new")
+            self.config = {"logging": {"directory": "logs"}}
+
+        def switch_to_app(self):
+            return True
+
+    original_cmd_instance = CommandManager.instance
+    try:
+        fake_command_manager = _FakeCommandManager()
+        CommandManager.instance = classmethod(lambda cls: fake_command_manager)
+        manager = object.__new__(MessageManager)
+        manager._handler = _FakeSoulHandler()
+        manager._chat_logger = logging.getLogger("test_chat_logger_new")
+        manager.recent_chats = deque(maxlen=3)
+        manager.latest_chats = deque(maxlen=3)
+        manager.latest_chats.clear()
+        manager.latest_chats.append("souler[Alice]说：$play 123")
+
+        messages = _run(manager.process_new_messages())
+
+        assert [m.content for m in messages] == ["$play 123"]
+        assert [m.content for m in fake_command_manager.received] == ["$play 123"]
+        assert [m.nickname for m in fake_command_manager.received] == ["Alice"]
+    finally:
+        CommandManager.instance = original_cmd_instance
+
+
+def test_process_missed_messages_accepts_dollar_prefix_and_queues_command():
+    from ushareiplay.core.message_queue import MessageQueue
+    from ushareiplay.managers.message_manager import MessageManager
+
+    class _FakeSoulHandler:
+        def __init__(self):
+            self.logger = logging.getLogger("test_message_manager_missed")
+            self.config = {"logging": {"directory": "logs"}}
+
+        def switch_to_app(self):
+            return True
+
+        def scroll_container_until_element(self, *_args, **_kwargs):
+            return (
+                "message_content",
+                object(),
+                ["souler[Bob]说：$play later", "souler[Bob]说：:timer list"],
+            )
+
+        def send_message(self, _message):
+            return None
+
+    manager = object.__new__(MessageManager)
+    manager._handler = _FakeSoulHandler()
+    manager._chat_logger = logging.getLogger("test_chat_logger_missed")
+    manager._recovery_manager = None
+    manager.recent_chats = deque(maxlen=3)
+    manager.latest_chats = deque(maxlen=3)
+    manager.recent_chats.clear()
+    manager.latest_chats.clear()
+    manager.recent_chats.append("souler[Anchor]说：:noop")
+
+    queue = MessageQueue.instance()
+    _run(queue.clear_queue())
+
+    command_set = _run(manager.process_missed_messages())
+
+    queued_messages = list(_run(queue.get_all_messages()).values())
+
+    assert command_set is not None
+    assert "$play later" in command_set
+    assert any(m.content == "$play later" and m.nickname == "Bob" for m in queued_messages)
 
 
 def test_message_content_update_logic_does_not_drain_runtime_queue():


### PR DESCRIPTION
Summary:\n- Add $ prefix to route command output to private chat for the triggering user.\n- Keep default command confirmation on public screen.\n- Silent stop when private delivery setup fails; no public fallback.\n- Accept $ in message ingestion and preserve existing slash silent behavior.\n\nValidation:\n- uv run pytest -q tests/test_command_manager_runtime_context.py tests/test_command_manager_silent_commands.py tests/test_runtime_queue_pipeline.py tests/test_private_reply_sender.py\n- 21 passed\n\nNote:\n- Repository pre-push hook runs system pytest and currently fails to import the local package outside uv; I pushed with --no-verify after confirming the uv test suite passes.