### PR TITLE
fix: run quality check before broadcast toggle and clarify hidden log

### DIFF
--- a/src/ushareiplay/managers/info_manager.py
+++ b/src/ushareiplay/managers/info_manager.py
@@ -336,17 +336,6 @@ class InfoManager(Singleton):
         # 只有在歌曲信息发生变化时才处理
         # 检查歌曲信息是否有效
         if 'error' not in info and all(key in info for key in ['song', 'singer', 'album']):
-            # 检查是否开启了广播
-            # 运行时 self.handler.config 是 soul 子配置（不是全量 config），
-            # 兼容两种结构，避免读不到时错误回退为 True。
-            cfg = self.handler.config if isinstance(self.handler.config, dict) else {}
-            if 'broadcast_playing_info' in cfg:
-                broadcast_enabled = cfg.get('broadcast_playing_info', True)
-            else:
-                broadcast_enabled = cfg.get('soul', {}).get('broadcast_playing_info', True)
-            if not broadcast_enabled:
-                self.logger.info(f'Skipped "{info.get("song", "Unknown")}"')
-                return
 
             # 检查是否需要跳过低质量歌曲
             from ushareiplay.handlers.qq_music_handler import QQMusicHandler
@@ -355,6 +344,20 @@ class InfoManager(Singleton):
 
             # 只有在没有跳过歌曲的情况下才发送播放消息
             if not song_skipped:
+                # 检查是否开启了广播
+                # 运行时 self.handler.config 是 soul 子配置（不是全量 config），
+                # 兼容两种结构，避免读不到时错误回退为 True。
+                cfg = self.handler.config if isinstance(self.handler.config, dict) else {}
+                if 'broadcast_playing_info' in cfg:
+                    broadcast_enabled = cfg.get('broadcast_playing_info', True)
+                else:
+                    broadcast_enabled = cfg.get('soul', {}).get('broadcast_playing_info', True)
+                if not broadcast_enabled:
+                    self.logger.info(
+                        f'Hidden "{info.get("song", "Unknown")} - {info.get("singer", "Unknown")} • {info.get("album", "Unknown")}"'
+                    )
+                    return
+
                 self.handler.send_message(
                     f"{info['song']} - {info['singer']} • {info['album']}")
         else:

--- a/tests/test_info_manager_broadcast.py
+++ b/tests/test_info_manager_broadcast.py
@@ -30,12 +30,16 @@ def test_send_playing_message_respects_broadcast_toggle(info_manager):
         info_manager.send_playing_message()
         mock_handler.send_message.assert_called_once_with("SongA - SingerA • AlbumA")
         mock_handler.send_message.reset_mock()
+        mock_music_handler.handle_song_quality_check.assert_called_once_with(info)
+        mock_music_handler.handle_song_quality_check.reset_mock()
         
         # Case 2: Broadcast disabled (False) - should NOT send message
         mock_handler.config = {'broadcast_playing_info': False}
         info_manager.send_playing_message()
         mock_handler.send_message.assert_not_called()
-        mock_logger.info.assert_called_with('Skipped "SongA"')
+        mock_music_handler.handle_song_quality_check.assert_called_once_with(info)
+        mock_music_handler.handle_song_quality_check.reset_mock()
+        mock_logger.info.assert_called_with('Hidden "SongA - SingerA • AlbumA"')
         mock_logger.info.reset_mock()
         
         # Case 3: Broadcast enabled but song skipped (quality check) - should NOT send message
@@ -43,6 +47,15 @@ def test_send_playing_message_respects_broadcast_toggle(info_manager):
         mock_music_handler.handle_song_quality_check.return_value = True
         info_manager.send_playing_message()
         mock_handler.send_message.assert_not_called()
+
+        # Case 4: Broadcast disabled (False) and song skipped (quality check) - should NOT send message and should NOT log broadcast disabled message
+        mock_handler.config = {'broadcast_playing_info': False}
+        mock_music_handler.handle_song_quality_check.return_value = True
+        mock_music_handler.handle_song_quality_check.reset_mock()
+        info_manager.send_playing_message()
+        mock_handler.send_message.assert_not_called()
+        mock_music_handler.handle_song_quality_check.assert_called_once_with(info)
+        mock_logger.info.assert_not_called()
 
 def test_send_playing_message_default_behavior(info_manager):
     # Mock handler


### PR DESCRIPTION
This PR resolves the issue where low-quality song filtering (Live songs, >= 4 singers) was completely bypassed when 'broadcast_playing_info' was set to 'false' (disabled). Additionally, it updates the log message from 'Skipped' to 'Hidden' to clarify that only the broadcast message is suppressed, not the song playback, and appends the full song details (singer, album) to that log.