### PR TITLE
refactor: share seat UI manager

### DIFF
--- a/src/ushareiplay/commands/seat.py
+++ b/src/ushareiplay/commands/seat.py
@@ -1,6 +1,6 @@
 import traceback
 from ushareiplay.core.base_command import BaseCommand
-from ushareiplay.managers.seat_manager import seat_manager
+from ushareiplay.managers.seat_manager import SeatManager
 
 
 class SeatCommand(BaseCommand):
@@ -11,42 +11,42 @@ class SeatCommand(BaseCommand):
         """Process seat command"""
         if not parameters:
             # No parameters - find and take an available seat for owner
-            return await seat_manager.seating.find_owner_seat(force_relocate=True)
+            return await SeatManager.get_instance().seating.find_owner_seat(force_relocate=True)
 
         command = parameters[0]
 
         if command == '0':
             # Remove user's reservations
-            return await seat_manager.reservation.remove_user_reservation(message_info.nickname)
+            return await SeatManager.get_instance().reservation.remove_user_reservation(message_info.nickname)
         elif command == '1' and len(parameters) == 2:
             # Reserve specific seat
             seat_number, err = self.coerce_int(
                 parameters[1], 1, 12, 'Invalid seat number. Must be between 1 and 12')
             if err:
                 return {'error': err}
-            return await seat_manager.reserve_seat(message_info.nickname, seat_number)
+            return await SeatManager.get_instance().reserve_seat(message_info.nickname, seat_number)
         elif command == '2' and len(parameters) == 2:
             # Sit at specific seat position
             seat_number, err = self.coerce_int(
                 parameters[1], 1, 12, 'Invalid seat number. Must be between 1 and 12')
             if err:
                 return {'error': err}
-            return await seat_manager.take_seat(seat_number)
+            return await SeatManager.get_instance().take_seat(seat_number)
         elif command == '3':
             # Accompany a specific user (sit next to them)
             target_username = parameters[1] if len(parameters) > 1 else message_info.nickname
-            return await seat_manager.seating.accompany_user(target_username, sender_username=message_info.nickname)
+            return await SeatManager.get_instance().seating.accompany_user(target_username, sender_username=message_info.nickname)
         elif command == '4':
             if len(parameters) == 1:
                 # Remove owner from their current seat
-                return await seat_manager.remove_seat_occupant(None)
+                return await SeatManager.get_instance().remove_seat_occupant(None)
             if len(parameters) == 2:
                 # Remove whoever is sitting at the specified seat
                 seat_number, err = self.coerce_int(
                     parameters[1], 1, 12, 'Invalid seat number. Must be between 1 and 12')
                 if err:
                     return {'error': err}
-                return await seat_manager.remove_seat_occupant(seat_number)
+                return await SeatManager.get_instance().remove_seat_occupant(seat_number)
             return {'error': 'Invalid command. Use: :seat 4 [seat_number]'}
         else:
             return {'error': 'Invalid command. Use: :seat [0|1 <seat_number>|2 <seat_number>|3 [username]|4 [seat_number]]'}
@@ -55,7 +55,7 @@ class SeatCommand(BaseCommand):
         """Called when a user enters the party"""
         try:
             # Check seats when user enters, passing the username
-            await seat_manager.check.check_seats_on_entry(username)
+            await SeatManager.get_instance().check.check_seats_on_entry(username)
         except Exception as e:
             self.handler.log_error(f"Error checking seats on user enter: {traceback.format_exc()}")
 
@@ -63,7 +63,7 @@ class SeatCommand(BaseCommand):
         """Called when a user returns to the party"""
         try:
             # Check seats when user returns, passing the username
-            await seat_manager.check.check_seats_on_entry(username)
+            await SeatManager.get_instance().check.check_seats_on_entry(username)
         except Exception as e:
             self.handler.log_error(f"Error checking seats on user return: {traceback.format_exc()}")
 

--- a/src/ushareiplay/core/app_controller.py
+++ b/src/ushareiplay/core/app_controller.py
@@ -319,11 +319,11 @@ class AppController(Singleton):
             from ushareiplay.managers.timer_manager import TimerManager
             from ushareiplay.managers.command_manager import CommandManager
             from ushareiplay.managers.info_manager import InfoManager
-            from ushareiplay.managers.seat_manager import init_seat_manager
+            from ushareiplay.managers.seat_manager import SeatManager
 
             # Initialize managers after handlers are ready
             self.logger.info("创建 manager 实例...")
-            self.seat_manager = init_seat_manager(self.soul_handler)
+            self.seat_manager = SeatManager.get_instance(self.soul_handler)
             self.topic_manager = TopicManager.instance()
             self.mic_manager = MicManager.instance()
             self.music_manager = MusicManager.instance()

--- a/src/ushareiplay/managers/message_manager.py
+++ b/src/ushareiplay/managers/message_manager.py
@@ -85,8 +85,8 @@ class MessageManager(Singleton):
 
     def _get_seat_manager(self):
         """Get the seat_manager lazily to avoid circular import issues"""
-        from ushareiplay.managers.seat_manager import seat_manager
-        return seat_manager
+        from ushareiplay.managers.seat_manager import SeatManager
+        return SeatManager.get_instance()
 
     def get_party_id(self):
         party_id = self.handler.party_id

--- a/src/ushareiplay/managers/seat_manager/__init__.py
+++ b/src/ushareiplay/managers/seat_manager/__init__.py
@@ -22,10 +22,10 @@ class SeatManager(SeatManagerBase):
             super().__init__(handler)
             # Initialize component managers
             # FocusManager 已迁移到事件系统，不再需要
-            self.reservation = ReservationManager(handler)
-            self.check = SeatCheckManager(handler)
             self.ui = SeatUIManager(handler)
-            self.seating = SeatingManager(handler)
+            self.check = SeatCheckManager(handler, self.ui)
+            self.reservation = ReservationManager(handler, self.ui, self.check)
+            self.seating = SeatingManager(handler, self.ui)
             self.initialized = True
             logging.getLogger('seat_manager').info("SeatManager 初始化完成")
         elif handler and not self.handler:
@@ -34,6 +34,7 @@ class SeatManager(SeatManagerBase):
             self.handler = handler
             self.reservation.handler = handler
             self.check.handler = handler
+            self.check._message_dispatch = None
             self.ui.handler = handler
             self.seating.handler = handler
 
@@ -57,22 +58,3 @@ class SeatManager(SeatManagerBase):
         if seat_number is None:
             return await self.seating.seat_off_owner()
         return await self.seating.seat_off_specific_seat(seat_number)
-
-# Create a default instance with a None handler
-# This ensures seat_manager is never None, components will be properly initialized later
-seat_manager = SeatManager(None)
-
-def init_seat_manager(handler):
-    """Initialize the global seat manager instance"""
-    global seat_manager
-    # Since we're using the singleton pattern, this will update the existing instance
-    logging.getLogger('seat_manager').info(f"调用 init_seat_manager，handler={handler}")
-    seat_manager = SeatManager(handler)
-    
-    # 额外检查确保所有子管理器的handler都已正确设置
-    if not seat_manager.handler:
-        logging.getLogger('seat_manager').error("初始化后 seat_manager.handler 仍为 None")
-    if not seat_manager.ui.handler:
-        logging.getLogger('seat_manager').error("初始化后 seat_manager.ui.handler 仍为 None")
-        
-    return seat_manager

--- a/src/ushareiplay/managers/seat_manager/base.py
+++ b/src/ushareiplay/managers/seat_manager/base.py
@@ -2,7 +2,7 @@ class SeatManagerBase:
     _instance = None
     _initialized = False
 
-    def __new__(cls, handler=None):
+    def __new__(cls, handler=None, *args, **kwargs):
         if cls._instance is None:
             cls._instance = super(SeatManagerBase, cls).__new__(cls)
         return cls._instance
@@ -23,7 +23,9 @@ class SeatManagerBase:
         return f"{self.__class__.__name__}(handler={handler_id}, initialized={self._initialized})"
 
     @classmethod
-    def get_instance(cls):
+    def get_instance(cls, handler=None, *args, **kwargs):
         if cls._instance is None:
-            cls._instance = cls()
-        return cls._instance 
+            cls._instance = cls(handler, *args, **kwargs)
+        elif handler is not None:
+            cls(handler, *args, **kwargs)
+        return cls._instance

--- a/src/ushareiplay/managers/seat_manager/reservation.py
+++ b/src/ushareiplay/managers/seat_manager/reservation.py
@@ -6,10 +6,10 @@ import traceback
 
 
 class ReservationManager(SeatManagerBase):
-    def __init__(self, handler=None):
+    def __init__(self, handler=None, seat_ui=None, seat_check=None):
         super().__init__(handler)
-        self.seat_ui = SeatUIManager(handler)
-        self.seat_check = SeatCheckManager(handler)
+        self.seat_ui = seat_ui or SeatUIManager(handler)
+        self.seat_check = seat_check or SeatCheckManager(handler, self.seat_ui)
 
     async def reserve_seat(self, username: str, seat_number: int) -> dict:
         """Reserve a seat for a user (data operation only)"""

--- a/src/ushareiplay/managers/seat_manager/seat_check.py
+++ b/src/ushareiplay/managers/seat_manager/seat_check.py
@@ -7,9 +7,9 @@ from ushareiplay.managers.seat_manager.seat_ui import SeatUIManager
 
 
 class SeatCheckManager(SeatManagerBase):
-    def __init__(self, handler=None):
+    def __init__(self, handler=None, seat_ui=None):
         super().__init__(handler)
-        self.seat_ui = SeatUIManager(handler)
+        self.seat_ui = seat_ui or SeatUIManager(handler)
         self._message_dispatch = None
 
     @property
@@ -78,37 +78,18 @@ class SeatCheckManager(SeatManagerBase):
             self.handler.log_error(f"Error checking seats: {traceback.format_exc()}")
 
     async def check_user_specific_seat(self, username: str, seat_number: int):
-        # ensure seats are expanded first
         self.handler.logger.info("expanding seats for check")
-        if not await self.seat_ui.expand_seats():
-            self.handler.log_error("failed to expand seats for check")
-            return
-        await asyncio.sleep(0.5)  # wait for expansion animation
-
-        # get all seat desks
-        seat_desks = self.handler.find_elements('seat_desk')
+        seat_desks = await self.seat_ui.expand_and_find_desks()
         if not seat_desks:
-            self.handler.log_error("cannot find seat desks")
-            self.message_dispatch.send_screen_message(f"System error: Unable to access seats for {username}")
             return
         self.handler.logger.info(f"found {len(seat_desks)} seat desks")
-        if len(seat_desks) != 6:
-            self.handler.log_error(
-                f"seat expansion incomplete: found {len(seat_desks)} desks, expected 6"
-            )
-            return
 
         # check and handle the user's specific seat
         self.handler.logger.info(f"checking specific seat {seat_number} for user {username}")
 
         desk_index = (seat_number - 1) // 2
-        row_index = desk_index // 2
-        if row_index in (0, 2):
-            reference_desk = seat_desks[2]
-            center_x = reference_desk.location['x'] + reference_desk.size['width'] // 2
-            center_y = reference_desk.location['y'] + reference_desk.size['height'] // 2
-            offset = reference_desk.size['height'] if row_index == 0 else -reference_desk.size['height']
-            self.handler.driver.swipe(center_x, center_y, center_x, center_y + offset, 1000)
+        self.seat_ui.scroll_to_row(desk_index, seat_desks, duration=1000)
+        if desk_index // 2 in (0, 2):
             await asyncio.sleep(0.5)
 
         await self._handle_occupied_seat(username, seat_desks, seat_number)

--- a/src/ushareiplay/managers/seat_manager/seat_ui.py
+++ b/src/ushareiplay/managers/seat_manager/seat_ui.py
@@ -75,7 +75,6 @@ class SeatUIManager(SeatManagerBase):
                     expand_seats.click()
                     self.handler.logger.info(f'Expanded seats')
                     self.is_expanded = True
-                    await asyncio.sleep(0.5)  # Give time for animation
                     return True
                 else:
                     self.handler.logger.warning(f"座位按钮文本不匹配预期，无法展开: '{actual_text}'")
@@ -87,6 +86,48 @@ class SeatUIManager(SeatManagerBase):
         except Exception as e:
             self.handler.logger.error(f"展开座位时出错: {str(e)}")
             return False
+
+    async def expand_and_find_desks(self):
+        """Expand the seat UI and return the six desk containers."""
+        if not await self.expand_seats():
+            return None
+
+        await asyncio.sleep(0.5)
+        seat_desks = self.handler.find_elements('seat_desk')
+        if not seat_desks:
+            self.handler.logger.error("Failed to find seat desks")
+            return None
+        if len(seat_desks) != 6:
+            self.handler.log_error(
+                f"seat expansion incomplete: found {len(seat_desks)} desks, expected 6"
+            )
+            return None
+        return seat_desks
+
+    def scroll_to_row(self, desk_index, seat_desks, duration=100):
+        """Scroll the requested desk row into view when it is outside the middle row."""
+        if not seat_desks or len(seat_desks) < 3:
+            return
+
+        row_index = desk_index // 2
+        if row_index == 1:
+            return
+
+        reference_desk = seat_desks[2]
+        center_x = reference_desk.location['x'] + reference_desk.size['width'] // 2
+        center_y = reference_desk.location['y'] + reference_desk.size['height'] // 2
+        desk_height = reference_desk.size['height']
+
+        if row_index == 0:
+            self.handler.driver.swipe(
+                center_x, center_y, center_x, center_y + desk_height, duration
+            )
+            self.handler.logger.info(f"Scrolled to show first row for desk {desk_index + 1}")
+        elif row_index == 2:
+            self.handler.driver.swipe(
+                center_x, center_y, center_x, center_y - desk_height, duration
+            )
+            self.handler.logger.info(f"Scrolled to show third row for desk {desk_index + 1}")
 
     async def collapse_seats(self):
         """Collapse seats if expanded"""

--- a/src/ushareiplay/managers/seat_manager/seating.py
+++ b/src/ushareiplay/managers/seat_manager/seating.py
@@ -6,9 +6,11 @@ import traceback
 
 
 class SeatingManager(SeatManagerBase):
-    def __init__(self, handler=None):
+    def __init__(self, handler=None, seat_ui=None):
         super().__init__(handler)
-        if not hasattr(self, 'seat_ui'):
+        if seat_ui is not None:
+            self.seat_ui = seat_ui
+        elif not hasattr(self, 'seat_ui'):
             self.seat_ui = SeatUIManager(handler)
         elif handler and self.seat_ui.handler is None:
             self.seat_ui.handler = handler
@@ -29,21 +31,15 @@ class SeatingManager(SeatManagerBase):
             desk_index = (seat_number - 1) // 2
             side = 'left' if seat_number % 2 == 1 else 'right'
 
-            # Expand seats if needed
-            await self.seat_ui.expand_seats()
-            await asyncio.sleep(0.5)  # Wait for expansion animation
-
-            # Find all seat desks
-            seat_desks = self.handler.find_elements('seat_desk')
+            seat_desks = await self.seat_ui.expand_and_find_desks()
             if not seat_desks:
-                self.handler.logger.error("Failed to find seat desks")
                 return {'error': 'Failed to find seat desks'}
 
             if desk_index >= len(seat_desks):
                 return {'error': f'Desk {desk_index + 1} does not exist'}
 
             # Ensure the target row is visible
-            self._ensure_row_visible(desk_index, seat_desks)
+            self.seat_ui.scroll_to_row(desk_index, seat_desks)
 
             # Get the specific desk and collect its info
             desk = seat_desks[desk_index]
@@ -70,14 +66,8 @@ class SeatingManager(SeatManagerBase):
             return {'error': 'Handler not initialized'}
 
         try:
-            # Expand seats if needed
-            await self.seat_ui.expand_seats()
-            await asyncio.sleep(0.5)  # Wait for expansion animation
-
-            # Find all seat desks
-            seat_desks = self.handler.find_elements('seat_desk')
+            seat_desks = await self.seat_ui.expand_and_find_desks()
             if not seat_desks:
-                self.handler.logger.error("Failed to find seat desks")
                 return {'error': 'Failed to find seat desks'}
 
             if self.current_desk_index >= len(seat_desks):
@@ -103,7 +93,7 @@ class SeatingManager(SeatManagerBase):
 
             for desk_index in scan_order:
                 # Ensure the row containing this desk is visible
-                self._ensure_row_visible(desk_index, seat_desks)
+                self.seat_ui.scroll_to_row(desk_index, seat_desks)
                 desk = seat_desks[desk_index]
                 desk_info = self._collect_desk_info(desk)
                 # self.handler.logger.debug(f"desk_info: {desk_info}" )
@@ -128,7 +118,7 @@ class SeatingManager(SeatManagerBase):
                 # Ensure the row containing the target seat is visible before taking it
                 # This is important because we may have scrolled to other rows during scanning
                 try:
-                    self._ensure_row_visible(first_empty_candidate['desk_index'], seat_desks)
+                    self.seat_ui.scroll_to_row(first_empty_candidate['desk_index'], seat_desks)
                     # Re-collect desk info to get fresh element references after scrolling
                     desk = seat_desks[first_empty_candidate['desk_index']]
                     desk_info = self._collect_desk_info(desk)
@@ -164,21 +154,15 @@ class SeatingManager(SeatManagerBase):
                 if not info_manager.is_user_online(target_username):
                     return {'error': f'User {target_username} is not online'}
 
-            # Step 2: Expand seats
-            await self.seat_ui.expand_seats()
-            await asyncio.sleep(0.5)
-
-            # Find all seat desks
-            seat_desks = self.handler.find_elements('seat_desk')
+            seat_desks = await self.seat_ui.expand_and_find_desks()
             if not seat_desks:
-                self.handler.logger.error("Failed to find seat desks")
                 return {'error': 'Failed to find seat desks'}
 
             # Step 3: Iterate through all desks.
             # Optimization: only check desks with exactly one occupant, because
             # if both seats are occupied, we can't sit next to the target anyway.
             for desk_index in range(len(seat_desks)):
-                self._ensure_row_visible(desk_index, seat_desks)
+                self.seat_ui.scroll_to_row(desk_index, seat_desks)
                 desk = seat_desks[desk_index]
                 desk_info = self._collect_desk_info(desk)
 
@@ -269,16 +253,12 @@ class SeatingManager(SeatManagerBase):
             return {'error': 'Handler not initialized'}
 
         try:
-            await self.seat_ui.expand_seats()
-            await asyncio.sleep(0.5)
-
-            seat_desks = self.handler.find_elements('seat_desk')
+            seat_desks = await self.seat_ui.expand_and_find_desks()
             if not seat_desks:
-                self.handler.logger.error("Failed to find seat desks")
                 return {'error': 'Failed to find seat desks'}
 
             for desk_index in range(len(seat_desks)):
-                self._ensure_row_visible(desk_index, seat_desks)
+                self.seat_ui.scroll_to_row(desk_index, seat_desks)
                 desk = seat_desks[desk_index]
                 desk_info = self._collect_desk_info(desk)
 
@@ -303,18 +283,14 @@ class SeatingManager(SeatManagerBase):
             desk_index = (seat_number - 1) // 2
             side = 'left' if seat_number % 2 == 1 else 'right'
 
-            await self.seat_ui.expand_seats()
-            await asyncio.sleep(0.5)
-
-            seat_desks = self.handler.find_elements('seat_desk')
+            seat_desks = await self.seat_ui.expand_and_find_desks()
             if not seat_desks:
-                self.handler.logger.error("Failed to find seat desks")
                 return {'error': 'Failed to find seat desks'}
 
             if desk_index >= len(seat_desks):
                 return {'error': f'Desk {desk_index + 1} does not exist'}
 
-            self._ensure_row_visible(desk_index, seat_desks)
+            self.seat_ui.scroll_to_row(desk_index, seat_desks)
             desk = seat_desks[desk_index]
             desk_info = self._collect_desk_info(desk)
             target_seat = desk_info[side]
@@ -402,43 +378,6 @@ class SeatingManager(SeatManagerBase):
 
     def _build_scan_order(self, total_count, start_index):
         return [(start_index + offset) % total_count for offset in range(total_count)]
-
-    def _ensure_row_visible(self, desk_index, seat_desks):
-        """Ensure the row containing the desk is visible by scrolling if needed"""
-        if not seat_desks or len(seat_desks) < 3:
-            return
-
-        # Calculate which row the desk belongs to (row_index = desk_index // 2)
-        row_index = desk_index // 2
-
-        # Row 1 (desk_index 2-3) is always visible, no scrolling needed
-        if row_index == 1:
-            return
-
-        # Use second row's first desk (index 2) as reference for scrolling
-        reference_desk = seat_desks[2]
-        desk_height = reference_desk.size['height']
-
-        if row_index == 0:  # First row (desk_index 0-1)
-            # Scroll down one row height to show first row
-            self.handler.driver.swipe(
-                reference_desk.location['x'] + reference_desk.size['width'] // 2,
-                reference_desk.location['y'] + reference_desk.size['height'] // 2,
-                reference_desk.location['x'] + reference_desk.size['width'] // 2,
-                reference_desk.location['y'] + reference_desk.size['height'] // 2 + desk_height,
-                100
-            )
-            self.handler.logger.info(f"Scrolled to show first row for desk {desk_index + 1}")
-        elif row_index == 2:  # Third row (desk_index 4-5)
-            # Scroll up one row height to show third row
-            self.handler.driver.swipe(
-                reference_desk.location['x'] + reference_desk.size['width'] // 2,
-                reference_desk.location['y'] + reference_desk.size['height'] // 2,
-                reference_desk.location['x'] + reference_desk.size['width'] // 2,
-                reference_desk.location['y'] + reference_desk.size['height'] // 2 - desk_height,
-                100
-            )
-            self.handler.logger.info(f"Scrolled to show third row for desk {desk_index + 1}")
 
     def _take_seat(self, desk_index, seat_info, neighbor_label=None):
         if self.handler is None or not seat_info or not seat_info.get('element'):

--- a/tests/test_seat_check.py
+++ b/tests/test_seat_check.py
@@ -37,8 +37,27 @@ class DummyHandler:
 
 
 class DummySeatUI:
-    async def expand_seats(self):
-        return True
+    def __init__(self, handler):
+        self.handler = handler
+
+    async def expand_and_find_desks(self):
+        seat_desks = self.handler.find_elements("seat_desk")
+        if len(seat_desks) != 6:
+            self.handler.log_error(
+                f"seat expansion incomplete: found {len(seat_desks)} desks, expected 6"
+            )
+            return None
+        return seat_desks
+
+    def scroll_to_row(self, desk_index, seat_desks, duration=100):
+        row_index = desk_index // 2
+        if row_index not in (0, 2):
+            return
+        reference_desk = seat_desks[2]
+        center_x = reference_desk.location["x"] + reference_desk.size["width"] // 2
+        center_y = reference_desk.location["y"] + reference_desk.size["height"] // 2
+        offset = reference_desk.size["height"] if row_index == 0 else -reference_desk.size["height"]
+        self.handler.driver.swipe(center_x, center_y, center_x, center_y + offset, duration)
 
 
 def _desk():
@@ -51,16 +70,12 @@ def _desk():
 def _manager(handler):
     SeatCheckManager._instance = None
     SeatCheckManager._initialized = False
-    manager = SeatCheckManager(handler)
-    manager.seat_ui = DummySeatUI()
-    return manager
+    return SeatCheckManager(handler, DummySeatUI(handler))
 
 
-def test_check_user_specific_seat_stops_when_expansion_shows_four_desks(monkeypatch):
+def test_check_user_specific_seat_stops_when_expansion_shows_four_desks():
     handler = DummyHandler([_desk() for _ in range(4)])
     manager = _manager(handler)
-    monkeypatch.setattr(seat_check_module.asyncio, "sleep", AsyncMock())
-
     asyncio.run(manager.check_user_specific_seat("Chainer", 9))
 
     assert handler.searched_desks == []
@@ -71,9 +86,10 @@ def test_check_user_specific_seat_uses_global_index_when_all_desks_are_visible(m
     seat_desks = [_desk() for _ in range(6)]
     handler = DummyHandler(seat_desks)
     manager = _manager(handler)
-    monkeypatch.setattr(seat_check_module.asyncio, "sleep", AsyncMock())
-
+    sleep = AsyncMock()
+    monkeypatch.setattr(seat_check_module.asyncio, "sleep", sleep)
     asyncio.run(manager.check_user_specific_seat("Chainer", 9))
 
     assert handler.swipes == [(5, 5, 5, -5, 1000)]
     assert handler.searched_desks == [seat_desks[4]]
+    sleep.assert_awaited_once_with(0.5)

--- a/tests/test_seat_management_interface.py
+++ b/tests/test_seat_management_interface.py
@@ -5,6 +5,10 @@ from types import SimpleNamespace
 import pytest
 
 from ushareiplay.managers.seat_manager import SeatManager
+from ushareiplay.managers.seat_manager.reservation import ReservationManager
+from ushareiplay.managers.seat_manager.seat_check import SeatCheckManager
+from ushareiplay.managers.seat_manager.seat_ui import SeatUIManager
+from ushareiplay.managers.seat_manager.seating import SeatingManager
 
 
 class _FakeSeatUI:
@@ -70,6 +74,25 @@ async def test_seat_management_preserves_remove_occupant_paths():
 
     assert await manager.remove_seat_occupant(None) == {"removed": "owner"}
     assert await manager.remove_seat_occupant(3) == {"removed": 3}
+
+
+def test_seat_management_shares_ui_and_check_dependencies():
+    singleton_classes = (SeatManager, ReservationManager, SeatCheckManager, SeatUIManager, SeatingManager)
+    for manager_class in singleton_classes:
+        manager_class._instance = None
+        manager_class._initialized = False
+
+    handler = object()
+    manager = SeatManager.get_instance(handler)
+
+    assert manager.ui is manager.check.seat_ui
+    assert manager.ui is manager.reservation.seat_ui
+    assert manager.ui is manager.seating.seat_ui
+    assert manager.reservation.seat_check is manager.check
+
+    for manager_class in singleton_classes:
+        manager_class._instance = None
+        manager_class._initialized = False
 
 
 @pytest.mark.asyncio

--- a/tests/test_seat_off_command.py
+++ b/tests/test_seat_off_command.py
@@ -86,8 +86,14 @@ class DummyHandler:
 
 
 class DummySeatUI:
-    async def expand_seats(self):
-        return True
+    def __init__(self, handler):
+        self.handler = handler
+
+    async def expand_and_find_desks(self):
+        return self.handler.find_elements("seat_desk")
+
+    def scroll_to_row(self, desk_index, seat_desks, duration=100):
+        pass
 
 
 def _desk(left_label="", left_occupied=False, right_label="", right_occupied=False):
@@ -105,7 +111,7 @@ def test_seat_1_delegates_reservation_to_seat_management(monkeypatch):
     manager = SimpleNamespace(
         reserve_seat=AsyncMock(return_value={"success": "Seat 5 reserved"})
     )
-    monkeypatch.setattr(seat_command_module, "seat_manager", manager)
+    monkeypatch.setattr(seat_command_module.SeatManager, "get_instance", lambda: manager)
 
     command = SeatCommand(DummyController())
     message = MessageInfo(content=":seat 1 5", nickname="Alice")
@@ -118,7 +124,7 @@ def test_seat_1_delegates_reservation_to_seat_management(monkeypatch):
 
 def test_seat_2_delegates_specific_seat_to_seat_management(monkeypatch):
     manager = SimpleNamespace(take_seat=AsyncMock(return_value={"success": "Took seat 5"}))
-    monkeypatch.setattr(seat_command_module, "seat_manager", manager)
+    monkeypatch.setattr(seat_command_module.SeatManager, "get_instance", lambda: manager)
 
     command = SeatCommand(DummyController())
     message = MessageInfo(content=":seat 2 5", nickname="Alice")
@@ -133,7 +139,7 @@ def test_seat_4_without_parameter_dispatches_owner_seat_off(monkeypatch):
     manager = SimpleNamespace(
         remove_seat_occupant=AsyncMock(return_value={"success": "Owner removed from seat"})
     )
-    monkeypatch.setattr(seat_command_module, "seat_manager", manager)
+    monkeypatch.setattr(seat_command_module.SeatManager, "get_instance", lambda: manager)
 
     command = SeatCommand(DummyController())
     message = MessageInfo(content=":seat 4", nickname="Alice")
@@ -148,7 +154,7 @@ def test_seat_4_with_parameter_dispatches_specific_seat_off(monkeypatch):
     manager = SimpleNamespace(
         remove_seat_occupant=AsyncMock(return_value={"success": "Seat 5 removed"})
     )
-    monkeypatch.setattr(seat_command_module, "seat_manager", manager)
+    monkeypatch.setattr(seat_command_module.SeatManager, "get_instance", lambda: manager)
 
     command = SeatCommand(DummyController())
     message = MessageInfo(content=":seat 4 5", nickname="Alice")
@@ -161,7 +167,7 @@ def test_seat_4_with_parameter_dispatches_specific_seat_off(monkeypatch):
 
 def test_seat_4_with_invalid_seat_number_returns_error(monkeypatch):
     manager = SimpleNamespace(remove_seat_occupant=AsyncMock())
-    monkeypatch.setattr(seat_command_module, "seat_manager", manager)
+    monkeypatch.setattr(seat_command_module.SeatManager, "get_instance", lambda: manager)
 
     command = SeatCommand(DummyController())
     message = MessageInfo(content=":seat 4 13", nickname="Alice")
@@ -176,7 +182,7 @@ def test_seat_off_owner_clicks_owner_seat_and_seat_off_button():
     desks = [_desk(left_label="群主", left_occupied=True)]
     handler = DummyHandler(desks, popup_name="群主")
     manager = SeatingManager(handler)
-    manager.seat_ui = DummySeatUI()
+    manager.seat_ui = DummySeatUI(handler)
 
     result = asyncio.run(manager.seat_off_owner())
 
@@ -192,7 +198,7 @@ def test_seat_off_specific_seat_clicks_target_seat_and_seat_off_button():
     ]
     handler = DummyHandler(desks, popup_name="C")
     manager = SeatingManager(handler)
-    manager.seat_ui = DummySeatUI()
+    manager.seat_ui = DummySeatUI(handler)
 
     result = asyncio.run(manager.seat_off_specific_seat(3))
 
@@ -204,7 +210,7 @@ def test_seat_off_specific_seat_clicks_target_seat_and_seat_off_button():
 def test_seat_off_owner_returns_error_when_owner_not_found():
     handler = DummyHandler([_desk(left_label="Alice", left_occupied=True)])
     manager = SeatingManager(handler)
-    manager.seat_ui = DummySeatUI()
+    manager.seat_ui = DummySeatUI(handler)
 
     result = asyncio.run(manager.seat_off_owner())
 


### PR DESCRIPTION
## Summary
- compose one shared seat UI and seat check dependency in `SeatManager`
- centralize seat expansion, desk discovery, and row scrolling
- remove stale module-level seat manager imports

## Verification
- `uv run pytest -q`