### PR TITLE
fix: restrict sleep exemption to manual keyword triggers

### DIFF
--- a/src/ushareiplay/events/message_content.py
+++ b/src/ushareiplay/events/message_content.py
@@ -122,10 +122,19 @@ class MessageContentEvent(BaseEvent):
                     keyword_record = await keyword_manager.find_keyword(keyword, username)
                     if keyword_record:
                         # 找到匹配的关键字，执行（command 中可用 {user_name}、{params} 占位符）
-                        await keyword_manager.execute_keyword(keyword_record, username, params=params)
+                        await keyword_manager.execute_keyword(
+                            keyword_record,
+                            username,
+                            params=params,
+                            sleep_exempt=True,
+                        )
                     else:
                         # 没有匹配，执行默认关键字
-                        await keyword_manager.execute_default_keyword(username, params=params)
+                        await keyword_manager.execute_default_keyword(
+                            username,
+                            params=params,
+                            sleep_exempt=True,
+                        )
 
                     chat_logger.critical(content)
                     continue  # 跳过后续的命令检测

--- a/src/ushareiplay/managers/keyword_manager.py
+++ b/src/ushareiplay/managers/keyword_manager.py
@@ -358,13 +358,20 @@ class KeywordManager(Singleton):
             self.logger.error(f"Error revoking keyword access: {traceback.format_exc()}")
             return {'error': '取消授权失败'}
 
-    async def execute_keyword(self, keyword_record: Keyword, username: str, params: str = ""):
+    async def execute_keyword(
+        self,
+        keyword_record: Keyword,
+        username: str,
+        params: str = "",
+        sleep_exempt: bool = False,
+    ):
         """执行关键字
         
         Args:
             keyword_record: 关键字记录
             username: 触发用户名
             params: 关键词后的参数字符串（空格后的整段），command 中可用 {params} 引用
+            sleep_exempt: 是否允许绕过睡眠保护，仅手动 @ 触发链路应设为 True
         """
         try:
             # 替换占位符：{user_name} 用户名，{params} 关键词后的参数
@@ -379,7 +386,7 @@ class KeywordManager(Singleton):
             message_info = MessageInfo(
                 content=command,  # 保留完整格式（包括冒号和分号）
                 nickname=username,
-                sleep_exempt=True,
+                sleep_exempt=sleep_exempt,
             )
             
             await message_queue.put_message(message_info)
@@ -388,12 +395,18 @@ class KeywordManager(Singleton):
         except Exception:
             self.logger.error(f"Error executing keyword: {traceback.format_exc()}")
 
-    async def execute_default_keyword(self, username: str, params: str = ""):
+    async def execute_default_keyword(
+        self,
+        username: str,
+        params: str = "",
+        sleep_exempt: bool = False,
+    ):
         """执行默认关键字
         
         Args:
             username: 触发用户名
             params: 关键词后的参数字符串，command 中可用 {params} 引用
+            sleep_exempt: 是否允许绕过睡眠保护，仅手动 @ 触发链路应设为 True
         """
         try:
             if not self._default_keyword_command:
@@ -413,7 +426,7 @@ class KeywordManager(Singleton):
             message_info = MessageInfo(
                 content=command,
                 nickname=username,
-                sleep_exempt=True,
+                sleep_exempt=sleep_exempt,
             )
             
             await message_queue.put_message(message_info)

--- a/src/ushareiplay/managers/message_manager.py
+++ b/src/ushareiplay/managers/message_manager.py
@@ -161,9 +161,18 @@ class MessageManager(Singleton):
 
                 keyword_record = await keyword_manager.find_keyword(keyword, username)
                 if keyword_record:
-                    await keyword_manager.execute_keyword(keyword_record, username, params=params)
+                    await keyword_manager.execute_keyword(
+                        keyword_record,
+                        username,
+                        params=params,
+                        sleep_exempt=True,
+                    )
                 else:
-                    await keyword_manager.execute_default_keyword(username, params=params)
+                    await keyword_manager.execute_default_keyword(
+                        username,
+                        params=params,
+                        sleep_exempt=True,
+                    )
 
                 continue
 

--- a/tests/test_keyword_sleep_exemption.py
+++ b/tests/test_keyword_sleep_exemption.py
@@ -1,0 +1,127 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture(autouse=True)
+def _clear_message_queue():
+    from ushareiplay.core.message_queue import MessageQueue
+
+    queue = MessageQueue.instance()
+    _run(queue.clear_queue())
+    yield
+    _run(queue.clear_queue())
+
+
+def test_keyword_command_execution_does_not_sleep_exempt_by_default():
+    from ushareiplay.core.message_queue import MessageQueue
+    from ushareiplay.managers.keyword_manager import KeywordManager
+
+    keyword_manager = KeywordManager.instance()
+    keyword_manager._logger = SimpleNamespace(
+        info=lambda *_args, **_kwargs: None,
+        error=lambda *_args, **_kwargs: None,
+    )
+    keyword_record = SimpleNamespace(
+        keyword="520",
+        command=":play love song",
+        mode="sequence",
+    )
+
+    _run(keyword_manager.execute_keyword(keyword_record, "Alice"))
+
+    messages = _run(MessageQueue.instance().get_all_messages())
+
+    assert len(messages) == 1
+    queued = next(iter(messages.values()))
+    assert queued.content == ":play love song"
+    assert queued.nickname == "Alice"
+    assert queued.sleep_exempt is False
+
+
+@pytest.mark.asyncio
+async def test_at_keyword_message_executes_keyword_with_sleep_exemption(monkeypatch):
+    from ushareiplay.events.message_content import MessageContentEvent
+    from ushareiplay.managers import keyword_manager as keyword_manager_module
+    from ushareiplay.managers import message_manager as message_manager_module
+
+    calls = []
+
+    class _FakeKeywordManager:
+        async def find_keyword(self, keyword, username):
+            return SimpleNamespace(keyword=keyword, command=":play love song", mode="sequence")
+
+        async def execute_keyword(self, keyword_record, username, params="", sleep_exempt=False):
+            calls.append(
+                {
+                    "keyword": keyword_record.keyword,
+                    "username": username,
+                    "params": params,
+                    "sleep_exempt": sleep_exempt,
+                }
+            )
+
+    class _FakeMessageManager:
+        def __init__(self):
+            self.latest_chats = []
+            self.recent_chats = []
+
+        def is_user_return_message(self, _content):
+            return False, ""
+
+    class _Logger:
+        def critical(self, *_args, **_kwargs):
+            return None
+
+        def info(self, *_args, **_kwargs):
+            return None
+
+        def error(self, *_args, **_kwargs):
+            return None
+
+    class _Handler:
+        config = {}
+        logger = _Logger()
+        controller = None
+
+    monkeypatch.setattr(
+        message_manager_module.MessageManager,
+        "instance",
+        staticmethod(lambda: _FakeMessageManager()),
+    )
+    monkeypatch.setattr(
+        message_manager_module,
+        "get_chat_logger",
+        lambda _config: _Logger(),
+    )
+    monkeypatch.setattr(
+        keyword_manager_module.KeywordManager,
+        "instance",
+        staticmethod(lambda: _FakeKeywordManager()),
+    )
+
+    event = MessageContentEvent(_Handler())
+
+    async def _noop_update_logic():
+        return None
+
+    event._process_update_logic = _noop_update_logic
+
+    await event.handle(
+        "message_content",
+        [SimpleNamespace(content="souler[Alice]说：@我 520 晚安")],
+    )
+
+    assert calls == [
+        {
+            "keyword": "520",
+            "username": "Alice",
+            "params": "晚安",
+            "sleep_exempt": True,
+        }
+    ]


### PR DESCRIPTION
## Summary
- Make keyword expansion queued commands sleep-protected by default.
- Pass sleep exemption only from explicit @我 keyword trigger paths, including missed chat recovery.
- Add regression coverage for default keyword execution and manual @ keyword exemption.

## Test Plan
- [x] uv run pytest -q