### PR TITLE
Fix skipped song broadcast log

### DIFF
--- a/src/ushareiplay/managers/info_manager.py
+++ b/src/ushareiplay/managers/info_manager.py
@@ -345,7 +345,7 @@ class InfoManager(Singleton):
             else:
                 broadcast_enabled = cfg.get('soul', {}).get('broadcast_playing_info', True)
             if not broadcast_enabled:
-                self.logger.info("Song broadcast is disabled in config, skipping message")
+                self.logger.info(f'Skipped "{info.get("song", "Unknown")}"')
                 return
 
             # 检查是否需要跳过低质量歌曲

--- a/tests/test_info_manager_broadcast.py
+++ b/tests/test_info_manager_broadcast.py
@@ -35,7 +35,7 @@ def test_send_playing_message_respects_broadcast_toggle(info_manager):
         mock_handler.config = {'broadcast_playing_info': False}
         info_manager.send_playing_message()
         mock_handler.send_message.assert_not_called()
-        mock_logger.info.assert_called_with("Song broadcast is disabled in config, skipping message")
+        mock_logger.info.assert_called_with('Skipped "SongA"')
         mock_logger.info.reset_mock()
         
         # Case 3: Broadcast enabled but song skipped (quality check) - should NOT send message


### PR DESCRIPTION
## Summary\n- Include the skipped song name in the disabled broadcast log message\n- Update the broadcast toggle test to assert the new log text\n\n## Verification\n- uv run pytest -q tests/test_info_manager_broadcast.py\n- python -m py_compile src/ushareiplay/managers/info_manager.py