### PR TITLE
fix: prevent infinite feedback loop on missed messages scrollback

### DIFF
--- a/src/ushareiplay/core/ui/gesture_handler.py
+++ b/src/ushareiplay/core/ui/gesture_handler.py
@@ -223,65 +223,74 @@ class GestureHandler:
             stable_rounds = 0
             max_stable_rounds = 2  # 连续多次无变化则认为到达边界
 
-            # 收集所有找到的元素的 attribute 值列表
-            attribute_values_list = []
+            # 收集每个屏幕视角下找到的元素属性值列表
+            views_list = []
 
             # 查找目标元素的辅助函数
             def find_target_element() -> Tuple[Optional[str], Optional[WebElement]]:
                 """在容器内查找目标元素，支持属性匹配（支持 | 分隔的多个属性）"""
                 found = self.find_child_element(container, element_key)
-                if found:
-                    if attribute_name and attribute_value:
-                        elements = self.find_child_elements(container, element_key)
-                        for element in elements:
-                            # 收集所有找到的元素的 attribute 值（不管是否匹配）
-                            attr_list = attribute_name.split('|')
-                            collected_value = None
-                            for attr in attr_list:
-                                value = self.try_get_attribute(element, attr)
-                                if value is not None and value != 'null':
-                                    collected_value = value
-                                    break
-                            if collected_value is not None:
-                                attribute_values_list.append(collected_value)
+                if not found:
+                    return None, None
 
-                            # 检查是否匹配目标值
-                            any_match = False
-                            for attr in attr_list:
-                                value = self.try_get_attribute(element, attr)
-                                if value == attribute_value:
-                                    any_match = True
-                                    break
-                            if any_match:
-                                return element_key, element
+                # 收集当前屏幕可见的所有目标元素的属性值
+                current_view_values = []
+                elements = self.find_child_elements(container, element_key)
+                for element in elements:
+                    if attribute_name:
+                        attr_list = attribute_name.split('|')
+                        for attr in attr_list:
+                            value = self.try_get_attribute(element, attr)
+                            if value is not None and value != 'null':
+                                current_view_values.append(value)
+                                break
                     else:
-                        # 如果没有指定属性匹配，也收集所有找到的元素
-                        elements = self.find_child_elements(container, element_key)
-                        for element in elements:
-                            if attribute_name:
-                                attr_list = attribute_name.split('|')
-                                for attr in attr_list:
-                                    value = self.try_get_attribute(element, attr)
-                                    if value is not None and value != 'null':
-                                        attribute_values_list.append(value)
-                                        break
-                            else:
-                                # 如果没有指定属性名，优先使用 content-desc，如果没有则使用 text
-                                content_desc = self.try_get_attribute(element, "content-desc")
-                                if content_desc is not None and content_desc != 'null':
-                                    attribute_values_list.append(content_desc)
-                                else:
-                                    text = self.try_get_attribute(element, "text")
-                                    if text is not None and text != 'null':
-                                        attribute_values_list.append(text)
-                        return element_key, found
-                return None, None
+                        content_desc = self.try_get_attribute(element, "content-desc")
+                        if content_desc is not None and content_desc != 'null':
+                            current_view_values.append(content_desc)
+                        else:
+                            text = self.try_get_attribute(element, "text")
+                            if text is not None and text != 'null':
+                                current_view_values.append(text)
+
+                if current_view_values:
+                    views_list.append(current_view_values)
+
+                # 检查是否有匹配的目标元素
+                if attribute_name and attribute_value:
+                    attr_list = attribute_name.split('|')
+                    for element in elements:
+                        any_match = False
+                        for attr in attr_list:
+                            value = self.try_get_attribute(element, attr)
+                            if value == attribute_value:
+                                any_match = True
+                                break
+                        if any_match:
+                            return element_key, element
+                    return None, None
+                else:
+                    return element_key, found
+
+            def get_chronological_values() -> list[str]:
+                chronological_list = []
+                seen = set()
+                # direction == "down" means we scroll up in history (newest views first, oldest views last).
+                # So we iterate in reverse order of views_list to process oldest views first.
+                # Within each view, we iterate in original order (top to bottom is oldest to newest).
+                ordered_views = reversed(views_list) if direction in ("down", "right") else views_list
+                for view in ordered_views:
+                    for val in view:
+                        if val not in seen:
+                            seen.add(val)
+                            chronological_list.append(val)
+                return chronological_list
 
             for _ in range(max_swipes):
                 # 尝试在容器内查找目标
                 key, element = find_target_element()
                 if element:
-                    return key, element, self._reversed_if_needed(attribute_values_list, direction)
+                    return key, element, get_chronological_values()
 
                 # 计算滑动坐标并执行滑动
                 sx, sy, ex, ey = compute_points(direction)
@@ -290,12 +299,12 @@ class GestureHandler:
                     self.logger.warning(
                         f"scroll_container_until_element: 滑动失败，终止:{element_key}"
                     )
-                    return None, None, self._reversed_if_needed(attribute_values_list, direction)
+                    return None, None, get_chronological_values()
 
                 # 滑动后再试一次（元素可能已进入可视区）
                 key, element = find_target_element()
                 if element:
-                    return key, element, self._reversed_if_needed(attribute_values_list, direction)
+                    return key, element, get_chronological_values()
 
                 # 判断是否到底/到边（页面无变化）
                 cur_hash = snapshot()
@@ -309,14 +318,14 @@ class GestureHandler:
                     self.logger.warning(
                         f"scroll_container_until_element: 已到达边界，未找到目标元素:{element_key}"
                     )
-                    return None, None, self._reversed_if_needed(attribute_values_list, direction)
+                    return None, None, get_chronological_values()
 
             self.logger.warning(
                 f"scroll_container_until_element: 达到最大滑动次数，未找到目标元素:{element_key}"
             )
-            return None, None, self._reversed_if_needed(attribute_values_list, direction)
+            return None, None, get_chronological_values()
         except Exception:
             self.logger.error(
                 f"scroll_container_until_element error: {traceback.format_exc()}"
             )
-            return None, None, self._reversed_if_needed(attribute_values_list, direction)
+            return None, None, []

--- a/src/ushareiplay/events/message_content.py
+++ b/src/ushareiplay/events/message_content.py
@@ -66,6 +66,11 @@ class MessageContentEvent(BaseEvent):
             message_manager.latest_chats.clear()
             recent_len = len(message_manager.recent_chats)
             content_len = len(content_list)
+            
+            if content_len == 0:
+                await self._process_update_logic()
+                return False
+
             missed = False
             if recent_len == 0:
                 for content in content_list:

--- a/src/ushareiplay/handlers/soul_handler.py
+++ b/src/ushareiplay/handlers/soul_handler.py
@@ -63,6 +63,7 @@ class SoulHandler(AppHandler, Singleton):
             send_button = self.wait_for_element_clickable('button_send')
             if not send_button:
                 self.logger.error(f'cannot find send button')
+                self.press_back()
                 return {
                     'error': 'Failed to find send button',
                 }
@@ -70,8 +71,7 @@ class SoulHandler(AppHandler, Singleton):
             send_button.click()
             # self.logger.info("Clicked send button")
 
-        self.click_element_at(input_box, 0.5, -1)
-        # self.logger.info("Hide input dialog")
+        self.press_back()
 
     def grab_mic_and_confirm(self):
         """Wait for the grab mic button and confirm the action"""

--- a/src/ushareiplay/managers/message_manager.py
+++ b/src/ushareiplay/managers/message_manager.py
@@ -135,8 +135,20 @@ class MessageManager(Singleton):
         nickname_map = {}
 
         missed_chats = set[str]()
+        last_chat_in_list = last_chat in attribute_values
+        found_last_chat = not last_chat_in_list
+        if not last_chat_in_list:
+            self.handler.logger.warning(
+                f"last_chat '{last_chat}' not found in scrollback attribute values. Processing all scrolled elements."
+            )
+
         for chat in attribute_values:
-            if last_chat == chat:
+            if not found_last_chat:
+                if chat == last_chat:
+                    found_last_chat = True
+                continue
+
+            if chat == last_chat:
                 continue
 
             is_missed = False

--- a/tests/test_runtime_queue_pipeline.py
+++ b/tests/test_runtime_queue_pipeline.py
@@ -369,6 +369,57 @@ def test_process_missed_messages_accepts_dollar_prefix_and_queues_command():
     assert "$play later" in command_set
     assert any(m.content == "$play later" and m.nickname == "Bob" for m in queued_messages)
 
+def test_process_missed_messages_ignores_before_last_chat():
+    from ushareiplay.core.message_queue import MessageQueue
+    from ushareiplay.managers.message_manager import MessageManager
+
+    class _FakeSoulHandler:
+        def __init__(self):
+            self.logger = logging.getLogger("test_message_manager_missed")
+            self.config = {"logging": {"directory": "logs"}}
+
+        def switch_to_app(self):
+            return True
+
+        def scroll_container_until_element(self, *_args, **_kwargs):
+            return (
+                "message_content",
+                object(),
+                [
+                    "souler[Alice]说：/topic old_topic",    # sent before last_chat
+                    "souler[Anchor]说：:noop",              # last_chat
+                    "souler[Bob]说：$play later",           # sent after last_chat
+                    "souler[Bob]说：:timer list",           # sent after last_chat
+                ],
+            )
+
+        def send_message(self, _message):
+            return None
+
+    manager = object.__new__(MessageManager)
+    manager._handler = _FakeSoulHandler()
+    manager._chat_logger = logging.getLogger("test_chat_logger_missed")
+    manager._recovery_manager = None
+    manager.recent_chats = deque(maxlen=3)
+    manager.latest_chats = deque(maxlen=3)
+    manager.recent_chats.clear()
+    manager.latest_chats.clear()
+    manager.recent_chats.append("souler[Anchor]说：:noop")
+
+    queue = MessageQueue.instance()
+    _run(queue.clear_queue())
+
+    command_set = _run(manager.process_missed_messages())
+
+    queued_messages = list(_run(queue.get_all_messages()).values())
+
+    assert command_set is not None
+    assert "$play later" in command_set
+    assert ":timer list" in command_set
+    assert "/topic old_topic" not in command_set
+    assert any(m.content == "$play later" and m.nickname == "Bob" for m in queued_messages)
+    assert not any(m.content == "/topic old_topic" for m in queued_messages)
+
 
 def test_message_content_update_logic_does_not_drain_runtime_queue():
     from ushareiplay.core.message_queue import MessageQueue

--- a/tests/test_runtime_queue_pipeline.py
+++ b/tests/test_runtime_queue_pipeline.py
@@ -500,3 +500,63 @@ def test_message_content_event_dispatches_dollar_command(monkeypatch):
         assert fake_manager.processed_new is True
     finally:
         MessageManager.instance = original_message_manager_instance
+
+
+def test_message_content_event_handles_empty_content_list(monkeypatch):
+    from ushareiplay.events import message_content as message_content_module
+    from ushareiplay.events.message_content import MessageContentEvent
+    from ushareiplay.managers.message_manager import MessageManager
+    from ushareiplay.managers.command_manager import CommandManager
+    from ushareiplay.managers.info_manager import InfoManager
+
+    class _FakeMessageManager:
+        def __init__(self):
+            self.recent_chats = deque(maxlen=3)
+            self.latest_chats = deque(maxlen=3)
+            self.processed_new = False
+            self.processed_missed = False
+
+        def is_user_return_message(self, _content):
+            return False, ""
+
+        async def process_new_messages(self):
+            self.processed_new = True
+
+        async def process_missed_messages(self):
+            self.processed_missed = True
+
+    class _FakeChatLogger:
+        def info(self, _message):
+            return None
+
+    update_logic_called = False
+    class _FakeCmdMgr:
+        def update_commands(self):
+            nonlocal update_logic_called
+            update_logic_called = True
+            return None
+
+    class _FakeInfoMgr:
+        def update_playback_info_cache(self):
+            return None
+
+    fake_manager = _FakeMessageManager()
+    monkeypatch.setattr(MessageManager, "instance", classmethod(lambda cls: fake_manager))
+    monkeypatch.setattr(CommandManager, "instance", classmethod(lambda cls: _FakeCmdMgr()))
+    monkeypatch.setattr(InfoManager, "instance", classmethod(lambda cls: _FakeInfoMgr()))
+    monkeypatch.setattr(
+        message_content_module,
+        "get_chat_logger",
+        lambda _config=None: _FakeChatLogger(),
+        raising=False,
+    )
+
+    event = MessageContentEvent(_FakeHandler())
+
+    handled = _run(event.handle("message_content", [_FakeWrapper(None)]))
+
+    assert handled is False
+    assert fake_manager.processed_new is False
+    assert fake_manager.processed_missed is False
+    assert update_logic_called is True
+

--- a/tests/test_scroll_chronological.py
+++ b/tests/test_scroll_chronological.py
@@ -1,0 +1,124 @@
+import pytest
+from unittest.mock import MagicMock
+from ushareiplay.core.ui.gesture_handler import GestureHandler
+
+class FakeWebElement:
+    def __init__(self, text):
+        self._text = text
+    
+    @property
+    def location(self):
+        return {"x": 0, "y": 0}
+    
+    @property
+    def size(self):
+        return {"width": 100, "height": 100}
+
+def test_scroll_container_until_element_down_chronological():
+    owner = MagicMock()
+    owner.logger = MagicMock()
+    owner.config = {}
+    
+    def try_get_attribute(element, attr):
+        if attr == "text":
+            return element._text
+        return None
+    owner.try_get_attribute.side_effect = try_get_attribute
+    
+    gh = GestureHandler(owner)
+    
+    container = FakeWebElement("container")
+    owner.wait_for_element_clickable.return_value = container
+    
+    gh._perform_swipe = MagicMock(return_value=True)
+    
+    owner.driver = MagicMock()
+    page_sources = ["source0", "source1", "source2"]
+    def get_page_source():
+        if page_sources:
+            return page_sources.pop(0)
+        return "source_end"
+    type(owner.driver).page_source = property(lambda self: get_page_source())
+    
+    # direction == "down" -> scrolling up in history.
+    # So Round 1 has newest elements. Round 2 has older elements.
+    view_1 = [FakeWebElement("msg_2"), FakeWebElement("msg_3")]  # Round 1 (bottom of chat)
+    view_2 = [FakeWebElement("msg_1"), FakeWebElement("msg_2")]  # Round 2 (after 1 swipe)
+    
+    def find_child_element(parent, key):
+        return MagicMock()
+        
+    owner.find_child_element.side_effect = find_child_element
+    
+    views = [view_1, view_2]
+    def find_child_elements(parent, key):
+        if views:
+            return views.pop(0)
+        return []
+    owner.find_child_elements.side_effect = find_child_elements
+    
+    key, found_elem, attribute_values = gh.scroll_container_until_element(
+        element_key="message_content",
+        container_key="message_list",
+        direction="down",
+        attribute_name="text",
+        attribute_value="msg_1",
+        max_swipes=5
+    )
+    
+    assert key == "message_content"
+    assert attribute_values == ["msg_1", "msg_2", "msg_3"]
+
+def test_scroll_container_until_element_up_chronological():
+    owner = MagicMock()
+    owner.logger = MagicMock()
+    owner.config = {}
+    
+    def try_get_attribute(element, attr):
+        if attr == "text":
+            return element._text
+        return None
+    owner.try_get_attribute.side_effect = try_get_attribute
+    
+    gh = GestureHandler(owner)
+    
+    container = FakeWebElement("container")
+    owner.wait_for_element_clickable.return_value = container
+    
+    gh._perform_swipe = MagicMock(return_value=True)
+    
+    owner.driver = MagicMock()
+    page_sources = ["source0", "source1", "source2"]
+    def get_page_source():
+        if page_sources:
+            return page_sources.pop(0)
+        return "source_end"
+    type(owner.driver).page_source = property(lambda self: get_page_source())
+    
+    # direction == "up" -> scrolling down in history.
+    # So Round 1 has older elements. Round 2 has newer elements.
+    view_1 = [FakeWebElement("line_1"), FakeWebElement("line_2")]
+    view_2 = [FakeWebElement("line_2"), FakeWebElement("line_3")]
+    
+    def find_child_element(parent, key):
+        return MagicMock()
+    owner.find_child_element.side_effect = find_child_element
+    
+    views = [view_1, view_2]
+    def find_child_elements(parent, key):
+        if views:
+            return views.pop(0)
+        return []
+    owner.find_child_elements.side_effect = find_child_elements
+    
+    key, found_elem, attribute_values = gh.scroll_container_until_element(
+        element_key="message_content",
+        container_key="message_list",
+        direction="up",
+        attribute_name="text",
+        attribute_value="line_3",
+        max_swipes=5
+    )
+    
+    assert key == "message_content"
+    assert attribute_values == ["line_1", "line_2", "line_3"]


### PR DESCRIPTION
This PR fixes an issue where the bot gets stuck in an infinite feedback loop repeatedly updating/changing the interest topic. 

### Cause
1. Changing the interest topic posts a system message in the chat room.
2. Because `recent_chats` is a small deque (size 3), new system messages do not align with it, triggering `missed = True` and running `process_missed_messages()`.
3. `process_missed_messages()` scrolls up (direction 'down') to locate the `last_chat` anchor. 
4. The helper `scroll_container_until_element` accumulated all read elements but returned them in a reversed/non-chronological order.
5. Due to this, the loop detection incorrectly processed older commands (like `/topic`) that were executed in the past, causing the bot to re-execute them, triggering the loop.

### Fix
1. Modified `scroll_container_until_element` in `gesture_handler.py` to collect the visible elements per view, and merge/de-duplicate them to return a clean chronological list (from oldest to newest).
2. Modified `process_missed_messages` in `message_manager.py` to only process messages that occur chronologically *after* the `last_chat` anchor is matched.
3. Added comprehensive unit tests in `tests/test_scroll_chronological.py` and `tests/test_runtime_queue_pipeline.py` to verify the chronological sorting and filtering logic.