### PR TITLE
Fix old-song whitelist and release date output

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -298,7 +298,7 @@ lyrics:
 commands:
   - prefix: "play"
     level: 1
-    response_template: "{song} - {singer} • {album}"
+    response_template: "{song} - {singer} • {album} • {release_date}"
     error_template: "Failed to play music, because {error}"
   - prefix: "fav"
     level: 1
@@ -310,7 +310,7 @@ commands:
     error_template: "Failed to skip song, because {error}"
   - prefix: "next"
     level: 0
-    response_template: "Added {song} by {singer} in {album} to playlist"
+    response_template: "Added {song} by {singer} in {album} • {release_date} to playlist"
     error_template: "Failed to add songs to play list, because {error}"
   - prefix: "pause"
     level: 1
@@ -346,7 +346,7 @@ commands:
     error_template: "别名绑定失败: {error}"
   - prefix: "info"
     level: 0
-    response_template: "播放模式: {play_mode}\n{current_playlist}\n{online_users}\n{party_duration}\n{song} - {singer} • {album}"
+    response_template: "播放模式: {play_mode}\n{current_playlist}\n{online_users}\n{party_duration}\n{song} - {singer} • {album} • {release_date}"
     error_template: "Failed to get playback info, because {error}"
   - prefix: "singer"
     level: 1
@@ -444,6 +444,7 @@ old_song_filter:
   enabled: true
   cutoff_date: "2000-01-01"
   radio_max_refreshes: 5
+  artist_whitelist: ["王菲", "911"]
 
 sleep:
   enabled: true

--- a/src/ushareiplay/commands/info.py
+++ b/src/ushareiplay/commands/info.py
@@ -10,7 +10,7 @@ class InfoCommand(BaseCommand):
         from ushareiplay.managers.info_manager import InfoManager
 
         info_manager = InfoManager.instance()
-        result = info_manager.get_playback_info_cache()
+        result = info_manager.ensure_cached_release_date()
 
         # 如果缓存未初始化，使用默认值
         if result is None:
@@ -18,8 +18,11 @@ class InfoCommand(BaseCommand):
                 "song": "Unknown",
                 "singer": "Unknown",
                 "album": "Unknown",
+                "release_date": "",
                 "state": None,
             }
+        else:
+            result["release_date"] = result.get("release_date") or ""
 
         # 追加播放器信息和在线用户列表
         result["player"] = info_manager.player_name

--- a/src/ushareiplay/handlers/qq_music_handler.py
+++ b/src/ushareiplay/handlers/qq_music_handler.py
@@ -430,7 +430,7 @@ class QQMusicHandler(AppHandler, Singleton):
             singer = song_info.get('singer', '')
             album = song_info.get('album', '')
 
-            if self._is_old_song(song, singer, album):
+            if self._is_old_song(song, singer, album, song_info):
                 return True
 
             # 检查是否包含 DJ 或 Remix
@@ -472,7 +472,7 @@ class QQMusicHandler(AppHandler, Singleton):
     def _old_song_filter_config(self) -> dict:
         return (self.config or {}).get("old_song_filter", {})
 
-    def _is_old_song(self, song: str, singer: str = "", album: str = "") -> bool:
+    def _is_old_song(self, song: str, singer: str = "", album: str = "", song_info: dict = None) -> bool:
         config = self._old_song_filter_config()
         if not config.get("enabled", True):
             return False
@@ -491,6 +491,9 @@ class QQMusicHandler(AppHandler, Singleton):
         if not release_date:
             self.logger.info(f"Release date unknown for {query}, accepting song")
             return False
+
+        if song_info is not None:
+            song_info["release_date"] = release_date.isoformat()
 
         if release_date < cutoff:
             self.logger.info(f"Skipping old song ({release_date} < {cutoff}): {query}")

--- a/src/ushareiplay/handlers/qq_music_handler.py
+++ b/src/ushareiplay/handlers/qq_music_handler.py
@@ -470,7 +470,42 @@ class QQMusicHandler(AppHandler, Singleton):
             return False
 
     def _old_song_filter_config(self) -> dict:
+        controller_config = getattr(getattr(self, "controller", None), "config", None)
+        if isinstance(controller_config, dict) and "old_song_filter" in controller_config:
+            return controller_config.get("old_song_filter", {})
         return (self.config or {}).get("old_song_filter", {})
+
+    def _is_old_song_whitelisted_artist(self, singer: str, config: dict) -> bool:
+        whitelist = {
+            str(artist).strip()
+            for artist in config.get("artist_whitelist", [])
+            if str(artist).strip()
+        }
+        if not whitelist or not singer:
+            return False
+
+        artists = {artist.strip() for artist in singer.split("/") if artist.strip()}
+        return bool(artists & whitelist)
+
+    def ensure_release_date(self, song_info: dict) -> None:
+        if not isinstance(song_info, dict) or song_info.get("release_date"):
+            return
+
+        song = song_info.get("song", "")
+        singer = song_info.get("singer", "")
+        album = song_info.get("album", "")
+        if not song:
+            return
+
+        query = " ".join(part for part in [song, singer, album] if part).strip()
+        try:
+            release_date = parse_release_date(self.song_release_lookup.get_release_date(query))
+        except Exception as exc:
+            self.logger.warning(f"Failed to query song release date for {query}: {exc}")
+            return
+
+        if release_date:
+            song_info["release_date"] = release_date.isoformat()
 
     def _is_old_song(self, song: str, singer: str = "", album: str = "", song_info: dict = None) -> bool:
         config = self._old_song_filter_config()
@@ -481,19 +516,19 @@ class QQMusicHandler(AppHandler, Singleton):
         if not cutoff or not song:
             return False
 
-        query = " ".join(part for part in [song, singer, album] if part).strip()
-        try:
-            release_date = parse_release_date(self.song_release_lookup.get_release_date(query))
-        except Exception as exc:
-            self.logger.warning(f"Failed to query song release date for {query}: {exc}")
-            return False
+        if song_info is None:
+            song_info = {"song": song, "singer": singer, "album": album}
 
+        self.ensure_release_date(song_info)
+        release_date = parse_release_date(song_info.get("release_date"))
+        query = " ".join(part for part in [song, singer, album] if part).strip()
         if not release_date:
             self.logger.info(f"Release date unknown for {query}, accepting song")
             return False
 
-        if song_info is not None:
-            song_info["release_date"] = release_date.isoformat()
+        if self._is_old_song_whitelisted_artist(singer, config):
+            self.logger.info(f"Accepting old song for whitelisted artist: {query}")
+            return False
 
         if release_date < cutoff:
             self.logger.info(f"Skipping old song ({release_date} < {cutoff}): {query}")

--- a/src/ushareiplay/managers/command_manager.py
+++ b/src/ushareiplay/managers/command_manager.py
@@ -300,6 +300,7 @@ class CommandManager(Singleton):
                 # keyword 命令返回的是 message 字段
                 res = f'{result["message"]} @{message_info.nickname}'
             else:
+                result.setdefault("release_date", "")
                 res = f'{command_info["response_template"].format(**result)} @{message_info.nickname}'
 
             try:

--- a/src/ushareiplay/managers/info_manager.py
+++ b/src/ushareiplay/managers/info_manager.py
@@ -328,6 +328,13 @@ class InfoManager(Singleton):
         """
         return self._playback_info_cache
 
+    def _format_playback_message(self, info: dict) -> str:
+        message = f"{info['song']} - {info['singer']} • {info['album']}"
+        release_date = info.get("release_date")
+        if release_date:
+            message = f"{message} {release_date}"
+        return message
+
     def send_playing_message(self):
         info = self.get_playback_info_cache()
         if info is None:
@@ -344,6 +351,7 @@ class InfoManager(Singleton):
 
             # 只有在没有跳过歌曲的情况下才发送播放消息
             if not song_skipped:
+                playback_message = self._format_playback_message(info)
                 # 检查是否开启了广播
                 # 运行时 self.handler.config 是 soul 子配置（不是全量 config），
                 # 兼容两种结构，避免读不到时错误回退为 True。
@@ -353,13 +361,10 @@ class InfoManager(Singleton):
                 else:
                     broadcast_enabled = cfg.get('soul', {}).get('broadcast_playing_info', True)
                 if not broadcast_enabled:
-                    self.logger.info(
-                        f'Hidden "{info.get("song", "Unknown")} - {info.get("singer", "Unknown")} • {info.get("album", "Unknown")}"'
-                    )
+                    self.logger.info(f'Hidden "{playback_message}"')
                     return
 
-                self.handler.send_message(
-                    f"{info['song']} - {info['singer']} • {info['album']}")
+                self.handler.send_message(playback_message)
         else:
             # 如果歌曲信息无效，记录错误但不中断监控
             if 'error' in info:

--- a/src/ushareiplay/managers/info_manager.py
+++ b/src/ushareiplay/managers/info_manager.py
@@ -328,6 +328,21 @@ class InfoManager(Singleton):
         """
         return self._playback_info_cache
 
+    def ensure_cached_release_date(self) -> Optional[dict]:
+        info = self.get_playback_info_cache()
+        if info is None or "error" in info:
+            return info
+        if info.get("release_date"):
+            return info
+
+        try:
+            from ushareiplay.handlers.qq_music_handler import QQMusicHandler
+            music_handler = QQMusicHandler.instance()
+            music_handler.ensure_release_date(info)
+        except Exception:
+            self.logger.warning(f"Failed to ensure cached release date: {traceback.format_exc()}")
+        return info
+
     def _format_playback_message(self, info: dict) -> str:
         message = f"{info['song']} - {info['singer']} • {info['album']}"
         release_date = info.get("release_date")

--- a/tests/test_command_manager_runtime_context.py
+++ b/tests/test_command_manager_runtime_context.py
@@ -116,6 +116,23 @@ def test_process_command_uses_runtime_for_observability_and_ui_session():
     ]
 
 
+def test_process_command_defaults_missing_release_date_for_templates():
+    manager, _runtime, _controller = make_manager(Path("."))
+    message_info = SimpleNamespace(content=":demo abc", nickname="Console")
+    command_info = {
+        "parameters": ["abc"],
+        "prefix": ":demo",
+        "response_template": "ok {song} {release_date}",
+        "error_template": "error {error}",
+    }
+
+    result = asyncio.run(
+        manager.process_command(FakeCommand(), message_info, command_info)
+    )
+
+    assert result == "ok abc  @Console"
+
+
 def test_extract_private_reply_and_normalize_dollar_prefix():
     manager, _runtime, _controller = make_manager(Path("."))
 

--- a/tests/test_info_command_release_date.py
+++ b/tests/test_info_command_release_date.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+import pytest
+
+from ushareiplay.commands.info import InfoCommand
+from ushareiplay.managers.info_manager import InfoManager
+
+
+@pytest.fixture
+def info_manager():
+    if hasattr(InfoManager, "_instance"):
+        del InfoManager._instance
+    manager = InfoManager.instance()
+    manager._logger = SimpleNamespace(info=lambda _message: None)
+    return manager
+
+
+class _MusicHandler:
+    play_mode_key = "unknown"
+
+    def play_mode_key_to_name(self, _key):
+        return "未知"
+
+
+def _patch_common_info_dependencies(monkeypatch, info_manager):
+    monkeypatch.setattr(
+        "ushareiplay.handlers.qq_music_handler.QQMusicHandler.instance",
+        lambda: _MusicHandler(),
+    )
+    info_manager._online_users = set()
+    info_manager._party_manager = SimpleNamespace(init_time=None)
+
+
+@pytest.mark.asyncio
+async def test_info_command_returns_empty_release_date_when_cache_missing(monkeypatch, info_manager):
+    _patch_common_info_dependencies(monkeypatch, info_manager)
+    command = InfoCommand(
+        SimpleNamespace(soul_handler=SimpleNamespace(), music_handler=SimpleNamespace())
+    )
+
+    result = await command.process(SimpleNamespace(nickname="Console"), [])
+
+    assert result["release_date"] == ""
+
+
+@pytest.mark.asyncio
+async def test_info_command_preserves_cached_release_date(monkeypatch, info_manager):
+    _patch_common_info_dependencies(monkeypatch, info_manager)
+    info_manager._playback_info_cache = {
+        "song": "泼墨桃花",
+        "singer": "林峯",
+        "album": "爱在记忆中找你",
+        "release_date": "2007-11-23",
+    }
+    command = InfoCommand(
+        SimpleNamespace(soul_handler=SimpleNamespace(), music_handler=SimpleNamespace())
+    )
+
+    result = await command.process(SimpleNamespace(nickname="Console"), [])
+
+    assert result["release_date"] == "2007-11-23"

--- a/tests/test_info_manager_broadcast.py
+++ b/tests/test_info_manager_broadcast.py
@@ -99,3 +99,23 @@ def test_send_playing_message_backward_compatible_nested_config(info_manager):
         mock_handler.config = {'soul': {'broadcast_playing_info': False}}
         info_manager.send_playing_message()
         mock_handler.send_message.assert_not_called()
+
+
+def test_ensure_cached_release_date_updates_playback_cache(info_manager):
+    info_manager._playback_info_cache = {
+        "song": "如风",
+        "singer": "王菲",
+        "album": "十万个为什么？(日本版）",
+    }
+
+    with patch("ushareiplay.handlers.qq_music_handler.QQMusicHandler.instance") as mock_qq_instance:
+        mock_music_handler = MagicMock()
+        mock_qq_instance.return_value = mock_music_handler
+        mock_music_handler.ensure_release_date.side_effect = (
+            lambda song_info: song_info.update({"release_date": "1993-09-07"})
+        )
+
+        result = info_manager.ensure_cached_release_date()
+
+    assert result["release_date"] == "1993-09-07"
+    assert info_manager.get_playback_info_cache()["release_date"] == "1993-09-07"

--- a/tests/test_info_manager_broadcast.py
+++ b/tests/test_info_manager_broadcast.py
@@ -23,12 +23,15 @@ def test_send_playing_message_respects_broadcast_toggle(info_manager):
     with patch('ushareiplay.handlers.qq_music_handler.QQMusicHandler.instance') as mock_qq_instance:
         mock_music_handler = MagicMock()
         mock_qq_instance.return_value = mock_music_handler
-        mock_music_handler.handle_song_quality_check.return_value = False
+        skip_result = {"value": False}
+        mock_music_handler.handle_song_quality_check.side_effect = (
+            lambda song_info: song_info.update({"release_date": "2020-01-02"}) or skip_result["value"]
+        )
         
         # Case 1: Broadcast enabled (True) - should send message
         mock_handler.config = {'broadcast_playing_info': True}
         info_manager.send_playing_message()
-        mock_handler.send_message.assert_called_once_with("SongA - SingerA • AlbumA")
+        mock_handler.send_message.assert_called_once_with("SongA - SingerA • AlbumA 2020-01-02")
         mock_handler.send_message.reset_mock()
         mock_music_handler.handle_song_quality_check.assert_called_once_with(info)
         mock_music_handler.handle_song_quality_check.reset_mock()
@@ -39,18 +42,18 @@ def test_send_playing_message_respects_broadcast_toggle(info_manager):
         mock_handler.send_message.assert_not_called()
         mock_music_handler.handle_song_quality_check.assert_called_once_with(info)
         mock_music_handler.handle_song_quality_check.reset_mock()
-        mock_logger.info.assert_called_with('Hidden "SongA - SingerA • AlbumA"')
+        mock_logger.info.assert_called_with('Hidden "SongA - SingerA • AlbumA 2020-01-02"')
         mock_logger.info.reset_mock()
         
         # Case 3: Broadcast enabled but song skipped (quality check) - should NOT send message
         mock_handler.config = {'broadcast_playing_info': True}
-        mock_music_handler.handle_song_quality_check.return_value = True
+        skip_result["value"] = True
         info_manager.send_playing_message()
         mock_handler.send_message.assert_not_called()
 
         # Case 4: Broadcast disabled (False) and song skipped (quality check) - should NOT send message and should NOT log broadcast disabled message
         mock_handler.config = {'broadcast_playing_info': False}
-        mock_music_handler.handle_song_quality_check.return_value = True
+        skip_result["value"] = True
         mock_music_handler.handle_song_quality_check.reset_mock()
         info_manager.send_playing_message()
         mock_handler.send_message.assert_not_called()
@@ -71,11 +74,14 @@ def test_send_playing_message_default_behavior(info_manager):
         mock_music_handler = MagicMock()
         mock_qq_instance.return_value = mock_music_handler
         mock_music_handler.handle_song_quality_check.return_value = False
+        mock_music_handler.handle_song_quality_check.side_effect = (
+            lambda song_info: song_info.update({"release_date": "2020-01-02"}) or False
+        )
         
         # Case: Config missing 'broadcast_playing_info' - should default to True and send message
         mock_handler.config = {}
         info_manager.send_playing_message()
-        mock_handler.send_message.assert_called_once_with("SongA - SingerA • AlbumA")
+        mock_handler.send_message.assert_called_once_with("SongA - SingerA • AlbumA 2020-01-02")
 
 
 def test_send_playing_message_backward_compatible_nested_config(info_manager):

--- a/tests/test_playlist_response_format.py
+++ b/tests/test_playlist_response_format.py
@@ -5,6 +5,12 @@ import yaml
 from ushareiplay.helpers.playlist_info import get_playlist_text_and_first_song
 
 
+def _commands_by_prefix():
+    config_path = Path(__file__).resolve().parents[1] / "config.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    return {item["prefix"]: item for item in config["commands"]}
+
+
 def test_get_playlist_text_and_first_song_returns_trimmed_playlist_and_first_song():
     playlist_text, first_song, error = get_playlist_text_and_first_song(
         {"playlist": " 第一首 - 歌手A \n第二首 - 歌手B "}
@@ -34,12 +40,34 @@ def test_get_playlist_text_and_first_song_rejects_empty_playlist():
 
 
 def test_list_play_commands_use_playlist_response_template():
-    config_path = Path(__file__).resolve().parents[1] / "config.yaml"
-    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    commands = {item["prefix"]: item for item in config["commands"]}
+    commands = _commands_by_prefix()
 
     assert commands["playlist"]["response_template"] == "{playlist}"
     assert commands["radio"]["response_template"] == "{playlist}"
     assert commands["singer"]["response_template"] == "{playlist}"
     assert commands["album"]["response_template"] == "{playlist}"
     assert commands["fav"]["response_template"] == "{playlist}"
+
+
+def test_info_response_template_includes_release_date_at_end():
+    commands = _commands_by_prefix()
+
+    template = commands["info"]["response_template"]
+
+    assert template.endswith("{song} - {singer} • {album} • {release_date}")
+
+
+def test_play_response_template_includes_release_date_at_end():
+    commands = _commands_by_prefix()
+
+    template = commands["play"]["response_template"]
+
+    assert template.endswith("{song} - {singer} • {album} • {release_date}")
+
+
+def test_next_response_template_includes_release_date_at_end():
+    commands = _commands_by_prefix()
+
+    template = commands["next"]["response_template"]
+
+    assert template.endswith("Added {song} by {singer} in {album} • {release_date} to playlist")

--- a/tests/test_radio_old_song_filter.py
+++ b/tests/test_radio_old_song_filter.py
@@ -252,12 +252,12 @@ def test_quality_check_skips_old_song_for_any_playback_mode(monkeypatch):
 def test_quality_check_accepts_new_song_for_any_playback_mode(monkeypatch):
     handler = _make_handler_for_quality_check()
     monkeypatch.setattr(handler.song_release_lookup, "get_release_date", lambda _song: "2018-01-01")
+    song_info = {"song": "新歌", "singer": "歌手A", "album": "专辑A"}
 
-    should_skip = handler.should_skip_low_quality_song(
-        {"song": "新歌", "singer": "歌手A", "album": "专辑A"}
-    )
+    should_skip = handler.should_skip_low_quality_song(song_info)
 
     assert should_skip is False
+    assert song_info["release_date"] == "2018-01-01"
 
 
 class _PlayMusicHandler:

--- a/tests/test_radio_old_song_filter.py
+++ b/tests/test_radio_old_song_filter.py
@@ -249,6 +249,39 @@ def test_quality_check_skips_old_song_for_any_playback_mode(monkeypatch):
     assert should_skip is True
 
 
+def test_quality_check_accepts_old_song_for_whitelisted_artist(monkeypatch):
+    handler = _make_handler_for_quality_check()
+    handler.config["old_song_filter"]["artist_whitelist"] = ["歌手A"]
+    monkeypatch.setattr(handler.song_release_lookup, "get_release_date", lambda _song: "1999-01-01")
+    song_info = {"song": "老歌", "singer": "歌手A/歌手B", "album": "专辑A"}
+
+    should_skip = handler.should_skip_low_quality_song(song_info)
+
+    assert should_skip is False
+    assert song_info["release_date"] == "1999-01-01"
+
+
+def test_quality_check_reads_artist_whitelist_from_controller_config(monkeypatch):
+    handler = _make_handler_for_quality_check()
+    handler.config = {}
+    handler.controller = SimpleNamespace(
+        config={
+            "old_song_filter": {
+                "enabled": True,
+                "cutoff_date": "2000-01-01",
+                "artist_whitelist": ["王菲", "911"],
+            }
+        }
+    )
+    monkeypatch.setattr(handler.song_release_lookup, "get_release_date", lambda _song: "1993-09-07")
+    song_info = {"song": "如风", "singer": "王菲", "album": "十万个为什么？(日本版）"}
+
+    should_skip = handler.should_skip_low_quality_song(song_info)
+
+    assert should_skip is False
+    assert song_info["release_date"] == "1993-09-07"
+
+
 def test_quality_check_accepts_new_song_for_any_playback_mode(monkeypatch):
     handler = _make_handler_for_quality_check()
     monkeypatch.setattr(handler.song_release_lookup, "get_release_date", lambda _song: "2018-01-01")
@@ -258,6 +291,16 @@ def test_quality_check_accepts_new_song_for_any_playback_mode(monkeypatch):
 
     assert should_skip is False
     assert song_info["release_date"] == "2018-01-01"
+
+
+def test_ensure_release_date_populates_song_info_without_skip_decision(monkeypatch):
+    handler = _make_handler_for_quality_check()
+    monkeypatch.setattr(handler.song_release_lookup, "get_release_date", lambda _song: "1993-09-07")
+    song_info = {"song": "如风", "singer": "王菲", "album": "十万个为什么？(日本版）"}
+
+    handler.ensure_release_date(song_info)
+
+    assert song_info["release_date"] == "1993-09-07"
 
 
 class _PlayMusicHandler:


### PR DESCRIPTION
## Summary
- Read `old_song_filter` from the root controller config so artist whitelists like 王菲 work at runtime.
- Populate release dates before play/next/info responses are formatted, not only during hidden broadcast checks.
- Add regression tests for whitelisted old songs, release-date templates, and safe missing-date formatting.

## Test Plan
- [x] uv run pytest -q