### PR TITLE
fix: replace deprecated plus UI wait interfaces in private reply flow

### DIFF
--- a/src/ushareiplay/managers/user_manager.py
+++ b/src/ushareiplay/managers/user_manager.py
@@ -164,7 +164,7 @@ class UserManager(Singleton):
                 self.logger.warning(f"打开用户资料页失败: {nickname}, error={open_result['error']}")
                 return False
 
-            avatar = self.handler.wait_for_element_clickable_plus(
+            avatar = self.handler.wait_for_element_clickable(
                 'sender_avatar',
                 timeout=5,
             )
@@ -175,7 +175,7 @@ class UserManager(Singleton):
                 self.logger.warning(f"点击头像入口失败: {nickname}")
                 return False
 
-            private_chat_btn = self.handler.wait_for_element_clickable_plus(
+            private_chat_btn = self.handler.wait_for_element_clickable(
                 'private_chat_button',
                 timeout=5,
             )
@@ -184,7 +184,7 @@ class UserManager(Singleton):
                 return False
             private_chat_btn.click()
 
-            input_box = self.handler.wait_for_element_clickable_plus(
+            input_box = self.handler.wait_for_element_clickable(
                 'private_message_input',
                 timeout=5,
             )
@@ -193,7 +193,7 @@ class UserManager(Singleton):
                 return False
             input_box.send_keys(message)
 
-            send_button = self.handler.wait_for_element_clickable_plus(
+            send_button = self.handler.wait_for_element_clickable(
                 'private_message_send',
                 timeout=5,
             )
@@ -210,14 +210,14 @@ class UserManager(Singleton):
     def _return_to_room_after_private_chat(self, nickname: str) -> bool:
         """私聊发送后返回聊天室。"""
         try:
-            _key, entry = self.handler.wait_for_any_element_plus(
+            _key, entry = self.handler.wait_for_any_element(
                 ['private_room_entry', 'floating_entry', 'item_left_back'],
                 timeout=3,
             )
             if entry:
                 entry.click()
                 if _key == 'item_left_back':
-                    titlebar_back = self.handler.wait_for_element_clickable_plus(
+                    titlebar_back = self.handler.wait_for_element_clickable(
                         'titlebar_back_ivbtn',
                         timeout=3,
                     )

--- a/tests/test_private_reply_sender.py
+++ b/tests/test_private_reply_sender.py
@@ -20,13 +20,13 @@ def test_send_private_message_to_user_success_path():
     send_btn = MagicMock()
     room_back = MagicMock()
 
-    manager.handler.wait_for_element_clickable_plus.side_effect = [
+    manager.handler.wait_for_element_clickable.side_effect = [
         avatar,
         private_btn,
         input_box,
         send_btn,
     ]
-    manager.handler.wait_for_any_element_plus.return_value = ("private_room_entry", room_back)
+    manager.handler.wait_for_any_element.return_value = ("private_room_entry", room_back)
     manager.handler.click_element_at.return_value = True
 
     ok = manager.send_private_message_to_user("Alice", "hello")
@@ -39,10 +39,10 @@ def test_send_private_message_to_user_success_path():
     private_btn.click.assert_called_once()
     send_btn.click.assert_called_once()
     room_back.click.assert_called_once()
-    manager.handler.wait_for_element_clickable_plus.assert_any_call(
+    manager.handler.wait_for_element_clickable.assert_any_call(
         'sender_avatar', timeout=5
     )
-    manager.handler.wait_for_any_element_plus.assert_called_once_with(
+    manager.handler.wait_for_any_element.assert_called_once_with(
         ['private_room_entry', 'floating_entry', 'item_left_back'], timeout=3
     )
 
@@ -57,19 +57,19 @@ def test_send_private_message_to_user_fallback_to_floating_entry():
     send_btn = MagicMock()
     floating_entry = MagicMock()
 
-    manager.handler.wait_for_element_clickable_plus.side_effect = [
+    manager.handler.wait_for_element_clickable.side_effect = [
         avatar,
         private_btn,
         input_box,
         send_btn,
     ]
-    manager.handler.wait_for_any_element_plus.return_value = ("floating_entry", floating_entry)
+    manager.handler.wait_for_any_element.return_value = ("floating_entry", floating_entry)
     manager.handler.click_element_at.return_value = True
 
     ok = manager.send_private_message_to_user("Bob", "hi")
 
     assert ok is True
-    manager.handler.wait_for_any_element_plus.assert_called_once_with(
+    manager.handler.wait_for_any_element.assert_called_once_with(
         ['private_room_entry', 'floating_entry', 'item_left_back'], timeout=3
     )
     floating_entry.click.assert_called_once()
@@ -85,20 +85,20 @@ def test_send_private_message_to_user_fallback_to_left_back_and_titlebar_back():
     send_btn = MagicMock()
     titlebar_back = MagicMock()
 
-    manager.handler.wait_for_element_clickable_plus.side_effect = [
+    manager.handler.wait_for_element_clickable.side_effect = [
         avatar,
         private_btn,
         input_box,
         send_btn,
         titlebar_back,
     ]
-    manager.handler.wait_for_any_element_plus.return_value = ("item_left_back", MagicMock())
+    manager.handler.wait_for_any_element.return_value = ("item_left_back", MagicMock())
     manager.handler.click_element_at.return_value = True
 
     ok = manager.send_private_message_to_user("Eve", "hi")
 
     assert ok is True
-    manager.handler.wait_for_any_element_plus.assert_called_once_with(
+    manager.handler.wait_for_any_element.assert_called_once_with(
         ['private_room_entry', 'floating_entry', 'item_left_back'], timeout=3
     )
     titlebar_back.click.assert_called_once()
@@ -109,7 +109,7 @@ def test_send_private_message_to_user_failure_returns_false():
     manager.open_user_profile_from_online_list = MagicMock(return_value={})
 
     avatar = MagicMock()
-    manager.handler.wait_for_element_clickable_plus.side_effect = [
+    manager.handler.wait_for_element_clickable.side_effect = [
         avatar,
         None,
     ]
@@ -128,7 +128,7 @@ def test_send_private_message_to_user_returns_false_when_avatar_offset_click_fai
     manager.open_user_profile_from_online_list = MagicMock(return_value={})
 
     avatar = MagicMock()
-    manager.handler.wait_for_element_clickable_plus.return_value = avatar
+    manager.handler.wait_for_element_clickable.return_value = avatar
     manager.handler.click_element_at.return_value = False
 
     ok = manager.send_private_message_to_user("Dana", "hey")


### PR DESCRIPTION
## Summary
- replace deprecated `wait_for_element_clickable_plus` calls in private reply flow with `wait_for_element_clickable`
- replace deprecated `wait_for_any_element_plus` call in private reply return-to-room flow with `wait_for_any_element`
- update private reply unit tests to mock/assert the unified handler interfaces

## Verification
- `uv run pytest -q tests/test_private_reply_sender.py`
- result: `5 passed`

## Notes
- commit intentionally excludes unrelated local modifications in `config.yaml` and `src/ushareiplay/managers/notice_manager.py`
