### PR TITLE
fix(gesture): use mobile clickGesture with fallbacks for element taps

### DIFF
--- a/src/ushareiplay/core/ui/gesture_handler.py
+++ b/src/ushareiplay/core/ui/gesture_handler.py
@@ -31,6 +31,67 @@ class GestureHandler:
     def logger(self):
         return self.owner.logger
 
+    def _clamp_click_coords(self, click_x: int, click_y: int) -> Tuple[int, int]:
+        """Clamp tap coordinates to the visible screen bounds."""
+        try:
+            window = self.driver.get_window_size()
+            screen_w = int(window.get("width", 0))
+            screen_h = int(window.get("height", 0))
+        except Exception:
+            screen_w = screen_h = 0
+
+        if screen_w > 0:
+            click_x = max(0, min(click_x, screen_w - 1))
+        else:
+            click_x = max(0, click_x)
+
+        if screen_h > 0:
+            click_y = max(0, min(click_y, screen_h - 1))
+        elif click_y < 60:
+            click_y = 60
+        else:
+            click_y = max(0, click_y)
+
+        return click_x, click_y
+
+    def _perform_click_at(self, click_x: int, click_y: int, element=None) -> bool:
+        """Tap at absolute screen coordinates with UiAutomator2-friendly fallbacks."""
+        click_x, click_y = self._clamp_click_coords(click_x, click_y)
+
+        try:
+            self.driver.execute_script(
+                "mobile: clickGesture", {"x": click_x, "y": click_y}
+            )
+            return True
+        except Exception:
+            self.logger.debug(
+                "mobile: clickGesture failed, falling back to W3C touch actions"
+            )
+
+        try:
+            actions = ActionChains(self.driver)
+            actions.w3c_actions = ActionBuilder(
+                self.driver, mouse=PointerInput(interaction.POINTER_TOUCH, "touch")
+            )
+            pointer = actions.w3c_actions.pointer_action
+            pointer.move_to_location(click_x, click_y)
+            pointer.pointer_down()
+            pointer.pause(0.1)
+            pointer.pointer_up()
+            actions.perform()
+            return True
+        except Exception:
+            self.logger.debug("W3C touch click failed, falling back to element.click()")
+
+        if element is not None:
+            try:
+                element.click()
+                return True
+            except Exception:
+                pass
+
+        return False
+
     @with_driver_recovery(retry=False, op="write")
     def click_element_at(
             self, element, x_ratio=0.5, y_ratio=0.5, x_offset=0, y_offset=0
@@ -47,29 +108,23 @@ class GestureHandler:
             if not element:
                 return False
 
-            # Get element size and location
             size = element.size
             location = element.location
 
-            # Calculate click position
             click_x = location["x"] + int(x_offset) + int(size["width"] * x_ratio)
             click_y = location["y"] + int(y_offset) + int(size["height"] * y_ratio)
-            if click_y < 60:
+            raw_x, raw_y = click_x, click_y
+            click_x, click_y = self._clamp_click_coords(click_x, click_y)
+            if (click_x, click_y) != (raw_x, raw_y):
                 self.logger.warning(
-                    f"Click position is too top, click_x: {click_x}, click_y: {click_y}"
+                    f"Click position clamped from ({raw_x}, {raw_y}) to ({click_x}, {click_y})"
                 )
-                click_y = 60
 
-            # Perform tap action at calculated position
-            actions = ActionChains(self.driver)
-            actions.w3c_actions = ActionBuilder(
-                self.driver, mouse=PointerInput(interaction.POINTER_TOUCH, "touch")
-            )
-            actions.w3c_actions.pointer_action.move_to_location(click_x, click_y)
-            actions.w3c_actions.pointer_action.pointer_down()
-            actions.w3c_actions.pointer_action.pause(0.1)
-            actions.w3c_actions.pointer_action.pointer_up()
-            actions.perform()
+            if not self._perform_click_at(click_x, click_y, element=element):
+                self.logger.error(
+                    f"All click strategies failed at position ({click_x}, {click_y})"
+                )
+                return False
 
             self.logger.debug(f"Clicked element at position ({click_x}, {click_y})")
             return True

--- a/tests/test_gesture_handler.py
+++ b/tests/test_gesture_handler.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock
+
+import pytest
+from selenium.common.exceptions import InvalidElementStateException
+
+from ushareiplay.core.ui.gesture_handler import GestureHandler
+
+
+class _Owner:
+    def __init__(self, driver):
+        self.driver = driver
+        self.logger = MagicMock()
+
+
+def _make_handler(driver):
+    return GestureHandler(_Owner(driver))
+
+
+def test_click_element_at_uses_mobile_click_gesture():
+    driver = MagicMock()
+    driver.get_window_size.return_value = {"width": 1080, "height": 2400}
+    element = MagicMock()
+    element.size = {"width": 200, "height": 80}
+    element.location = {"x": 100, "y": 200}
+
+    handler = _make_handler(driver)
+    assert handler.click_element_at(element, x_ratio=0.5, y_ratio=0.5) is True
+
+    driver.execute_script.assert_called_once_with(
+        "mobile: clickGesture", {"x": 200, "y": 240}
+    )
+
+
+def test_click_element_at_falls_back_to_element_click_when_gestures_fail(monkeypatch):
+    driver = MagicMock()
+    driver.get_window_size.return_value = {"width": 1080, "height": 2400}
+    driver.execute_script.side_effect = InvalidElementStateException("gesture failed")
+    element = MagicMock()
+    element.size = {"width": 200, "height": 80}
+    element.location = {"x": 100, "y": 200}
+    element.click.return_value = None
+
+    class _FailingActions:
+        def __init__(self, *_args, **_kwargs):
+            self.w3c_actions = MagicMock()
+
+        def perform(self):
+            raise InvalidElementStateException("w3c failed")
+
+    monkeypatch.setattr(
+        "ushareiplay.core.ui.gesture_handler.ActionChains", _FailingActions
+    )
+
+    handler = _make_handler(driver)
+    assert handler.click_element_at(element) is True
+    element.click.assert_called_once_with()
+
+
+def test_click_element_at_clamps_negative_y_ratio_to_screen_top():
+    driver = MagicMock()
+    driver.get_window_size.return_value = {"width": 1080, "height": 2400}
+    element = MagicMock()
+    element.size = {"width": 200, "height": 80}
+    element.location = {"x": 100, "y": 40}
+
+    handler = _make_handler(driver)
+    assert handler.click_element_at(element, x_ratio=0.5, y_ratio=-1) is True
+
+    driver.execute_script.assert_called_once_with(
+        "mobile: clickGesture", {"x": 200, "y": 0}
+    )
+
+
+def test_clamp_click_coords_without_window_size_uses_legacy_floor():
+    driver = MagicMock()
+    driver.get_window_size.side_effect = RuntimeError("no session")
+    handler = _make_handler(driver)
+
+    assert handler._clamp_click_coords(120, -20) == (120, 60)


### PR DESCRIPTION
## Summary
- Fix `InvalidElementStateException` when clicking `input_box` to dismiss the keyboard after sending a message
- Prefer Appium `mobile: clickGesture` over W3C touch actions in `click_element_at`, with fallbacks to W3C and `element.click()`
- Clamp tap coordinates to screen bounds for negative `y_ratio` offsets (e.g. `click_element_at(input_box, 0.5, -1)`)

## Test plan
- [x] `uv run pytest -q tests/test_gesture_handler.py tests/test_app_handler_ui_delegates.py`
- [ ] Send a chat message on device and confirm keyboard dismiss no longer errors
- [ ] Verify drawer/recovery clicks still work (`click_element_at` with negative offsets)


Made with [Cursor](https://cursor.com)