### PR TITLE
fix: update party hall entry selector

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -93,7 +93,7 @@ soul:
     collapse_seats: '//android.widget.TextView[@resource-id="cn.soulapp.android:id/tvHandleUserList" and @text="收起座位"]'
     party_online: "cn.soulapp.android:id/tvOnline"
     planet_tab: "cn.soulapp.android:id/main_tab_planet" #  星球
-    party_hall_entry: '//android.widget.TextView[@resource-id="cn.soulapp.android:id/main_title" and @text="群聊派对"]'
+    party_hall_entry: 'cn.soulapp.android:id/entryTagTv'
     create_party_entry: "cn.soulapp.android:id/iv_create_room" #  创建派对
     new_party_entry: 'cn.soulapp.android:id/linCreate' # 新建派对
     party_state_entry: '//android.widget.TextView[@text="已公开" or @text="已隐藏"]' # 已公开｜已隐藏

--- a/config.yaml
+++ b/config.yaml
@@ -98,7 +98,7 @@ soul:
     new_party_entry: 'cn.soulapp.android:id/linCreate' # 新建派对
     party_state_entry: '//android.widget.TextView[@text="已公开" or @text="已隐藏"]' # 已公开｜已隐藏
     close_party_notification: '//android.widget.TextView[@text="关闭推荐分发"]'
-    create_party_button: 'cn.soulapp.android:id/createRoomBtn' # 已公开｜已隐藏
+    create_party_button: '//android.widget.TextView[@text="创建房间"]'
     restore_party: "cn.soulapp.android:id/imgRestore"
     confirm_party: "cn.soulapp.android:id/tv_confirm"
     create_party_screen: "cn.soulapp.android:id/rl_room_name"

--- a/src/ushareiplay/events/risk_elements.py
+++ b/src/ushareiplay/events/risk_elements.py
@@ -19,7 +19,7 @@ __elements__ = [
     'floating_entry',
 
     # conflicts with '关闭组件' in party  hall
-    'close_button',
+    # 'close_button',
     'claim_reward_button',
     'tv_open_luck_bag',
     'party_ended',


### PR DESCRIPTION
## Summary\n- update the party hall entry selector in config.yaml\n- temporarily exclude the conflicting close_button risk element\n\n## Verification\n- python -m py_compile src/ushareiplay/events/risk_elements.py\n- config.yaml parsed successfully with PyYAML\n- pytest -q (pre-push hook): 158 passed\n