### PR TITLE
[codex] Centralize outbound message dispatch

### DIFF
--- a/src/ushareiplay/commands/lyrics.py
+++ b/src/ushareiplay/commands/lyrics.py
@@ -222,7 +222,7 @@ class LyricsCommand(BaseCommand):
         l = 0
         for lyr in groups:
             l += len(lyr)
-            self.soul_handler.send_message(lyr)
+            self.message_dispatch.send_screen_message(lyr)
 
         prompt = f' {len(groups)} piece(s) of lyrics sent, {l} characters'
         # Send lyrics back to Soul using command's template

--- a/src/ushareiplay/commands/notice.py
+++ b/src/ushareiplay/commands/notice.py
@@ -52,7 +52,7 @@ class NoticeCommand(BaseCommand):
                 notice_content = str(success_message).replace('Notice restored to: ', '')
                 
                 self.handler.logger.info(f'Notice update completed: {notice_content}')
-                self.handler.send_message(f"Notice updated to: {notice_content}")
+                self.message_dispatch.send_screen_message(f"Notice updated to: {notice_content}")
 
         except Exception:
             self.handler.log_error(f"Error in notice update: {traceback.format_exc()}")

--- a/src/ushareiplay/commands/radio.py
+++ b/src/ushareiplay/commands/radio.py
@@ -44,7 +44,7 @@ class RadioCommand(BaseCommand):
 
     def _report_error(self, message: str):
         self.music_handler.logger.error(message)
-        self.soul_handler.send_message(message)
+        self.message_dispatch.send_screen_message(message)
         return {"error": message}
 
     def _navigate_home(self):

--- a/src/ushareiplay/commands/say.py
+++ b/src/ushareiplay/commands/say.py
@@ -25,7 +25,6 @@ class SayCommand(BaseCommand):
             return {'error': '消息内容不能为空'}
 
         # 发送消息
-        # self.handler.send_message(message)
         self.handler.logger.info(f"Say command executed by {message_info.nickname}: {message}")
 
         return {'message': f'{message}'}

--- a/src/ushareiplay/commands/title.py
+++ b/src/ushareiplay/commands/title.py
@@ -117,7 +117,7 @@ class TitleCommand(BaseCommand):
             if 'error' not in result:
                 # Success - update completed
                 self.handler.logger.info(f'标题更新成功: {self.title_manager.get_current_title()}')
-                self.handler.send_message(
+                self.message_dispatch.send_screen_message(
                     f"标题已更新为: {self.title_manager.get_current_title()}"
                 )
             else:

--- a/src/ushareiplay/core/app_controller.py
+++ b/src/ushareiplay/core/app_controller.py
@@ -333,6 +333,8 @@ class AppController(Singleton):
             self.command_manager = CommandManager.instance()
             self.command_manager.controller = self
             self.command_manager.configure_runtime(self.command_runtime_context)
+            from ushareiplay.core.message_dispatch import MessageDispatch
+            self.message_dispatch = MessageDispatch.instance()
             self.info_manager = InfoManager.instance()
             self.party_manager = PartyManager.instance()
             self.notice_manager = NoticeManager.instance()
@@ -340,6 +342,7 @@ class AppController(Singleton):
             self._runtime_queue_drainer = RuntimeQueueDrainer(
                 handler=self.soul_handler,
                 command_manager=self.command_manager,
+                send_screen_message=self.message_dispatch.send_screen_message,
                 obs=self.obs,
                 logger=self.logger,
             )
@@ -462,7 +465,7 @@ class AppController(Singleton):
                                     )
                                     self.logger.info(f"{input_source} message added to queue: {message}")
                                 else:
-                                    self.soul_handler.send_message(message)
+                                    self.message_dispatch.send_screen_message(message)
 
                 except queue.Empty:
                     pass

--- a/src/ushareiplay/core/base_command.py
+++ b/src/ushareiplay/core/base_command.py
@@ -27,6 +27,7 @@ class BaseCommand(ABC):
         self._title_manager = None
         self._topic_manager = None
         self._theme_manager = None
+        self._message_dispatch = None
 
     async def process(self, message_info, parameters):
         """Command shell: mic prelude -> do_process -> exception-to-error mapping.
@@ -104,6 +105,14 @@ class BaseCommand(ABC):
             from ushareiplay.managers.theme_manager import ThemeManager
             self._theme_manager = ThemeManager.instance()
         return self._theme_manager
+
+    @property
+    def message_dispatch(self):
+        if self._message_dispatch is None:
+            from ushareiplay.core.message_dispatch import MessageDispatch
+
+            self._message_dispatch = MessageDispatch.instance().bind_handler(self.soul_handler)
+        return self._message_dispatch
 
     def update(self):
         """Update method called every monitoring loop

--- a/src/ushareiplay/core/message_dispatch.py
+++ b/src/ushareiplay/core/message_dispatch.py
@@ -1,0 +1,109 @@
+import traceback
+
+from ushareiplay.core.command_silence import is_command_silent
+from ushareiplay.core.singleton import Singleton
+
+
+class MessageDispatch(Singleton):
+    """Route outbound chat messages through one observable application seam."""
+
+    def __init__(self):
+        self._handler = None
+        self._user_manager = None
+        self._runtime = None
+
+    def configure_runtime(self, runtime):
+        self._runtime = runtime
+        controller = getattr(runtime, "controller", None)
+        handler = getattr(controller, "soul_handler", None)
+        if handler is not None:
+            self._handler = handler
+
+    def bind_handler(self, handler):
+        """Bind the active Soul handler for callers constructed outside runtime setup."""
+        if handler is not None:
+            self._handler = handler
+        return self
+
+    @property
+    def handler(self):
+        if self._handler is None:
+            from ushareiplay.handlers.soul_handler import SoulHandler
+
+            self._handler = SoulHandler.instance()
+        return self._handler
+
+    @property
+    def user_manager(self):
+        if self._user_manager is None:
+            from ushareiplay.managers.user_manager import UserManager
+
+            self._user_manager = UserManager.instance()
+        return self._user_manager
+
+    def _emit(self, event, ctx):
+        if self._runtime is None:
+            return
+        try:
+            self._runtime.emit(event, ctx=ctx)
+        except Exception:
+            pass
+
+    def send_screen_message(self, message: str, silent: bool = False):
+        """Send a room message unless the current command suppresses screen output."""
+        if silent or is_command_silent():
+            try:
+                self.handler.logger.info(f"Silent command suppressed screen message: {message}")
+            except Exception:
+                pass
+            self._emit(
+                "message.dispatch.suppressed",
+                {"channel": "screen", "message_len": len(message)},
+            )
+            return None
+
+        try:
+            result = self.handler.send_message(message)
+        except Exception:
+            self._emit(
+                "message.dispatch.screen",
+                {"message_len": len(message), "sent": False},
+            )
+            raise
+        self._emit(
+            "message.dispatch.screen",
+            {"message_len": len(message), "sent": not isinstance(result, dict) or "error" not in result},
+        )
+        return result
+
+    def send_private_message(self, nickname: str, message: str) -> bool:
+        """Send a private reply and record its outcome without logging its contents."""
+        try:
+            sent = self.user_manager.send_private_message_to_user(nickname, message)
+            if not sent:
+                self.handler.logger.warning(f"Private reply dropped for {nickname}: send failed")
+            self._emit(
+                "message.dispatch.private",
+                {"nickname": nickname, "message_len": len(message), "sent": bool(sent)},
+            )
+            return bool(sent)
+        except Exception:
+            try:
+                self.handler.logger.error(
+                    f"Private reply failed for {nickname}: {traceback.format_exc()}"
+                )
+            except Exception:
+                pass
+            self._emit(
+                "message.dispatch.private",
+                {"nickname": nickname, "message_len": len(message), "sent": False},
+            )
+            return False
+
+    def send_for_message_info(self, message_info, response: str, silent: bool = False):
+        """Route command output according to the requester's private-reply preference."""
+        if not response:
+            return None
+        if getattr(message_info, "private_reply", False):
+            return self.send_private_message(message_info.nickname, response)
+        return self.send_screen_message(response, silent=silent)

--- a/src/ushareiplay/core/runtime_services.py
+++ b/src/ushareiplay/core/runtime_services.py
@@ -8,9 +8,10 @@ from ushareiplay.core.message_queue import MessageQueue
 class RuntimeQueueDrainer:
     """Drain MessageQueue from runtime loop (single authoritative path)."""
 
-    def __init__(self, *, handler, command_manager, obs=None, logger=None):
+    def __init__(self, *, handler, command_manager, send_screen_message, obs=None, logger=None):
         self.handler = handler
         self.command_manager = command_manager
+        self.send_screen_message = send_screen_message
         self.obs = obs
         self.logger = logger or getattr(handler, "logger", None)
 
@@ -24,7 +25,7 @@ class RuntimeQueueDrainer:
 
         command_count = await self.command_manager.execute_runtime_queue_messages(
             queue_messages.values(),
-            send_screen_message=self.handler.send_message,
+            send_screen_message=self.send_screen_message,
         )
 
         if self.obs:

--- a/src/ushareiplay/handlers/soul_handler.py
+++ b/src/ushareiplay/handlers/soul_handler.py
@@ -1,6 +1,5 @@
 import logging
 
-from ushareiplay.core.command_silence import is_command_silent
 from ushareiplay.managers.message_manager import MessageManager
 from ushareiplay.core.app_handler import AppHandler
 from ushareiplay.core.singleton import Singleton
@@ -27,10 +26,11 @@ class SoulHandler(AppHandler, Singleton):
         return self._message_manager
 
     def send_message(self, message):
-        """Send message"""
-        if is_command_silent():
-            self.logger.info(f"Silent command suppressed screen message: {message}")
-            return None
+        """Send a room message through the low-level Soul UI primitive.
+
+        Business code should use ``MessageDispatch`` so routing and suppression
+        are applied consistently.
+        """
 
         self.switch_to_app()
 

--- a/src/ushareiplay/managers/command_manager.py
+++ b/src/ushareiplay/managers/command_manager.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from ushareiplay.core.chat_intake import ChatIntakeKind, classify_chat_line, expand_queue_text
 from ushareiplay.core.command_silence import command_silence
+from ushareiplay.core.message_dispatch import MessageDispatch
 from ushareiplay.core.singleton import Singleton
 from ushareiplay.core.command_parser import CommandParser
 from ushareiplay.models.message_info import MessageInfo
@@ -38,6 +39,7 @@ class CommandManager(Singleton):
 
     def configure_runtime(self, runtime):
         self._runtime = runtime
+        MessageDispatch.instance().configure_runtime(runtime)
 
     @property
     def runtime(self):
@@ -59,6 +61,10 @@ class CommandManager(Singleton):
         if self._logger is None:
             self._logger = self.handler.logger
         return self._logger
+
+    @property
+    def message_dispatch(self):
+        return MessageDispatch.instance().bind_handler(self.handler)
 
     def _get_command_controller(self):
         if self.controller is not None:
@@ -173,39 +179,6 @@ class CommandManager(Singleton):
         """Get command by name"""
         module = self.load_command_module(command_name)
         return module.command if module else None
-
-    def _send_screen_message(self, message: str, silent: bool = False):
-        if silent:
-            try:
-                self.logger.info(f"Silent command suppressed screen message: {message}")
-            except Exception:
-                pass
-            return None
-        return self.handler.send_message(message)
-
-    def _send_command_output(self, message_info, response: str, silent: bool = False):
-        """Route command execution output to private chat or screen."""
-        if not response:
-            return None
-        if getattr(message_info, "private_reply", False):
-            try:
-                from ushareiplay.managers.user_manager import UserManager
-
-                sent = UserManager.instance().send_private_message_to_user(
-                    message_info.nickname,
-                    response,
-                )
-                if not sent:
-                    self.logger.warning(
-                        f"Private reply dropped for {message_info.nickname}: send failed"
-                    )
-                return sent
-            except Exception:
-                self.logger.error(
-                    f"Private reply failed for {message_info.nickname}: {traceback.format_exc()}"
-                )
-                return False
-        return self._send_screen_message(response, silent=silent)
 
     async def process_command(self, command, message_info, command_info):
         """Process command using module if available
@@ -470,7 +443,7 @@ class CommandManager(Singleton):
                     # Handle different commands using match-case
                     cmd = command_info['prefix']
                     time_prefix = datetime.now().strftime('%H:%M:%S')
-                    self._send_screen_message(
+                    self.message_dispatch.send_screen_message(
                         f'[{time_prefix}] {cmd} ... @{message_info.nickname}',
                         silent=silent,
                     )
@@ -479,11 +452,13 @@ class CommandManager(Singleton):
                     if command:
                         response = await self.process_command(command, message_info, command_info)
                         if response:
-                            self._send_command_output(message_info, response, silent=silent)
+                            self.message_dispatch.send_for_message_info(
+                                message_info, response, silent=silent
+                            )
                         success_count += 1
                     else:
                         self.logger.error(f"Unknown command: {cmd}")
-                        self._send_screen_message(
+                        self.message_dispatch.send_screen_message(
                             f'[{time_prefix}] Unknown command: {cmd} @{message_info.nickname}',
                             silent=silent,
                         )

--- a/src/ushareiplay/managers/party_manager.py
+++ b/src/ushareiplay/managers/party_manager.py
@@ -14,6 +14,7 @@ class PartyManager(Singleton):
         # 延迟初始化，避免循环依赖
         self._handler = None
         self._logger = None
+        self._message_dispatch = None
 
         # 派对重启相关状态
         self.init_time = None  # 初始化时间
@@ -34,6 +35,14 @@ class PartyManager(Singleton):
         if self._logger is None:
             self._logger = self.handler.logger
         return self._logger
+
+    @property
+    def message_dispatch(self):
+        if self._message_dispatch is None:
+            from ushareiplay.core.message_dispatch import MessageDispatch
+
+            self._message_dispatch = MessageDispatch.instance().bind_handler(self.handler)
+        return self._message_dispatch
 
     def initialize(self):
         """初始化派对管理器"""
@@ -103,7 +112,7 @@ class PartyManager(Singleton):
         返回包含结果的字典
         """
         try:
-            self.handler.send_message('Ending party')
+            self.message_dispatch.send_screen_message('Ending party')
 
             # Switch to Soul app first
             if not self.handler.switch_to_app():

--- a/src/ushareiplay/managers/seat_manager/seat_check.py
+++ b/src/ushareiplay/managers/seat_manager/seat_check.py
@@ -10,6 +10,15 @@ class SeatCheckManager(SeatManagerBase):
     def __init__(self, handler=None):
         super().__init__(handler)
         self.seat_ui = SeatUIManager(handler)
+        self._message_dispatch = None
+
+    @property
+    def message_dispatch(self):
+        if self._message_dispatch is None:
+            from ushareiplay.core.message_dispatch import MessageDispatch
+
+            self._message_dispatch = MessageDispatch.instance().bind_handler(self.handler)
+        return self._message_dispatch
 
     async def check_seats_on_entry(self, username: str = None):
         """Check seats when user enters the party"""
@@ -80,7 +89,7 @@ class SeatCheckManager(SeatManagerBase):
         seat_desks = self.handler.find_elements('seat_desk')
         if not seat_desks:
             self.handler.log_error("cannot find seat desks")
-            self.handler.send_message(f"System error: Unable to access seats for {username}")
+            self.message_dispatch.send_screen_message(f"System error: Unable to access seats for {username}")
             return
         self.handler.logger.info(f"found {len(seat_desks)} seat desks")
         if len(seat_desks) != 6:
@@ -124,7 +133,7 @@ class SeatCheckManager(SeatManagerBase):
 
         if not seat_element:
             self.handler.logger.error(f"Cannot find seat element for seat {seat_number}")
-            self.handler.send_message(f"Failed to locate seat {seat_number} for {username}")
+            self.message_dispatch.send_screen_message(f"Failed to locate seat {seat_number} for {username}")
             return
 
         if not seat_label:
@@ -133,7 +142,7 @@ class SeatCheckManager(SeatManagerBase):
         self.handler.logger.info(f"Found seat {seat_number} with label {seat_label.text if seat_label else 'None'}")
         
         # Send welcome message only when seat is occupied to reduce message frequency
-        self.handler.send_message(f"Welcome {username}!")
+        self.message_dispatch.send_screen_message(f"Welcome {username}!")
 
         # wait for input dialog disappear
         await asyncio.sleep(1)
@@ -145,13 +154,13 @@ class SeatCheckManager(SeatManagerBase):
         seat_off = self.handler.wait_for_element_clickable('seat_off')
         if not seat_off:
             self.handler.logger.error(f"Failed to find seat off button for seat {seat_number}")
-            self.handler.send_message(f"Unable to manage seat {seat_number} for {username}")
+            self.message_dispatch.send_screen_message(f"Unable to manage seat {seat_number} for {username}")
             return
 
         found_key, souler_name = self.handler.wait_for_any_element(['souler_name', 'user_name'])
         if not souler_name:
             self.handler.logger.error(f"No souler name found for seat {seat_number}")
-            self.handler.send_message(f"Failed to verify occupant on seat {seat_number}")
+            self.message_dispatch.send_screen_message(f"Failed to verify occupant on seat {seat_number}")
             return
 
         souler_name_text = souler_name.text
@@ -167,7 +176,7 @@ class SeatCheckManager(SeatManagerBase):
             self.handler.logger.info(
                 f"Souler {souler_name_text} has higher or equal level ({souler.level}) than {username} ({user.level}), skipping")
             self.handler.press_back()
-            self.handler.send_message(f"Cannot seat {username}: Seat {seat_number} occupied by higher level user")
+            self.message_dispatch.send_screen_message(f"Cannot seat {username}: Seat {seat_number} occupied by higher level user")
             return
 
         seat_off.click()

--- a/src/ushareiplay/managers/topic_manager.py
+++ b/src/ushareiplay/managers/topic_manager.py
@@ -13,6 +13,7 @@ class TopicManager(Singleton):
         # 延迟初始化 handler，避免循环依赖
         self._soul_handler = None
         self._logger = None
+        self._message_dispatch = None
         
         # 话题状态管理
         self.last_update_time = None
@@ -34,6 +35,14 @@ class TopicManager(Singleton):
         if self._logger is None:
             self._logger = self.soul_handler.logger
         return self._logger
+
+    @property
+    def message_dispatch(self):
+        if self._message_dispatch is None:
+            from ushareiplay.core.message_dispatch import MessageDispatch
+
+            self._message_dispatch = MessageDispatch.instance().bind_handler(self.soul_handler)
+        return self._message_dispatch
     
     def get_status(self) -> dict:
         """
@@ -187,7 +196,7 @@ class TopicManager(Singleton):
                 self.current_topic = self.next_topic
                 self.next_topic = None
                 self.logger.info(f'Topic updated successfully to {self.current_topic}')
-                self.soul_handler.send_message(f"Updating topic to {self.current_topic}")
+                self.message_dispatch.send_screen_message(f"Updating topic to {self.current_topic}")
             else:
                 # 失败：保留 next_topic，等待下次冷却时间后重试
                 self.logger.warning(

--- a/src/ushareiplay/state/playback_broadcaster.py
+++ b/src/ushareiplay/state/playback_broadcaster.py
@@ -13,6 +13,7 @@ class PlaybackBroadcaster(Singleton):
         self._music_handler = None
         self._playback_info_cache: Optional[dict] = None  # 播放信息缓存
         self._last_playback_info = None  # 上次的播放信息，用于检测变化
+        self._message_dispatch = None
 
     @property
     def logger(self):
@@ -37,6 +38,14 @@ class PlaybackBroadcaster(Singleton):
             from ushareiplay.handlers.qq_music_handler import QQMusicHandler
             self._music_handler = QQMusicHandler.instance()
         return self._music_handler
+
+    @property
+    def message_dispatch(self):
+        if self._message_dispatch is None:
+            from ushareiplay.core.message_dispatch import MessageDispatch
+
+            self._message_dispatch = MessageDispatch.instance().bind_handler(self.soul_handler)
+        return self._message_dispatch
 
     def update_playback_info_cache(self):
         """
@@ -116,7 +125,7 @@ class PlaybackBroadcaster(Singleton):
                     self.logger.info(f'Hidden "{playback_message}"')
                     return
 
-                self.soul_handler.send_message(playback_message)
+                self.message_dispatch.send_screen_message(playback_message)
         else:
             # 如果歌曲信息无效，记录错误但不中断监控
             if 'error' in info:

--- a/tests/test_command_manager_runtime_context.py
+++ b/tests/test_command_manager_runtime_context.py
@@ -7,6 +7,22 @@ from ushareiplay.managers.command_manager import CommandManager
 from ushareiplay.models.message_info import MessageInfo
 
 
+class FakeMessageDispatch:
+    def __init__(self):
+        self.screen_messages = []
+        self.command_outputs = []
+
+    def bind_handler(self, _handler):
+        return self
+
+    def send_screen_message(self, message, silent=False):
+        self.screen_messages.append((message, silent))
+
+    def send_for_message_info(self, message_info, response, silent=False):
+        self.command_outputs.append((message_info.nickname, response, silent))
+        return True
+
+
 class FakeLogger:
     def __init__(self):
         self.messages = []
@@ -182,7 +198,10 @@ def test_handle_message_commands_merges_existing_private_reply(monkeypatch):
 
     monkeypatch.setattr(manager, "get_command", lambda _cmd: object())
     monkeypatch.setattr(manager, "process_command", _fake_process)
-    monkeypatch.setattr(manager, "_send_screen_message", lambda *args, **kwargs: None)
+    dispatch = FakeMessageDispatch()
+    monkeypatch.setattr(
+        "ushareiplay.managers.command_manager.MessageDispatch.instance", lambda: dispatch
+    )
 
     processed = asyncio.run(
         manager.handle_message_commands(
@@ -208,24 +227,16 @@ def test_handle_message_commands_private_reply_keeps_confirmation_public(monkeyp
         ]
     )
 
-    sent_public = []
-    sent_private = []
-
     async def _fake_process(_command, _message_info, _command_info):
         return "ok result @Console"
 
     monkeypatch.setattr(manager, "get_command", lambda _cmd: object())
     monkeypatch.setattr(manager, "process_command", _fake_process)
 
-    def _fake_send_screen(message, silent=False):
-        sent_public.append((message, silent))
-
-    def _fake_send_private(message_info, response, silent=False):
-        sent_private.append((message_info.nickname, response, silent))
-        return True
-
-    monkeypatch.setattr(manager, "_send_screen_message", _fake_send_screen)
-    monkeypatch.setattr(manager, "_send_command_output", _fake_send_private)
+    dispatch = FakeMessageDispatch()
+    monkeypatch.setattr(
+        "ushareiplay.managers.command_manager.MessageDispatch.instance", lambda: dispatch
+    )
 
     processed = asyncio.run(
         manager.handle_message_commands(
@@ -234,10 +245,10 @@ def test_handle_message_commands_private_reply_keeps_confirmation_public(monkeyp
     )
 
     assert processed == 1
-    assert len(sent_public) == 1
-    assert sent_public[0][0].endswith("play ... @Console")
-    assert sent_public[0][1] is False
-    assert sent_private == [("Console", "ok result @Console", False)]
+    assert len(dispatch.screen_messages) == 1
+    assert dispatch.screen_messages[0][0].endswith("play ... @Console")
+    assert dispatch.screen_messages[0][1] is False
+    assert dispatch.command_outputs == [("Console", "ok result @Console", False)]
 
 
 def test_handle_message_commands_private_reply_error_routes_private(monkeypatch):
@@ -253,24 +264,16 @@ def test_handle_message_commands_private_reply_error_routes_private(monkeypatch)
         ]
     )
 
-    sent_public = []
-    sent_private = []
-
     async def _fake_process(_command, _message_info, _command_info):
         return "error boom @Console"
 
     monkeypatch.setattr(manager, "get_command", lambda _cmd: object())
     monkeypatch.setattr(manager, "process_command", _fake_process)
 
-    def _fake_send_screen(message, silent=False):
-        sent_public.append((message, silent))
-
-    def _fake_send_private(message_info, response, silent=False):
-        sent_private.append((message_info.nickname, response, silent))
-        return True
-
-    monkeypatch.setattr(manager, "_send_screen_message", _fake_send_screen)
-    monkeypatch.setattr(manager, "_send_command_output", _fake_send_private)
+    dispatch = FakeMessageDispatch()
+    monkeypatch.setattr(
+        "ushareiplay.managers.command_manager.MessageDispatch.instance", lambda: dispatch
+    )
 
     processed = asyncio.run(
         manager.handle_message_commands(
@@ -279,7 +282,7 @@ def test_handle_message_commands_private_reply_error_routes_private(monkeypatch)
     )
 
     assert processed == 1
-    assert len(sent_public) == 1
-    assert sent_public[0][0].endswith("play ... @Console")
-    assert sent_public[0][1] is False
-    assert sent_private == [("Console", "error boom @Console", False)]
+    assert len(dispatch.screen_messages) == 1
+    assert dispatch.screen_messages[0][0].endswith("play ... @Console")
+    assert dispatch.screen_messages[0][1] is False
+    assert dispatch.command_outputs == [("Console", "error boom @Console", False)]

--- a/tests/test_command_manager_silent_commands.py
+++ b/tests/test_command_manager_silent_commands.py
@@ -37,10 +37,6 @@ class _Handler:
         self.logger = _Logger()
 
     def send_message(self, message):
-        from ushareiplay.core.command_silence import is_command_silent
-
-        if is_command_silent():
-            return None
         self.sent.append(message)
 
 
@@ -108,10 +104,14 @@ def test_slash_command_suppresses_screen_messages_but_still_executes(monkeypatch
 
     assert processed == 1
     assert handler.sent == []
-    assert [event[0] for event in runtime.events] == [
+    assert [event[0] for event in runtime.events if event[0].startswith("command.")] == [
         "command.received",
         "command.dispatch",
         "command.result",
+    ]
+    assert [event[0] for event in runtime.events if event[0] == "message.dispatch.suppressed"] == [
+        "message.dispatch.suppressed",
+        "message.dispatch.suppressed",
     ]
 
 
@@ -147,7 +147,7 @@ def test_colon_command_keeps_existing_screen_messages(monkeypatch):
     assert handler.sent[1] == "processed abc @Console"
 
 
-def test_silent_lifecycle_suppresses_direct_command_send_message():
+def test_silent_lifecycle_does_not_change_low_level_handler_primitive():
     manager, _runtime, handler = _make_manager()
     message_info = SimpleNamespace(content="/demo", nickname="Console")
     command_info = {
@@ -164,7 +164,7 @@ def test_silent_lifecycle_suppresses_direct_command_send_message():
     )
 
     assert response == "done @Console"
-    assert handler.sent == []
+    assert handler.sent == ["inside command"]
 
 
 def test_silent_lifecycle_marks_queued_keyword_commands_silent(monkeypatch):
@@ -193,6 +193,7 @@ def test_silent_lifecycle_marks_queued_keyword_commands_silent(monkeypatch):
         RuntimeQueueDrainer(
             handler=handler,
             command_manager=manager,
+            send_screen_message=handler.send_message,
         ).drain()
     )
 

--- a/tests/test_message_dispatch.py
+++ b/tests/test_message_dispatch.py
@@ -1,0 +1,137 @@
+from types import SimpleNamespace
+
+import pytest
+
+from ushareiplay.core.command_silence import command_silence
+from ushareiplay.core.message_dispatch import MessageDispatch
+from ushareiplay.models.message_info import MessageInfo
+
+
+class _Runtime:
+    def __init__(self):
+        self.events = []
+
+    def emit(self, event, **kwargs):
+        self.events.append((event, kwargs))
+
+
+class _Handler:
+    def __init__(self):
+        self.sent = []
+        self.logger = SimpleNamespace(
+            info=lambda _message: None,
+            warning=lambda _message: None,
+            error=lambda _message: None,
+        )
+
+    def send_message(self, message):
+        self.sent.append(message)
+
+
+class _UserManager:
+    def __init__(self):
+        self.sent = []
+
+    def send_private_message_to_user(self, nickname, message):
+        self.sent.append((nickname, message))
+        return True
+
+
+@pytest.fixture(autouse=True)
+def reset_message_dispatch_singleton():
+    if hasattr(MessageDispatch, "_instance"):
+        delattr(MessageDispatch, "_instance")
+    yield
+    if hasattr(MessageDispatch, "_instance"):
+        delattr(MessageDispatch, "_instance")
+
+
+def _make_dispatch():
+    dispatch = MessageDispatch.instance()
+    dispatch._handler = _Handler()
+    dispatch._user_manager = _UserManager()
+    runtime = _Runtime()
+    dispatch.configure_runtime(runtime)
+    return dispatch, runtime
+
+
+def test_send_screen_message_routes_and_emits_result():
+    dispatch, runtime = _make_dispatch()
+
+    dispatch.send_screen_message("hello")
+
+    assert dispatch.handler.sent == ["hello"]
+    assert runtime.events == [
+        ("message.dispatch.screen", {"ctx": {"message_len": 5, "sent": True}})
+    ]
+
+
+def test_send_screen_message_suppresses_explicit_or_context_silence():
+    dispatch, runtime = _make_dispatch()
+
+    dispatch.send_screen_message("explicit", silent=True)
+    with command_silence(True):
+        dispatch.send_screen_message("context")
+
+    assert dispatch.handler.sent == []
+    assert runtime.events == [
+        ("message.dispatch.suppressed", {"ctx": {"channel": "screen", "message_len": 8}}),
+        ("message.dispatch.suppressed", {"ctx": {"channel": "screen", "message_len": 7}}),
+    ]
+
+
+def test_send_screen_message_emits_failure_before_reraising_ui_error():
+    dispatch, runtime = _make_dispatch()
+
+    def raise_ui_error(_message):
+        raise RuntimeError("UI unavailable")
+
+    dispatch.handler.send_message = raise_ui_error
+
+    with pytest.raises(RuntimeError, match="UI unavailable"):
+        dispatch.send_screen_message("hello")
+
+    assert runtime.events == [
+        ("message.dispatch.screen", {"ctx": {"message_len": 5, "sent": False}})
+    ]
+
+
+def test_private_and_message_info_routing_keep_private_replies_private():
+    dispatch, runtime = _make_dispatch()
+
+    assert dispatch.send_private_message("Alice", "private") is True
+    assert dispatch.send_for_message_info(
+        MessageInfo(content="$demo", nickname="Bob", private_reply=True),
+        "reply",
+        silent=True,
+    ) is True
+    dispatch.send_for_message_info(
+        MessageInfo(content=":demo", nickname="Carol"), "public"
+    )
+
+    assert dispatch.user_manager.sent == [("Alice", "private"), ("Bob", "reply")]
+    assert dispatch.handler.sent == ["public"]
+    assert runtime.events == [
+        (
+            "message.dispatch.private",
+            {"ctx": {"nickname": "Alice", "message_len": 7, "sent": True}},
+        ),
+        (
+            "message.dispatch.private",
+            {"ctx": {"nickname": "Bob", "message_len": 5, "sent": True}},
+        ),
+        ("message.dispatch.screen", {"ctx": {"message_len": 6, "sent": True}}),
+    ]
+
+
+def test_private_message_emits_failed_result_when_user_manager_returns_false():
+    dispatch, runtime = _make_dispatch()
+    dispatch.user_manager.send_private_message_to_user = lambda _nickname, _message: False
+
+    assert dispatch.send_private_message("Alice", "private") is False
+    assert runtime.events == [
+        (
+            "message.dispatch.private",
+            {"ctx": {"nickname": "Alice", "message_len": 7, "sent": False}},
+        )
+    ]

--- a/tests/test_runtime_queue_pipeline.py
+++ b/tests/test_runtime_queue_pipeline.py
@@ -73,7 +73,7 @@ def test_runtime_queue_drainer_routes_commands_and_plain_messages():
     handler = _FakeHandler()
     command_manager = _FakeCommandManager()
     drainer = RuntimeQueueDrainer(
-        handler=handler, command_manager=command_manager, obs=obs, logger=handler.logger
+        handler=handler, command_manager=command_manager, send_screen_message=handler.send_message, obs=obs, logger=handler.logger
     )
 
     drained, command_count = _run(drainer.drain())
@@ -102,7 +102,7 @@ def test_runtime_queue_drainer_propagates_silent_commands_and_suppresses_plain_m
     handler = _FakeHandler()
     command_manager = _FakeCommandManager()
     drainer = RuntimeQueueDrainer(
-        handler=handler, command_manager=command_manager, logger=handler.logger
+        handler=handler, command_manager=command_manager, send_screen_message=handler.send_message, logger=handler.logger
     )
 
     drained, command_count = _run(drainer.drain())
@@ -134,7 +134,7 @@ def test_runtime_queue_drainer_propagates_sleep_exempt_to_split_commands():
     handler = _FakeHandler()
     command_manager = _FakeCommandManager()
     drainer = RuntimeQueueDrainer(
-        handler=handler, command_manager=command_manager, logger=handler.logger
+        handler=handler, command_manager=command_manager, send_screen_message=handler.send_message, logger=handler.logger
     )
 
     drained, command_count = _run(drainer.drain())
@@ -157,7 +157,7 @@ def test_runtime_queue_drainer_treats_slash_parts_as_silent_commands():
     handler = _FakeHandler()
     command_manager = _FakeCommandManager()
     drainer = RuntimeQueueDrainer(
-        handler=handler, command_manager=command_manager, logger=handler.logger
+        handler=handler, command_manager=command_manager, send_screen_message=handler.send_message, logger=handler.logger
     )
 
     drained, command_count = _run(drainer.drain())
@@ -181,7 +181,7 @@ def test_runtime_queue_drainer_routes_dollar_parts_as_private_commands():
     handler = _FakeHandler()
     command_manager = _FakeCommandManager()
     drainer = RuntimeQueueDrainer(
-        handler=handler, command_manager=command_manager, logger=handler.logger
+        handler=handler, command_manager=command_manager, send_screen_message=handler.send_message, logger=handler.logger
     )
 
     drained, command_count = _run(drainer.drain())
@@ -205,7 +205,7 @@ def test_runtime_queue_drainer_routes_fullwidth_dollar_parts_as_private_commands
     handler = _FakeHandler()
     command_manager = _FakeCommandManager()
     drainer = RuntimeQueueDrainer(
-        handler=handler, command_manager=command_manager, logger=handler.logger
+        handler=handler, command_manager=command_manager, send_screen_message=handler.send_message, logger=handler.logger
     )
 
     drained, command_count = _run(drainer.drain())


### PR DESCRIPTION
## Summary

- centralize outbound screen and private chat delivery in `MessageDispatch`
- route command, queue, console, manager, and playback broadcasts through the new seam
- record body-free dispatch outcomes and retain the empty-message UI scroll primitive

## Validation

- `uv run pytest -q` (296 passed)
- `python -m py_compile` on changed modules
