### PR TITLE
refactor: make singleton initialization explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ No linter configuration (flake8/pylint/ruff) is committed. Use `python -m py_com
 ### Key gotchas
 
 - `config.yaml` is 26k+ lines. Local overrides go in `config.local.yaml` (gitignored). See `config.local.yaml.example`.
-- All managers use the Singleton pattern via `Singleton` metaclass — always call `.instance()`, never construct directly.
+- Singleton creation is limited to the composition root: call `.initialize(...)` exactly once there, then use `.instance()` for lookup only. Never construct singleton classes directly.
 - The project is configured via `pyproject.toml` and can be run with `uv run ushareiplay`.
 
 ### GitHub / PR account switching

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,13 +44,13 @@ uv run pytest -q tests/test_timer_add.py tests/test_db_manager.py
 main.py
   → ConfigLoader.load_config()        # Loads config.yaml
   → DatabaseManager.init()            # SQLite via Tortoise ORM
-  → AppController.instance(config)    # Main singleton orchestrator
+  → AppController.initialize(config)  # Main singleton orchestrator
   → controller.start_monitoring()     # Main event loop
 ```
 
 ### Key Design Patterns
 
-- **Singleton** — All managers and handlers use thread-safe singletons; never call constructors directly, always use `.instance()`
+- **Singleton** — The composition root creates managers and handlers once with `.initialize(...)`; all other code uses `.instance()` as a lookup-only API. Never call singleton constructors directly.
 - **Manager Pattern** — Business logic split into 14+ specialized managers under `src/managers/`
 - **Command Pattern** — 30+ commands under `src/commands/`, all inheriting from `BaseCommand`; commands are dynamically loaded by `CommandManager`
 - **DAO Pattern** — Database access via DAOs in `src/dal/`; models in `src/models/` using Tortoise ORM

--- a/src/ushareiplay/__main__.py
+++ b/src/ushareiplay/__main__.py
@@ -1,6 +1,7 @@
 from ushareiplay.core.app_controller import AppController
 from ushareiplay.core.config_loader import ConfigLoader
 from ushareiplay.core.db_manager import DatabaseManager
+from ushareiplay.core.singleton import Singleton
 import asyncio
 
 
@@ -17,14 +18,25 @@ async def close_db():
 async def run_app():
     config = ConfigLoader.load_config()
     await init_db()
-    controller = AppController.instance(config)
-    return await controller.start_monitoring()
+    controller = None
+    try:
+        controller = AppController.initialize(config)
+        return await controller.start_monitoring()
+    finally:
+        if controller is not None:
+            await controller.shutdown()
+        Singleton.reset_all_instances()
 
 
 async def main():
     run_count = 0
     while run_count <= 9:
-        res = await run_app()
+        try:
+            res = await run_app()
+        except Exception:
+            run_count += 1
+            print(f"[main]App crashed, restarting... {run_count}")
+            continue
         if res:
             break
         run_count += 1

--- a/src/ushareiplay/commands/end.py
+++ b/src/ushareiplay/commands/end.py
@@ -13,7 +13,7 @@ class EndCommand(BaseCommand):
         # 初始化派对管理器
         from ushareiplay.managers.party_manager import PartyManager
         self.party_manager = PartyManager.instance()
-        self.party_manager.initialize()
+        self.party_manager.initialize_party()
 
     async def do_process(self, message_info, parameters):
         """Process end command to close party"""

--- a/src/ushareiplay/commands/sleep.py
+++ b/src/ushareiplay/commands/sleep.py
@@ -8,12 +8,7 @@ class SleepCommand(BaseCommand):
     async def do_process(self, message_info, parameters):
         keyword = (parameters[0].strip().lower() if parameters else "status")
 
-        # Prefer the controller's root config (contains `sleep`). Fall back to handler config.
-        config = getattr(self.controller, "config", None)
-        if not isinstance(config, dict):
-            config = getattr(self.soul_handler, "config", {}) or {}
-
-        manager = SleepManager.instance(config)
+        manager = SleepManager.instance()
 
         if keyword == "on":
             manager.set_override(True)

--- a/src/ushareiplay/core/app_controller.py
+++ b/src/ushareiplay/core/app_controller.py
@@ -12,6 +12,7 @@ from appium.options.common import AppiumOptions
 from selenium.common import WebDriverException, StaleElementReferenceException
 
 from ushareiplay.core.message_queue import MessageQueue
+from ushareiplay.core.message_dispatch import MessageDispatch
 from ushareiplay.core.post_party_create_automation import PostPartyCreateAutomation
 from ushareiplay.core.runtime_services import (
     AgentCommandSpool,
@@ -301,11 +302,11 @@ class AppController(Singleton):
         """Initialize handlers after driver is ready"""
         try:
             # Initialize handlers using singleton pattern
-            self.soul_handler = SoulHandler.instance(
+            self.soul_handler = SoulHandler.initialize(
                 self.driver, self.config["soul"], self
             )
             self.register_driver_subscriber(self.soul_handler)
-            self.music_handler = QQMusicHandler.instance(
+            self.music_handler = QQMusicHandler.initialize(
                 self.driver, self.config["qq_music"], self
             )
             self.register_driver_subscriber(self.music_handler)
@@ -320,24 +321,52 @@ class AppController(Singleton):
             from ushareiplay.managers.command_manager import CommandManager
             from ushareiplay.managers.info_manager import InfoManager
             from ushareiplay.managers.seat_manager import SeatManager
+            from ushareiplay.managers.admin_manager import AdminManager
+            from ushareiplay.managers.keyword_manager import KeywordManager
+            from ushareiplay.managers.message_manager import MessageManager
+            from ushareiplay.managers.sleep_manager import SleepManager
+            from ushareiplay.managers.theme_manager import ThemeManager
+            from ushareiplay.managers.title_manager import TitleManager
+            from ushareiplay.managers.user_manager import UserManager
+            from ushareiplay.state.online_list_scraper import OnlineListScraper
+            from ushareiplay.state.playback_broadcaster import PlaybackBroadcaster
+            from ushareiplay.state.playlist_state import PlaylistState
+            from ushareiplay.state.presence_tracker import PresenceTracker
+            from ushareiplay.state.room_state import RoomState
 
             # Initialize managers after handlers are ready
             self.logger.info("创建 manager 实例...")
             self.seat_manager = SeatManager.get_instance(self.soul_handler)
-            self.topic_manager = TopicManager.instance()
-            self.mic_manager = MicManager.instance()
-            self.music_manager = MusicManager.instance()
+
+            # Creation is deliberately centralized here. Every other module uses
+            # .instance() as a lookup-only API.
+            UserManager.initialize()
+            SleepManager.initialize(self.config)
+            MessageQueue.initialize()
+            RecoveryManager.initialize()
+            MessageManager.initialize()
+            self.message_dispatch = MessageDispatch.initialize()
+            self.topic_manager = TopicManager.initialize()
+            self.mic_manager = MicManager.initialize()
+            self.music_manager = MusicManager.initialize()
             self.register_driver_subscriber(self.music_manager)
             self.recovery_manager = RecoveryManager.instance()
-            self.timer_manager = TimerManager.instance()
-            self.command_manager = CommandManager.instance()
+            self.timer_manager = TimerManager.initialize()
+            self.command_manager = CommandManager.initialize()
             self.command_manager.controller = self
             self.command_manager.configure_runtime(self.command_runtime_context)
-            from ushareiplay.core.message_dispatch import MessageDispatch
-            self.message_dispatch = MessageDispatch.instance()
-            self.info_manager = InfoManager.instance()
-            self.party_manager = PartyManager.instance()
-            self.notice_manager = NoticeManager.instance()
+            RoomState.initialize()
+            PresenceTracker.initialize()
+            PlaylistState.initialize()
+            PlaybackBroadcaster.initialize()
+            OnlineListScraper.initialize()
+            self.info_manager = InfoManager.initialize()
+            self.party_manager = PartyManager.initialize()
+            self.notice_manager = NoticeManager.initialize()
+            ThemeManager.initialize()
+            TitleManager.initialize()
+            AdminManager.initialize()
+            KeywordManager.initialize()
             self.post_party_create_automation = PostPartyCreateAutomation(self)
             self._runtime_queue_drainer = RuntimeQueueDrainer(
                 handler=self.soul_handler,
@@ -355,9 +384,9 @@ class AppController(Singleton):
 
             # Initialize event manager
             self.logger.info("初始化事件管理器...")
-            self.event_manager = EventManager.instance()
+            self.event_manager = EventManager.initialize()
             self.event_manager.configure_runtime(self.event_runtime_context)
-            self.event_manager.initialize()
+            self.event_manager.initialize_events()
             self.logger.info("事件管理器初始化完成")
 
             self.logger.info("Handlers and managers initialized successfully")
@@ -546,3 +575,24 @@ class AppController(Singleton):
         # Stop async timer manager
         await self.timer_manager.stop()
         self.logger.info("Application stopped")
+
+    async def shutdown(self):
+        """Release per-run resources before the singleton graph is reset."""
+        self.is_running = False
+
+        if self._non_ui_task:
+            self._non_ui_task.cancel()
+            try:
+                await self._non_ui_task
+            except asyncio.CancelledError:
+                pass
+
+        if self.timer_manager and self.timer_manager.is_running():
+            await self.timer_manager.stop()
+
+        if self.driver:
+            try:
+                self.driver.quit()
+            except Exception:
+                if self.logger:
+                    self.logger.warning("Failed to close Appium driver during shutdown")

--- a/src/ushareiplay/core/app_controller.py
+++ b/src/ushareiplay/core/app_controller.py
@@ -42,13 +42,22 @@ class AppController(Singleton):
         self.obs.emit("app.start", ctx={"component": "AppController"})
 
         # 先创建主driver（会自动启动Soul app）
-        self.obs.emit("driver.init.start")
-        self.driver = self._init_driver()
-        self._driver_subscribers = []
-        self.obs.emit("driver.init.ok")
+        self.driver = None
+        try:
+            self.obs.emit("driver.init.start")
+            self.driver = self._init_driver()
+            self._driver_subscribers = []
+            self.obs.emit("driver.init.ok")
 
-        # 使用主driver启动其他应用
-        self._start_apps()
+            # 使用主driver启动其他应用
+            self._start_apps()
+        except Exception:
+            if self.driver:
+                try:
+                    self.driver.quit()
+                except Exception:
+                    pass
+            raise
         self.input_queue = queue.Queue()
         self.agent_command_dir = Path(".agent") / "commands"
         self.is_running = True

--- a/src/ushareiplay/core/singleton.py
+++ b/src/ushareiplay/core/singleton.py
@@ -1,5 +1,4 @@
 import threading
-import weakref
 
 
 class SingletonError(RuntimeError):
@@ -9,13 +8,7 @@ class SingletonError(RuntimeError):
 class SingletonMeta(type):
     """所有单例类共用的元类"""
     _lock = threading.RLock()
-    _registry: weakref.WeakSet[type] = weakref.WeakSet()
-    _initialization_order: list[weakref.ReferenceType[type]] = []
-
-    def __init__(cls, name, bases, namespace, **kwargs):
-        super().__init__(name, bases, namespace, **kwargs)
-        if any(isinstance(base, SingletonMeta) for base in bases):
-            SingletonMeta._registry.add(cls)
+    _initialization_order: list[type] = []
 
     def __call__(cls, *args, **kwargs):
         raise SingletonError(
@@ -34,7 +27,7 @@ class SingletonMeta(type):
             instance = type.__call__(cls, *args, **kwargs)
             cls._instance = instance
             cls._singleton_initialized = True
-            SingletonMeta._initialization_order.append(weakref.ref(cls))
+            SingletonMeta._initialization_order.append(cls)
             return instance
 
 
@@ -68,10 +61,8 @@ class Singleton(metaclass=SingletonMeta):
         """Reset initialized singletons in reverse creation order."""
         with SingletonMeta._lock:
             initialized = []
-            for class_ref in SingletonMeta._initialization_order:
-                singleton_class = class_ref()
-                if singleton_class is not None:
-                    initialized.append(singleton_class)
+            for singleton_class in SingletonMeta._initialization_order:
+                initialized.append(singleton_class)
 
             for singleton_class in reversed(initialized):
                 singleton_class.reset_instance()

--- a/src/ushareiplay/core/singleton.py
+++ b/src/ushareiplay/core/singleton.py
@@ -1,24 +1,78 @@
 import threading
+import weakref
+
+
+class SingletonError(RuntimeError):
+    """Raised when a singleton is created or accessed through the wrong API."""
 
 
 class SingletonMeta(type):
     """所有单例类共用的元类"""
-    _lock = threading.Lock()  # 确保线程安全
+    _lock = threading.RLock()
+    _registry: weakref.WeakSet[type] = weakref.WeakSet()
+    _initialization_order: list[weakref.ReferenceType[type]] = []
+
+    def __init__(cls, name, bases, namespace, **kwargs):
+        super().__init__(name, bases, namespace, **kwargs)
+        if any(isinstance(base, SingletonMeta) for base in bases):
+            SingletonMeta._registry.add(cls)
 
     def __call__(cls, *args, **kwargs):
-        if not hasattr(cls, "_instance"):
-            with cls._lock:  # 双重检查锁
-                if not hasattr(cls, "_instance"):
-                    cls._instance = super().__call__(*args, **kwargs)
-        return cls._instance
+        raise SingletonError(
+            f"{cls.__name__} singleton creation is restricted. "
+            f"Use {cls.__name__}.initialize(...)."
+        )
+
+    def _initialize(cls, *args, **kwargs):
+        with SingletonMeta._lock:
+            if cls.__dict__.get("_singleton_initialized", False):
+                raise SingletonError(
+                    f"{cls.__name__} singleton already initialized. "
+                    f"Use {cls.__name__}.instance() to access it."
+                )
+
+            instance = type.__call__(cls, *args, **kwargs)
+            cls._instance = instance
+            cls._singleton_initialized = True
+            SingletonMeta._initialization_order.append(weakref.ref(cls))
+            return instance
 
 
 class Singleton(metaclass=SingletonMeta):
     """单例基类，子类只需继承即可"""
 
     @classmethod
-    def instance(cls, *args, **kwargs):
-        # 如果实例已存在且没有传入参数，直接返回现有实例
-        if hasattr(cls, "_instance") and not args and not kwargs:
-            return cls._instance
-        return cls(*args, **kwargs)
+    def initialize(cls, *args, **kwargs):
+        """Create this singleton exactly once."""
+        return SingletonMeta._initialize(cls, *args, **kwargs)
+
+    @classmethod
+    def instance(cls):
+        """Return an initialized singleton without creating one implicitly."""
+        if not cls.__dict__.get("_singleton_initialized", False):
+            raise SingletonError(
+                f"{cls.__name__} has not been initialized. "
+                f"Call {cls.__name__}.initialize(...) first."
+            )
+        return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset one singleton. Intended for tests and process restart only."""
+        with SingletonMeta._lock:
+            cls._instance = None
+            cls._singleton_initialized = False
+
+    @classmethod
+    def reset_all_instances(cls) -> None:
+        """Reset initialized singletons in reverse creation order."""
+        with SingletonMeta._lock:
+            initialized = []
+            for class_ref in SingletonMeta._initialization_order:
+                singleton_class = class_ref()
+                if singleton_class is not None:
+                    initialized.append(singleton_class)
+
+            for singleton_class in reversed(initialized):
+                singleton_class.reset_instance()
+            SingletonMeta._initialization_order.clear()

--- a/src/ushareiplay/managers/command_manager.py
+++ b/src/ushareiplay/managers/command_manager.py
@@ -232,12 +232,7 @@ class CommandManager(Singleton):
 
                     prefix = command_info.get("prefix") or ""
                     sleep_exempt = bool(getattr(message_info, "sleep_exempt", False))
-                    # Prefer root config (controller.config) so `sleep` can live at top-level.
-                    controller = self._get_command_controller()
-                    cfg = getattr(controller, "config", None) if controller is not None else None
-                    if not isinstance(cfg, dict):
-                        cfg = self.handler.config
-                    sg = SleepManager.instance(cfg)
+                    sg = SleepManager.instance()
                     if not sleep_exempt and sg.is_blocked_command(prefix):
                         result = {
                             "error": (

--- a/src/ushareiplay/managers/event_manager.py
+++ b/src/ushareiplay/managers/event_manager.py
@@ -84,7 +84,7 @@ class EventManager(Singleton):
             raise RuntimeError("EventManager runtime has not been configured")
         return self._runtime
 
-    def initialize(self):
+    def initialize_events(self):
         """初始化事件管理器，加载所有事件模块"""
         if self._initialized:
             return
@@ -386,7 +386,7 @@ class EventManager(Singleton):
             事件触发数量和未知页面恢复结果
         """
         if not self._initialized:
-            self.initialize()
+            self.initialize_events()
 
         if not page_source:
             return {

--- a/src/ushareiplay/managers/party_manager.py
+++ b/src/ushareiplay/managers/party_manager.py
@@ -44,7 +44,7 @@ class PartyManager(Singleton):
             self._message_dispatch = MessageDispatch.instance().bind_handler(self.handler)
         return self._message_dispatch
 
-    def initialize(self):
+    def initialize_party(self):
         """初始化派对管理器"""
         if self.init_time is None:
             self.init_time = datetime.now()
@@ -63,7 +63,7 @@ class PartyManager(Singleton):
         try:
             # 确保已初始化
             if self.init_time is None:
-                self.initialize()
+                self.initialize_party()
                 return
 
             current_time = datetime.now()

--- a/src/ushareiplay/managers/sleep_manager.py
+++ b/src/ushareiplay/managers/sleep_manager.py
@@ -137,16 +137,6 @@ class SleepManager(Singleton):
                     out.add(s)
         return out
 
-    @classmethod
-    def reset_for_tests(cls) -> None:
-        """
-        Official singleton reset hook for tests.
-
-        Do not use in production code.
-        """
-        if hasattr(cls, "_instance"):
-            delattr(cls, "_instance")
-
     def set_override(self, enabled: bool | None) -> None:
         if enabled is None:
             self._override_enabled = None
@@ -230,4 +220,3 @@ class SleepManager(Singleton):
         if cmd not in self._blocked_commands:
             return False
         return self.is_in_sleep_window(now)
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+
+from ushareiplay.core.message_dispatch import MessageDispatch
+from ushareiplay.core.message_queue import MessageQueue
+from ushareiplay.core.singleton import Singleton
+from ushareiplay.managers.command_manager import CommandManager
+from ushareiplay.managers.event_manager import EventManager
+from ushareiplay.managers.party_manager import PartyManager
+from ushareiplay.managers.timer_manager import TimerManager
+
+
+@pytest.fixture(autouse=True)
+def initialized_test_singletons():
+    """Provide dependency-free singleton services and isolate every test."""
+    Singleton.reset_all_instances()
+    for singleton_class in (
+        MessageQueue,
+        MessageDispatch,
+        CommandManager,
+        EventManager,
+        PartyManager,
+        TimerManager,
+    ):
+        singleton_class.initialize()
+
+    yield
+
+    Singleton.reset_all_instances()

--- a/tests/state/test_info_manager_facade.py
+++ b/tests/state/test_info_manager_facade.py
@@ -20,9 +20,13 @@ def info_manager():
         PlaybackBroadcaster,
         OnlineListScraper,
     ):
-        if hasattr(cls, "_instance"):
-            del cls._instance
-    manager = InfoManager.instance()
+        cls.reset_instance()
+    RoomState.initialize()
+    PresenceTracker.initialize()
+    PlaylistState.initialize()
+    PlaybackBroadcaster.initialize()
+    OnlineListScraper.initialize()
+    manager = InfoManager.initialize()
     manager._logger = SimpleNamespace(
         info=lambda _msg: None,
         warning=lambda _msg: None,

--- a/tests/state/test_online_list_scraper.py
+++ b/tests/state/test_online_list_scraper.py
@@ -10,9 +10,8 @@ from ushareiplay.state.presence_tracker import PresenceTracker
 
 @pytest.fixture
 def scraper():
-    if hasattr(OnlineListScraper, "_instance"):
-        del OnlineListScraper._instance
-    s = OnlineListScraper.instance()
+    OnlineListScraper.reset_instance()
+    s = OnlineListScraper.initialize()
     s._logger = SimpleNamespace(
         info=lambda _msg: None,
         warning=lambda _msg: None,
@@ -24,19 +23,17 @@ def scraper():
 
 @pytest.fixture
 def reset_singletons():
-    if hasattr(RoomState, "_instance"):
-        del RoomState._instance
-    if hasattr(PresenceTracker, "_instance"):
-        del PresenceTracker._instance
+    RoomState.reset_instance()
+    PresenceTracker.reset_instance()
 
 
 @pytest.mark.asyncio
 async def test_refresh_online_users_parses_and_updates_presence(scraper, reset_singletons):
-    room_state = RoomState.instance()
+    room_state = RoomState.initialize()
     room_state._logger = SimpleNamespace(info=lambda _msg: None)
     room_state.user_count = 2
 
-    presence_tracker = PresenceTracker.instance()
+    presence_tracker = PresenceTracker.initialize()
     presence_tracker._logger = SimpleNamespace(
         info=lambda _msg: None,
         debug=lambda _msg: None,
@@ -79,6 +76,8 @@ async def test_refresh_online_users_parses_and_updates_presence(scraper, reset_s
 
 
 def test_refresh_online_users_no_op_when_user_count_element_missing(scraper):
+    RoomState.initialize()
+    PresenceTracker.initialize()
     scraper._handler.try_find_element.return_value = None
     # Should return early without raising
     import asyncio

--- a/tests/state/test_playback_broadcaster.py
+++ b/tests/state/test_playback_broadcaster.py
@@ -3,14 +3,16 @@ from types import SimpleNamespace
 import pytest
 from unittest.mock import MagicMock, patch
 
+from ushareiplay.core.message_dispatch import MessageDispatch
 from ushareiplay.state.playback_broadcaster import PlaybackBroadcaster
 
 
 @pytest.fixture
 def broadcaster():
-    if hasattr(PlaybackBroadcaster, "_instance"):
-        del PlaybackBroadcaster._instance
-    b = PlaybackBroadcaster.instance()
+    MessageDispatch.reset_instance()
+    MessageDispatch.initialize()
+    PlaybackBroadcaster.reset_instance()
+    b = PlaybackBroadcaster.initialize()
     b._logger = SimpleNamespace(
         info=lambda _msg: None,
         warning=lambda _msg: None,

--- a/tests/state/test_playlist_state.py
+++ b/tests/state/test_playlist_state.py
@@ -7,9 +7,8 @@ from ushareiplay.state.playlist_state import PlaylistState
 
 @pytest.fixture
 def playlist_state():
-    if hasattr(PlaylistState, "_instance"):
-        del PlaylistState._instance
-    state = PlaylistState.instance()
+    PlaylistState.reset_instance()
+    state = PlaylistState.initialize()
     state._logger = SimpleNamespace(info=lambda _msg: None)
     return state
 

--- a/tests/state/test_presence_tracker.py
+++ b/tests/state/test_presence_tracker.py
@@ -8,9 +8,8 @@ from ushareiplay.state.presence_tracker import PresenceTracker
 
 @pytest.fixture
 def presence_tracker():
-    if hasattr(PresenceTracker, "_instance"):
-        del PresenceTracker._instance
-    tracker = PresenceTracker.instance()
+    PresenceTracker.reset_instance()
+    tracker = PresenceTracker.initialize()
     tracker._logger = SimpleNamespace(
         info=lambda _msg: None,
         debug=lambda _msg: None,

--- a/tests/state/test_room_state.py
+++ b/tests/state/test_room_state.py
@@ -7,9 +7,8 @@ from ushareiplay.state.room_state import RoomState
 
 @pytest.fixture
 def room_state():
-    if hasattr(RoomState, "_instance"):
-        del RoomState._instance
-    state = RoomState.instance()
+    RoomState.reset_instance()
+    state = RoomState.initialize()
     state._logger = SimpleNamespace(info=lambda _msg: None)
     return state
 

--- a/tests/test_app_controller_driver_subscribers.py
+++ b/tests/test_app_controller_driver_subscribers.py
@@ -2,6 +2,8 @@ import asyncio
 from types import SimpleNamespace
 from queue import Queue
 
+import pytest
+
 from ushareiplay.core.app_controller import AppController
 
 
@@ -66,6 +68,22 @@ def controller_without_init(driver=None):
     controller.obs = FakeObserver()
     controller.soul_handler = None
     return controller
+
+
+def test_controller_init_closes_driver_when_starting_apps_fails(monkeypatch):
+    driver = FakeDriver("startup-driver")
+    controller = object.__new__(AppController)
+    monkeypatch.setattr(AppController, "_init_driver", lambda _self: driver)
+
+    def fail_to_start_apps(_self):
+        raise RuntimeError("startup failed")
+
+    monkeypatch.setattr(AppController, "_start_apps", fail_to_start_apps)
+
+    with pytest.raises(RuntimeError, match="startup failed"):
+        AppController.__init__(controller, {})
+
+    assert driver.quit_called is True
 
 
 def test_register_driver_subscriber_adds_unique_objects_and_current_driver():

--- a/tests/test_command_manager_sleep_block.py
+++ b/tests/test_command_manager_sleep_block.py
@@ -45,11 +45,17 @@ class DummyCommand:
 
 @pytest.fixture(autouse=True)
 def _reset_sleep_singleton():
+    from ushareiplay.core.message_dispatch import MessageDispatch
+    from ushareiplay.managers.command_manager import CommandManager
     from ushareiplay.managers.sleep_manager import SleepManager
 
-    SleepManager.reset_for_tests()
+    CommandManager.reset_instance()
+    MessageDispatch.reset_instance()
+    SleepManager.reset_instance()
     yield
-    SleepManager.reset_for_tests()
+    CommandManager.reset_instance()
+    MessageDispatch.reset_instance()
+    SleepManager.reset_instance()
 
 
 @pytest.fixture
@@ -66,9 +72,13 @@ def _patch_user_dao(monkeypatch):
 
 
 def _make_command_manager(config: dict):
+    from ushareiplay.core.message_dispatch import MessageDispatch
     from ushareiplay.managers.command_manager import CommandManager
+    from ushareiplay.managers.sleep_manager import SleepManager
 
-    cm = CommandManager.instance()
+    SleepManager.initialize(config)
+    MessageDispatch.initialize()
+    cm = CommandManager.initialize()
     cm._handler = HandlerStub(config)
     cm.configure_runtime(RuntimeStub())
     return cm

--- a/tests/test_info_command_release_date.py
+++ b/tests/test_info_command_release_date.py
@@ -19,9 +19,12 @@ def info_manager():
         PresenceTracker,
         RoomState,
     ):
-        if hasattr(cls, "_instance"):
-            del cls._instance
-    manager = InfoManager.instance()
+        cls.reset_instance()
+    PlaybackBroadcaster.initialize()
+    PlaylistState.initialize()
+    PresenceTracker.initialize()
+    RoomState.initialize()
+    manager = InfoManager.initialize()
     manager._logger = SimpleNamespace(info=lambda _message: None)
     return manager
 

--- a/tests/test_info_manager_broadcast.py
+++ b/tests/test_info_manager_broadcast.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
+from ushareiplay.core.message_dispatch import MessageDispatch
 from ushareiplay.managers.info_manager import InfoManager
 from ushareiplay.state.online_list_scraper import OnlineListScraper
 from ushareiplay.state.playback_broadcaster import PlaybackBroadcaster
@@ -11,6 +12,8 @@ from ushareiplay.state.room_state import RoomState
 
 @pytest.fixture
 def info_manager():
+    MessageDispatch.reset_instance()
+    MessageDispatch.initialize()
     for cls in (
         InfoManager,
         RoomState,
@@ -19,9 +22,13 @@ def info_manager():
         PlaybackBroadcaster,
         OnlineListScraper,
     ):
-        if hasattr(cls, '_instance'):
-            del cls._instance
-    return InfoManager.instance()
+        cls.reset_instance()
+    RoomState.initialize()
+    PresenceTracker.initialize()
+    PlaylistState.initialize()
+    PlaybackBroadcaster.initialize()
+    OnlineListScraper.initialize()
+    return InfoManager.initialize()
 
 def test_send_playing_message_respects_broadcast_toggle(info_manager):
     # Mock handler and logger

--- a/tests/test_keyword_sleep_exemption.py
+++ b/tests/test_keyword_sleep_exemption.py
@@ -22,7 +22,7 @@ def test_keyword_command_execution_does_not_sleep_exempt_by_default():
     from ushareiplay.core.message_queue import MessageQueue
     from ushareiplay.managers.keyword_manager import KeywordManager
 
-    keyword_manager = KeywordManager.instance()
+    keyword_manager = KeywordManager.initialize()
     keyword_manager._logger = SimpleNamespace(
         info=lambda *_args, **_kwargs: None,
         error=lambda *_args, **_kwargs: None,

--- a/tests/test_message_dispatch.py
+++ b/tests/test_message_dispatch.py
@@ -39,15 +39,13 @@ class _UserManager:
 
 @pytest.fixture(autouse=True)
 def reset_message_dispatch_singleton():
-    if hasattr(MessageDispatch, "_instance"):
-        delattr(MessageDispatch, "_instance")
+    MessageDispatch.reset_instance()
     yield
-    if hasattr(MessageDispatch, "_instance"):
-        delattr(MessageDispatch, "_instance")
+    MessageDispatch.reset_instance()
 
 
 def _make_dispatch():
-    dispatch = MessageDispatch.instance()
+    dispatch = MessageDispatch.initialize()
     dispatch._handler = _Handler()
     dispatch._user_manager = _UserManager()
     runtime = _Runtime()

--- a/tests/test_recovery_manager.py
+++ b/tests/test_recovery_manager.py
@@ -9,11 +9,9 @@ from ushareiplay.managers.recovery_manager import RecoveryManager
 
 @pytest.fixture(autouse=True)
 def reset_recovery_manager_singleton():
-    if hasattr(RecoveryManager, "_instance"):
-        delattr(RecoveryManager, "_instance")
+    RecoveryManager.reset_instance()
     yield
-    if hasattr(RecoveryManager, "_instance"):
-        delattr(RecoveryManager, "_instance")
+    RecoveryManager.reset_instance()
 
 
 class FakeHandler:
@@ -47,7 +45,7 @@ class FakeHandler:
 
 def _make_manager(monkeypatch, handler):
     monkeypatch.setattr(SoulHandler, "instance", classmethod(lambda cls: handler))
-    return RecoveryManager.instance()
+    return RecoveryManager.initialize()
 
 
 def test_close_drawer_succeeds_after_second_tap(monkeypatch):

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -47,7 +47,19 @@ def test_initialize_twice_raises_clear_error():
         _FooService.initialize()
 
 
+def test_instance_rejects_constructor_arguments():
+    with pytest.raises(TypeError):
+        _FooService.instance("unexpected")
+
+
 def test_direct_constructor_is_not_a_creation_api():
+    with pytest.raises(SingletonError, match="Use _FooService.initialize"):
+        _FooService()
+
+
+def test_direct_constructor_rejects_creation_after_initialize():
+    _FooService.initialize()
+
     with pytest.raises(SingletonError, match="Use _FooService.initialize"):
         _FooService()
 

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -1,12 +1,9 @@
 """
-验证 Singleton 基类在重构后行为不变：
-- 同类返回同一实例
-- 不同类各自独立
-- 多线程并发创建仍是同一实例
+验证 Singleton 的创建、查找与重置契约。
 """
 import threading
 import pytest
-from ushareiplay.core.singleton import Singleton
+from ushareiplay.core.singleton import Singleton, SingletonError
 
 
 class _FooService(Singleton):
@@ -17,22 +14,42 @@ class _BarService(Singleton):
     pass
 
 
-def test_same_class_returns_same_instance():
-    a = _FooService.instance()
+@pytest.fixture(autouse=True)
+def reset_test_singletons():
+    _FooService.reset_instance()
+    _BarService.reset_instance()
+    yield
+    _FooService.reset_instance()
+    _BarService.reset_instance()
+
+
+def test_initialize_creates_instance_and_instance_returns_it():
+    a = _FooService.initialize()
     b = _FooService.instance()
     assert a is b
 
 
 def test_different_classes_are_independent():
-    foo = _FooService.instance()
-    bar = _BarService.instance()
+    foo = _FooService.initialize()
+    bar = _BarService.initialize()
     assert foo is not bar
 
 
-def test_direct_constructor_returns_same_instance():
-    a = _FooService()
-    b = _FooService()
-    assert a is b
+def test_instance_before_initialize_raises_clear_error():
+    with pytest.raises(SingletonError, match="_FooService has not been initialized"):
+        _FooService.instance()
+
+
+def test_initialize_twice_raises_clear_error():
+    _FooService.initialize()
+
+    with pytest.raises(SingletonError, match="_FooService singleton already initialized"):
+        _FooService.initialize()
+
+
+def test_direct_constructor_is_not_a_creation_api():
+    with pytest.raises(SingletonError, match="Use _FooService.initialize"):
+        _FooService()
 
 
 def test_thread_safe_concurrent_creation():
@@ -41,6 +58,8 @@ def test_thread_safe_concurrent_creation():
 
     class _ConcurrentService(Singleton):
         pass
+
+    _ConcurrentService.initialize()
 
     def create():
         barrier.wait()
@@ -53,3 +72,4 @@ def test_thread_safe_concurrent_creation():
         t.join()
 
     assert len(set(id(i) for i in instances)) == 1, "并发创建应返回同一实例"
+    _ConcurrentService.reset_instance()

--- a/tests/test_sleep_manager.py
+++ b/tests/test_sleep_manager.py
@@ -5,8 +5,8 @@ def _fresh_manager(config: dict):
     from ushareiplay.managers.sleep_manager import SleepManager
 
     # Singleton test isolation (official hook)
-    SleepManager.reset_for_tests()
-    return SleepManager.instance(config)
+    SleepManager.reset_instance()
+    return SleepManager.initialize(config)
 
 
 def test_non_cross_midnight_window_start_inclusive_end_exclusive():
@@ -210,4 +210,3 @@ def test_default_blocked_commands_contains_required_minimum_set():
     required = ("play", "next", "fav", "singer", "album", "playlist", "radio")
     for cmd in required:
         assert mgr.is_blocked_command(cmd, dt.time(12, 0)) is True
-


### PR DESCRIPTION
## Summary
- Split singleton creation (`initialize`) from lookup (`instance`) and reject direct construction.
- Centralize production singleton setup in `AppController`, including `SleepManager` configuration.
- Reset the full singleton graph and release the Appium driver between restart attempts.
- Migrate singleton tests to official reset helpers and add strict API coverage.

## Verification
- `uv run pytest -q` (302 passed)