### PR TITLE
[codex] Collapse AppHandler UI delegates

### DIFF
--- a/src/ushareiplay/commands/acc.py
+++ b/src/ushareiplay/commands/acc.py
@@ -22,13 +22,13 @@ class AccompanimentCommand(BaseCommand):
         Returns:
             dict: {'enabled': 'on'/'off'}
         """
-        if not self.handler.switch_to_app():
+        if not self.handler.key_actions.switch_to_app():
             return {'error': 'Failed to switch to QQ Music app'}
         self.handler.logger.info("Switched to QQ Music app")
 
-        self.handler.press_back()
+        self.handler.key_actions.press_back()
         # 1. 查找四个控件中的任意一个，找不到说明没有在播放
-        found_key, found_element = self.handler.wait_for_any_element([
+        found_key, found_element = self.handler.element_finder.wait_for_any_element([
             'accompaniment_text_off', 'accompaniment_text_on', 'playing_bar', 'more_entry'
         ])
 
@@ -40,10 +40,10 @@ class AccompanimentCommand(BaseCommand):
         if found_key == 'playing_bar':
             # 找到播放条，需要进入播放页面
             self.handler.logger.info("Found playing bar, clicking to enter playing page")
-            if not self.handler.click_element_at(found_element):
+            if not self.handler.gesture_handler.click_element_at(found_element):
                 return {'error': 'Failed to click playing bar'}
 
-            found_key, found_element = self.handler.wait_for_any_element([
+            found_key, found_element = self.handler.element_finder.wait_for_any_element([
                 'accompaniment_text_off', 'accompaniment_text_on', 'more_entry'
             ])
 
@@ -53,17 +53,17 @@ class AccompanimentCommand(BaseCommand):
         # 3. 如果找到的是accompaniment_switch，说明此前还没激活过伴唱模式
         if found_key == 'more_entry':
 
-            accompaniment_switch = self.handler.try_find_element('accompaniment_switch')
+            accompaniment_switch = self.handler.element_finder.try_find_element('accompaniment_switch')
             # if disabled, return
             if accompaniment_switch and accompaniment_switch.get_attribute('enabled') == 'false':
                 return {'error': 'Accompaniment mode is disabled'}
 
             self.handler.logger.info("Found accompaniment more menu entry, activating accompaniment mode")
-            if not self.handler.click_element_at(found_element):
+            if not self.handler.gesture_handler.click_element_at(found_element):
                 return {'error': 'Failed to click accompaniment switch'}
 
             # 查找伴唱菜单
-            button_key, found_button, _ = self.handler.scroll_container_until_element('accompaniment_menu',
+            button_key, found_button, _ = self.handler.gesture_handler.scroll_container_until_element('accompaniment_menu',
                                                                                    'menu_container')
             if found_button is None:
                 return {'error': 'Failed to find accompaniment menu'}
@@ -71,7 +71,7 @@ class AccompanimentCommand(BaseCommand):
             self.handler.logger.info("Clicked accompaniment menu")
 
             # 查找伴唱状态按钮
-            button_key, found_button = self.handler.wait_for_any_element([
+            button_key, found_button = self.handler.element_finder.wait_for_any_element([
                 'accompaniment_button_on', 'accompaniment_button_off'
             ])
 
@@ -83,12 +83,12 @@ class AccompanimentCommand(BaseCommand):
 
             if enable != current_state:
                 # 需要切换状态，直接点击找到的按钮
-                if not self.handler.click_element_at(found_button):
+                if not self.handler.gesture_handler.click_element_at(found_button):
                     return {'error': 'Failed to toggle accompaniment state'}
                 self.handler.logger.info(f"Toggled accompaniment state to {'on' if enable else 'off'}")
             else:
                 self.handler.logger.info(f"Accompaniment state already {'on' if enable else 'off'}, no action needed")
-            self.handler.press_back()
+            self.handler.key_actions.press_back()
 
         # 4. 如果找到的是accompaniment_text_off或accompaniment_text_on，说明已经开启过伴奏模式
         else:
@@ -97,7 +97,7 @@ class AccompanimentCommand(BaseCommand):
 
             if enable != current_state:
                 # 需要切换状态，直接点击找到的元素
-                if not self.handler.click_element_at(found_element):
+                if not self.handler.gesture_handler.click_element_at(found_element):
                     return {'error': f"Failed to {'enable' if enable else 'disable'} accompaniment mode"}
                 self.handler.logger.info(f"{'Enabled' if enable else 'Disabled'} accompaniment mode")
             else:

--- a/src/ushareiplay/commands/album.py
+++ b/src/ushareiplay/commands/album.py
@@ -29,10 +29,10 @@ class AlbumCommand(BaseCommand):
         """Select the 'Album' tab in search results"""
         try:
             # Try to find album tab first
-            album_tab = self.handler.try_find_element('album_tab')
+            album_tab = self.handler.element_finder.try_find_element('album_tab')
             if not album_tab:
                 # If not found, scroll music_tabs to find it
-                music_tabs = self.handler.try_find_element('music_tabs')
+                music_tabs = self.handler.element_finder.try_find_element('music_tabs')
                 if not music_tabs:
                     self.handler.logger.error("Failed to find music tabs")
                     return False
@@ -42,7 +42,7 @@ class AlbumCommand(BaseCommand):
                 location = music_tabs.location
 
                 # Scroll to right
-                self.handler.driver.swipe(
+                self.handler.gesture_handler.swipe(
                     location['x'] + 200,  # Start from left
                     location['y'] + size['height'] // 2,
                     location['x'] + size['width'] - 10,  # End at right
@@ -51,7 +51,7 @@ class AlbumCommand(BaseCommand):
                 )
 
                 # Try to find album tab again
-                album_tab = self.handler.try_find_element('album_tab')
+                album_tab = self.handler.element_finder.try_find_element('album_tab')
                 if not album_tab:
                     self.handler.logger.error("Failed to find album tab after scrolling")
                     return False
@@ -82,13 +82,13 @@ class AlbumCommand(BaseCommand):
                 'error': 'Failed to select album tab',
             }
 
-        key, element = self.handler.wait_for_any_element(['album_result', 'not_found'])
+        key, element = self.handler.element_finder.wait_for_any_element(['album_result', 'not_found'])
         if not key or key == 'not_found':
             self.handler.logger.error(f"Not found album result with query {query}")
             return {
                 'error': f'Failed to find album result with query {query}',
             }
-        album_result = self.handler.find_elements('album_result')
+        album_result = self.handler.element_finder.find_elements('album_result')
         if len(album_result) < 2:
             self.handler.logger.error(f"Failed to find album result with query {query}")
             return {
@@ -102,7 +102,7 @@ class AlbumCommand(BaseCommand):
         album_name.click()
         self.handler.logger.info("album name clicked")
 
-        key, play_button = self.handler.wait_for_any_element(['play_all'])
+        key, play_button = self.handler.element_finder.wait_for_any_element(['play_all'])
         if not play_button:
             self.handler.logger.error(f"Failed to find play button for query {query}")
             return {'error': 'Failed to find play button'}
@@ -116,7 +116,7 @@ class AlbumCommand(BaseCommand):
             self.handler.logger.warning(f"Failed to read album playlist after playback started: {error}")
             playlist_text = f"{title} - {topic}"
 
-        self.handler.press_back()
+        self.handler.key_actions.press_back()
 
         self.handler.list_mode = 'album'
 

--- a/src/ushareiplay/commands/fav.py
+++ b/src/ushareiplay/commands/fav.py
@@ -60,7 +60,7 @@ class FavCommand(BaseCommand):
         新版“筛选歌曲”页：同页展示歌手/语种/流派。
         流程：点筛选 -> 点选关键字(TextView[@text]) -> 点“确定（xxx首）”
         """
-        filter_favourite = self.handler.wait_for_element_clickable('filter_favourite')
+        filter_favourite = self.handler.element_finder.wait_for_element_clickable('filter_favourite')
         if not filter_favourite:
             return {'error': 'Cannot find filter button'}
         filter_favourite.click()
@@ -149,7 +149,7 @@ class FavCommand(BaseCommand):
 
     def play_favorites_all(self):
         """导航到收藏并播放所有"""
-        if not self.handler.switch_to_app():
+        if not self.handler.key_actions.switch_to_app():
             return {'error': 'Cannot switch to qq music'}
         self.handler.logger.info("Switched to QQ Music app")
 
@@ -157,7 +157,7 @@ class FavCommand(BaseCommand):
         if err:
             return err
 
-        result_item = self.handler.try_find_element('result_item')
+        result_item = self.handler.element_finder.try_find_element('result_item')
         song_text = None
         singer_text = None
         if result_item:
@@ -166,7 +166,7 @@ class FavCommand(BaseCommand):
                 song_text = elements[1].text
                 singer_text = elements[2].text
 
-        play_fav = self.handler.wait_for_element_clickable('play_all')
+        play_fav = self.handler.element_finder.wait_for_element_clickable('play_all')
         play_fav.click()
         self.handler.logger.info("Clicked play all button")
 
@@ -194,7 +194,7 @@ class FavCommand(BaseCommand):
         参数:
             keyword: 筛选关键字，如“国语”“流行”“张国荣”
         """
-        if not self.handler.switch_to_app():
+        if not self.handler.key_actions.switch_to_app():
             return {'error': 'Cannot switch to qq music'}
         self.handler.logger.info("Switched to QQ Music app")
 
@@ -208,7 +208,7 @@ class FavCommand(BaseCommand):
         count = filter_result.get('count') if isinstance(filter_result, dict) else None
 
         # Get song info from the first result
-        result_item = self.handler.try_find_element('result_item')
+        result_item = self.handler.element_finder.try_find_element('result_item')
         song_text = None
         singer_text = None
         if result_item:
@@ -218,7 +218,7 @@ class FavCommand(BaseCommand):
                 singer_text = elements[2].text
 
         # Click play all button
-        play_fav = self.handler.wait_for_element_clickable('play_all')
+        play_fav = self.handler.element_finder.wait_for_element_clickable('play_all')
         if not play_fav:
             return {'error': 'Cannot find play all button'}
         play_fav.click()
@@ -262,7 +262,7 @@ class FavCommand(BaseCommand):
         5) 标题=关键字；话题=搜索到的第一首歌
         6) 通过 InfoManager.current_playlist_name 广播歌单（在 process 内设置）
         """
-        if not self.handler.switch_to_app():
+        if not self.handler.key_actions.switch_to_app():
             return {'error': 'Cannot switch to qq music'}
         self.handler.logger.info("Switched to QQ Music app")
 
@@ -271,7 +271,7 @@ class FavCommand(BaseCommand):
             return err
 
         # 1) 在“全部播放”按钮上下滑动其高度，目的是显示搜索框
-        play_all_btn = self.handler.wait_for_element_clickable('play_all')
+        play_all_btn = self.handler.element_finder.wait_for_element_clickable('play_all')
         if not play_all_btn:
             return {'error': 'Cannot find play all button'}
 
@@ -281,26 +281,26 @@ class FavCommand(BaseCommand):
         cy = int(loc["y"] + size["height"] * 0.5)
         dy = max(60, int(size["height"]))
 
-        self.handler._perform_swipe(cx, cy, cx, cy + dy, duration_ms=260)
+        self.handler.gesture_handler.swipe(cx, cy, cx, cy + dy, duration_ms=260)
 
         # 2) 找到 search_box 并点击激活搜索框
-        search_box = self.handler.wait_for_element_clickable('search_box')
+        search_box = self.handler.element_finder.wait_for_element_clickable('search_box')
         if not search_box:
             return {'error': 'Cannot find search box in favourites'}
         search_box.click()
         self.handler.logger.info("Clicked favourite search box")
 
-        favourite_search = self.handler.wait_for_element('favourite_search')
+        favourite_search = self.handler.element_finder.wait_for_element('favourite_search')
         if not favourite_search:
             return {'error': 'Cannot find favourite search'}
 
         # 3) 粘贴关键字
-        self.handler.set_clipboard_text(keyword)
-        self.handler.paste_text()
+        self.handler.key_actions.set_clipboard_text(keyword)
+        self.handler.key_actions.paste_text()
         self.handler.logger.info(f"Pasted keyword: {keyword}")
 
         # 4) 点击 play_favourite_search 播放搜索的歌曲列表
-        play_search = self.handler.wait_for_element_clickable('play_favourite_search')
+        play_search = self.handler.element_finder.wait_for_element_clickable('play_favourite_search')
         if not play_search:
             return {'error': 'Cannot find play_favourite_search button'}
         play_search.click()

--- a/src/ushareiplay/commands/lyrics.py
+++ b/src/ushareiplay/commands/lyrics.py
@@ -48,15 +48,15 @@ class LyricsCommand(BaseCommand):
         """Select lyrics tab in music player"""
         try:
             # Make sure we're in the music app
-            if not self.music_handler.switch_to_app():
+            if not self.music_handler.key_actions.switch_to_app():
                 self.handler.logger.error("Failed to switch to music app")
                 return False
                 
             # Try to find lyrics tab first (fast path)
-            lyrics_tab = self.music_handler.try_find_element("lyrics_tab")
+            lyrics_tab = self.music_handler.element_finder.try_find_element("lyrics_tab")
             if not lyrics_tab:
                 # 标签靠后时，单次滑动距离不够：改用通用容器滚动（参考 radio sleep）
-                _, lyrics_tab, _ = self.music_handler.scroll_container_until_element(
+                _, lyrics_tab, _ = self.music_handler.gesture_handler.scroll_container_until_element(
                     "lyrics_tab",
                     "music_tabs",
                     "left",
@@ -83,7 +83,7 @@ class LyricsCommand(BaseCommand):
             dict: Result with lyrics groups or error
         """
         # Make sure we're in the music app
-        if not self.music_handler.switch_to_app():
+        if not self.music_handler.key_actions.switch_to_app():
             return {'error': 'Failed to switch to music app'}
             
         # If no query provided, construct from current playing info
@@ -107,7 +107,7 @@ class LyricsCommand(BaseCommand):
             return {'error': 'Failed to select lyrics tab'}
             
         # Get lyrics text
-        key, element = self.music_handler.wait_for_any_element(['lyrics_text', 'not_found'])
+        key, element = self.music_handler.element_finder.wait_for_any_element(['lyrics_text', 'not_found'])
         if not key or key == 'not_found':
             self.music_handler.logger.error(f"Failed to find lyrics with query {query}")
             return {'error': f'No lyrics found for "{query}"'}

--- a/src/ushareiplay/commands/mic.py
+++ b/src/ushareiplay/commands/mic.py
@@ -12,12 +12,12 @@ class MicCommand(BaseCommand):
             dict: Result with success or error
         """
         try:
-            toggle_mic_button = self.handler.wait_for_element_clickable('toggle_mic')
+            toggle_mic_button = self.handler.element_finder.wait_for_element_clickable('toggle_mic')
 
             if not toggle_mic_button:
                 return {'error': 'Microphone button not found'}
             
-            desc = self.handler.try_get_attribute(toggle_mic_button, 'content-desc')
+            desc = self.handler.element_finder.try_get_attribute(toggle_mic_button, 'content-desc')
             if not desc:
                 self.handler.logger.error('failed to get mic status')
                 return {'error': 'Failed to get mic status'}

--- a/src/ushareiplay/commands/mode.py
+++ b/src/ushareiplay/commands/mode.py
@@ -47,14 +47,14 @@ class ModeCommand(BaseCommand):
                 self.handler.logger.info(f"[MODE_TEST][{step}] {kv}".strip())
 
             # 0. 先切换到音乐App
-            switched = self.handler.switch_to_app()
+            switched = self.handler.key_actions.switch_to_app()
             if not switched:
                 self.handler.logger.info("无法切换到音乐App")
                 return {
                     'error': '无法切换到音乐App，稍后重试'
                 }
 
-            self.handler.press_back()
+            self.handler.key_actions.press_back()
 
             # 1. 尝试查找当前界面状态
             # - playing_bar: 在非播放页但底部有播放导航条，需要先点它进入播放页
@@ -65,7 +65,7 @@ class ModeCommand(BaseCommand):
                 'play_mode_single',
                 'play_mode_random',
             ]
-            found_element_key, found_element = self.handler.wait_for_any_element(element_keys)
+            found_element_key, found_element = self.handler.element_finder.wait_for_any_element(element_keys)
 
             if not found_element_key or not found_element:
                 self.handler.logger.info("未找到播放模式相关元素，说明现在没有播放音乐")
@@ -78,14 +78,14 @@ class ModeCommand(BaseCommand):
             # 2. 如果在非播放页：先点底部 Playing Bar 进入播放页
             if found_element_key == 'playing_bar':
                 self.handler.logger.info("找到 playing_bar，点击进入播放页")
-                if not self.handler.click_element_at(found_element):
+                if not self.handler.gesture_handler.click_element_at(found_element):
                     return {
                         'error': 'FAIL: 点击 playing_bar 进入播放页失败'
                     }
 
                 # 进入播放页后，再等待播放模式按钮出现
                 mode_element_keys = ['play_mode_list', 'play_mode_single', 'play_mode_random']
-                found_element_key, found_element = self.handler.wait_for_any_element(mode_element_keys)
+                found_element_key, found_element = self.handler.element_finder.wait_for_any_element(mode_element_keys)
                 log_step("Step1", after_playing_bar_found_key=found_element_key)
 
                 if not found_element_key or not found_element:
@@ -118,13 +118,13 @@ class ModeCommand(BaseCommand):
                     before_click_mode=mode_names[current_mode],
                     target_mode=mode_names[target_mode],
                 )
-                if not self.handler.click_element_at(current_mode_element):
+                if not self.handler.gesture_handler.click_element_at(current_mode_element):
                     self.handler.logger.warning("click_element_at 返回 False，继续下一次重试")
                     continue
 
                 # 重新检查当前模式
                 mode_element_keys = ['play_mode_list', 'play_mode_single', 'play_mode_random']
-                found_element_key, found_element = self.handler.wait_for_any_element(mode_element_keys)
+                found_element_key, found_element = self.handler.element_finder.wait_for_any_element(mode_element_keys)
 
                 if not found_element_key or not found_element:
                     self.handler.logger.warning("切换后未找到播放模式元素")

--- a/src/ushareiplay/commands/pack.py
+++ b/src/ushareiplay/commands/pack.py
@@ -44,7 +44,7 @@ class PackCommand(BaseCommand):
         """
         try:
             # Find luck pack button
-            luck_pack = self.handler.try_find_element('luck_pack', log=False)
+            luck_pack = self.handler.element_finder.try_find_element('luck_pack', log=False)
             if not luck_pack:
                 return {'error': 'No luck pack available'}
 
@@ -59,7 +59,7 @@ class PackCommand(BaseCommand):
             self.handler.logger.info("Clicked luck pack button")
 
             # Find and click luck item
-            luck_item = self.handler.wait_for_element_clickable('luck_item')
+            luck_item = self.handler.element_finder.wait_for_element_clickable('luck_item')
             if not luck_item:
                 self.handler.logger.error("Failed to find luck item")
                 return {'error': 'Failed to find luck item'}
@@ -71,14 +71,14 @@ class PackCommand(BaseCommand):
                 if user_count <= 10 and not (
                         "初级" in item_text or "中级" in item_text or "一级" in item_text or "二级" in item_text):
                     self.handler.logger.info(f"Skipping high level pack with {user_count} users: {item_text}")
-                    self.handler.press_back()
+                    self.handler.key_actions.press_back()
                     return {'error': 'Skipping high level pack (not enough users)'}
 
             luck_item.click()
             self.handler.logger.info("Selected luck item")
 
             # Find and click use pack button
-            use_pack = self.handler.wait_for_element_clickable('use_pack')
+            use_pack = self.handler.element_finder.wait_for_element_clickable('use_pack')
             if not use_pack:
                 self.handler.logger.error("Failed to find use pack button")
                 return {'error': 'Failed to find use pack button'}

--- a/src/ushareiplay/commands/play.py
+++ b/src/ushareiplay/commands/play.py
@@ -36,7 +36,7 @@ class PlayCommand(BaseCommand):
             self.handler.logger.error(f'Failed to play music {music_query}')
             return playing_info
 
-        song_element = self.handler.wait_for_element_clickable('result_item')
+        song_element = self.handler.element_finder.wait_for_element_clickable('result_item')
         song_element.click()
         self.handler.logger.info("Select first song")
 
@@ -48,7 +48,7 @@ class PlayCommand(BaseCommand):
 
     def play_favorites(self):
         """Navigate to favorites and play all"""
-        if not self.handler.switch_to_app():
+        if not self.handler.key_actions.switch_to_app():
             return {'error': 'Cannot switch to qq music'}
         self.handler.logger.info(f"Switched to QQ Music app")
 
@@ -56,7 +56,7 @@ class PlayCommand(BaseCommand):
         if err:
             return err
 
-        result_item = self.handler.try_find_element('result_item')
+        result_item = self.handler.element_finder.try_find_element('result_item')
         song_text = None
         singer_text = None
         if result_item:
@@ -65,7 +65,7 @@ class PlayCommand(BaseCommand):
                 song_text = elements[1].text
                 singer_text = elements[2].text
 
-        play_fav = self.handler.wait_for_element_clickable('play_all')
+        play_fav = self.handler.element_finder.wait_for_element_clickable('play_all')
         if not play_fav:
             return {'error': 'Cannot find play all button'}
         play_fav.click()
@@ -80,13 +80,13 @@ class PlayCommand(BaseCommand):
 
     def play_radar(self):
         """Navigate to favorites and play all"""
-        if not self.handler.switch_to_app():
+        if not self.handler.key_actions.switch_to_app():
             return {'error': 'Cannot switch to qq music'}
         self.handler.logger.info(f"Switched to QQ Music app")
 
         self.handler.navigate_to_home()
         self.handler.logger.info("Navigated to home page")
-        radar_nav = self.handler.try_find_element('radar_nav', log=False)
+        radar_nav = self.handler.element_finder.try_find_element('radar_nav', log=False)
         if not radar_nav:
             return {'error': 'Cannot find radar_nav'}
 
@@ -96,9 +96,9 @@ class PlayCommand(BaseCommand):
         self.handler.list_mode = 'radar'
 
         # Click on play all button
-        song = self.handler.wait_for_element_clickable('radar_song')
+        song = self.handler.element_finder.wait_for_element_clickable('radar_song')
         song_text = song.text if song else "Unknown"
-        singer = self.handler.wait_for_element_clickable('radar_singer')
+        singer = self.handler.element_finder.wait_for_element_clickable('radar_singer')
         singer_text = singer.text if singer else "Unknown"
 
         # 使用 title_manager 和 topic_manager 管理标题和话题

--- a/src/ushareiplay/commands/playlist.py
+++ b/src/ushareiplay/commands/playlist.py
@@ -36,7 +36,7 @@ class PlaylistCommand(BaseCommand):
         """Select the 'Playlist' tab in search results by scrolling to the leftmost position"""
         try:
             # Try to find playlist tab first
-            key, element = self.handler.wait_for_any_element(['playlist_tab', 'music_tabs'])
+            key, element = self.handler.element_finder.wait_for_any_element(['playlist_tab', 'music_tabs'])
 
             if key == 'playlist_tab':
                 playlist_tab = element
@@ -47,7 +47,7 @@ class PlaylistCommand(BaseCommand):
                 location = music_tabs.location
 
                 # Scroll to left (opposite direction of singer tab)
-                self.handler.driver.swipe(
+                self.handler.gesture_handler.swipe(
                     location['x'] + 200,  # Start from left
                     location['y'] + size['height'] // 2,
                     location['x'] + size['width'] - 10,  # End at right
@@ -56,7 +56,7 @@ class PlaylistCommand(BaseCommand):
                 )
 
                 # Try to find playlist tab again
-                playlist_tab = self.handler.try_find_element('playlist_tab')
+                playlist_tab = self.handler.element_finder.try_find_element('playlist_tab')
                 if not playlist_tab:
                     self.handler.logger.error("Failed to find playlist tab after scrolling")
                     return False
@@ -86,7 +86,7 @@ class PlaylistCommand(BaseCommand):
             }
         self.handler.logger.info("Selected playlist tab")
 
-        key, element = self.handler.wait_for_any_element(['playlist_result', 'not_found'])
+        key, element = self.handler.element_finder.wait_for_any_element(['playlist_result', 'not_found'])
         if not key or key == 'not_found':
             self.handler.logger.error(f"Failed to find playlist result with query {query}")
             return {
@@ -103,7 +103,7 @@ class PlaylistCommand(BaseCommand):
 
         subject, topic = parser.parse_playlist_name(playlist)
 
-        result_item = self.handler.try_find_element('result_item')
+        result_item = self.handler.element_finder.try_find_element('result_item')
         song_name = None
         singer_name = None
         if result_item:
@@ -123,7 +123,7 @@ class PlaylistCommand(BaseCommand):
             if song_name:
                 topic = song_name.text
 
-        key, play_button = self.handler.wait_for_any_element(['play_all', 'play_all_playlist', 'play_all_compact'])
+        key, play_button = self.handler.element_finder.wait_for_any_element(['play_all', 'play_all_playlist', 'play_all_compact'])
         if not play_button:
             self.handler.logger.error("Failed to find play all button (album or playlist)")
             return {

--- a/src/ushareiplay/commands/radio.py
+++ b/src/ushareiplay/commands/radio.py
@@ -48,14 +48,14 @@ class RadioCommand(BaseCommand):
         return {"error": message}
 
     def _navigate_home(self):
-        if not self.music_handler.switch_to_app():
+        if not self.music_handler.key_actions.switch_to_app():
             return self._report_error("Cannot switch to QQ Music")
         if not self.music_handler.navigate_to_home():
             return self._report_error("Failed to navigate to home in QQ Music")
         return None
 
     def _switch_back_to_soul(self):
-        if not self.soul_handler.switch_to_app():
+        if not self.soul_handler.key_actions.switch_to_app():
             return self._report_error("Failed to switch back to Soul app")
         return None
 
@@ -118,15 +118,15 @@ class RadioCommand(BaseCommand):
         return is_old
 
     def _refresh_collection_radio(self):
-        home_nav = self.music_handler.wait_for_element_clickable("home_nav")
+        home_nav = self.music_handler.element_finder.wait_for_element_clickable("home_nav")
         if not home_nav:
             return self._report_error("Failed to find home navigation while refreshing radio")
         home_nav.click()
 
-        play_button = self.music_handler.wait_for_element_clickable("play_collection")
+        play_button = self.music_handler.element_finder.wait_for_element_clickable("play_collection")
         if not play_button:
             return self._report_error("Failed to find collection play button after refresh")
-        collection_topic = self.music_handler.wait_for_element("collection_topic")
+        collection_topic = self.music_handler.element_finder.wait_for_element("collection_topic")
         if not collection_topic:
             return self._report_error("Failed to locate collection radio topic after refresh")
         return play_button, collection_topic
@@ -139,7 +139,7 @@ class RadioCommand(BaseCommand):
                 self.music_handler.logger.warning(
                     f"Radio collection topic element stale, refinding topic ({attempt}/{max_attempts})"
                 )
-                collection_topic = self.music_handler.wait_for_element("collection_topic")
+                collection_topic = self.music_handler.element_finder.wait_for_element("collection_topic")
                 if not collection_topic:
                     return None
         return None
@@ -148,8 +148,8 @@ class RadioCommand(BaseCommand):
         error = self._navigate_home()
         if error:
             return error
-        guess_title = self.music_handler.wait_for_element_clickable("guess_title")
-        guess_topic = self.music_handler.wait_for_element("guess_topic")
+        guess_title = self.music_handler.element_finder.wait_for_element_clickable("guess_title")
+        guess_topic = self.music_handler.element_finder.wait_for_element("guess_topic")
         if not guess_title or not guess_topic:
             return self._report_error("Failed to locate guess like radio elements")
         guess_title_text = guess_title.text
@@ -177,14 +177,14 @@ class RadioCommand(BaseCommand):
         error = self._navigate_home()
         if error:
             return error
-        daily_title = self.music_handler.wait_for_element_clickable("daily_title")
-        daily_topic = self.music_handler.wait_for_element("daily_topic")
+        daily_title = self.music_handler.element_finder.wait_for_element_clickable("daily_title")
+        daily_topic = self.music_handler.element_finder.wait_for_element("daily_topic")
         if not daily_title or not daily_topic:
             return self._report_error("Failed to locate daily radio elements")
         daily_title_text = daily_title.text
         daily_topic_text = self._extract_primary_topic(daily_topic.text)
         daily_title.click()
-        play_all = self.music_handler.wait_for_element_clickable("play_all")
+        play_all = self.music_handler.element_finder.wait_for_element_clickable("play_all")
         if not play_all:
             return self._report_error("Failed to locate play all button")
         play_all.click()
@@ -216,12 +216,12 @@ class RadioCommand(BaseCommand):
         error = self._navigate_home()
         if error:
             return error
-        key, element = self.music_handler.wait_for_any_element(["pause_collection", "play_collection"])
+        key, element = self.music_handler.element_finder.wait_for_any_element(["pause_collection", "play_collection"])
         if key == "pause_collection":
             self.music_handler.logger.info("正在播放精选，刷新")
-            home_nav = self.music_handler.wait_for_element_clickable("home_nav")
+            home_nav = self.music_handler.element_finder.wait_for_element_clickable("home_nav")
             home_nav.click()
-            play_button = self.music_handler.wait_for_element_clickable("play_collection")
+            play_button = self.music_handler.element_finder.wait_for_element_clickable("play_collection")
         elif key == "play_collection":
             play_button = element
         else:
@@ -229,11 +229,11 @@ class RadioCommand(BaseCommand):
         if not play_button:
             return self._report_error("Failed to find collection play button")
 
-        collection_title = self.music_handler.wait_for_element_clickable("collection_title")
-        collection_topic = self.music_handler.wait_for_element("collection_topic")
+        collection_title = self.music_handler.element_finder.wait_for_element_clickable("collection_title")
+        collection_topic = self.music_handler.element_finder.wait_for_element("collection_topic")
         if not collection_title or not collection_topic:
             return self._report_error("Failed to locate collection radio elements")
-        collection_title_text = self.soul_handler.try_get_attribute(collection_title, 'content-desc') or "Unknown"
+        collection_title_text = self.soul_handler.element_finder.try_get_attribute(collection_title, 'content-desc') or "Unknown"
         splitter = '音频按钮'
         # Truncate text after splitter if present
         if splitter in collection_title_text:
@@ -305,7 +305,7 @@ class RadioCommand(BaseCommand):
             return error
 
         healing_room_name = "音乐疗愈"
-        _, healing_tab, _ = self.music_handler.scroll_container_until_element(
+        _, healing_tab, _ = self.music_handler.gesture_handler.scroll_container_until_element(
             "home_tab_label",
             "home_tab_strip",
             "left",
@@ -318,7 +318,7 @@ class RadioCommand(BaseCommand):
         healing_tab.click()
         self.music_handler.logger.info("Clicked 疗愈 tab after scrolling home tab strip")
 
-        play_healing = self.music_handler.wait_for_element_clickable("play_healing")
+        play_healing = self.music_handler.element_finder.wait_for_element_clickable("play_healing")
         if not play_healing:
             return self._report_error("Failed to find healing play button")
         play_healing.click()
@@ -350,7 +350,7 @@ class RadioCommand(BaseCommand):
             return error
 
         # 点击 radar 导航
-        radar_nav = self.music_handler.try_find_element('radar_nav', log=False)
+        radar_nav = self.music_handler.element_finder.try_find_element('radar_nav', log=False)
         if not radar_nav:
             return self._report_error("Cannot find radar_nav")
 
@@ -358,8 +358,8 @@ class RadioCommand(BaseCommand):
         self.music_handler.logger.info("Clicked radar navigation button")
 
         # 获取 radar 歌曲和歌手信息
-        radar_song = self.music_handler.wait_for_element_clickable('radar_song')
-        radar_singer = self.music_handler.wait_for_element_clickable('radar_singer')
+        radar_song = self.music_handler.element_finder.wait_for_element_clickable('radar_song')
+        radar_singer = self.music_handler.element_finder.wait_for_element_clickable('radar_singer')
 
         if not radar_song or not radar_singer:
             return self._report_error("Failed to locate radar song or singer elements")

--- a/src/ushareiplay/commands/singer.py
+++ b/src/ushareiplay/commands/singer.py
@@ -35,10 +35,10 @@ class SingerCommand(BaseCommand):
         """Select the 'Singer' tab in search results"""
         try:
             # Try to find singer tab first
-            singer_tab = self.handler.try_find_element("singer_tab")
+            singer_tab = self.handler.element_finder.try_find_element("singer_tab")
             if not singer_tab:
                 # If not found, scroll music_tabs to find it
-                music_tabs = self.handler.wait_for_element_clickable("music_tabs")
+                music_tabs = self.handler.element_finder.wait_for_element_clickable("music_tabs")
                 if not music_tabs:
                     self.handler.logger.error("Failed to find music tabs")
                     return False
@@ -48,7 +48,7 @@ class SingerCommand(BaseCommand):
                 location = music_tabs.location
 
                 # Scroll to right
-                self.handler.driver.swipe(
+                self.handler.gesture_handler.swipe(
                     location["x"] + 200,  # Start from left
                     location["y"] + size["height"] // 2,
                     location["x"] + size["width"] - 10,  # End at right
@@ -57,7 +57,7 @@ class SingerCommand(BaseCommand):
                 )
 
                 # Try to find singer tab again
-                singer_tab = self.handler.try_find_element("singer_tab")
+                singer_tab = self.handler.element_finder.try_find_element("singer_tab")
                 if not singer_tab:
                     self.handler.logger.error(
                         "Failed to find singer tab after scrolling"
@@ -84,19 +84,19 @@ class SingerCommand(BaseCommand):
         play_singer = None
         singer_name = 'Unknown'
         if from_key == "home_nav":
-            key, element = self.handler.wait_for_any_element(["first_song", "not_found"])
+            key, element = self.handler.element_finder.wait_for_any_element(["first_song", "not_found"])
             if not key or key == "not_found":
                 self.handler.logger.error(f'not found singer with query {query}')
                 return {
                     'error': f'not found singer with query {query}',
                 }
 
-            if play_singer := self.handler.try_find_element("play_singer_1"):
-                if singer_name := self.handler.try_get_attribute(play_singer, "content-desc"):
+            if play_singer := self.handler.element_finder.try_find_element("play_singer_1"):
+                if singer_name := self.handler.element_finder.try_get_attribute(play_singer, "content-desc"):
                     singer_name = singer_name.split(': ')[1]
                     singer_name = singer_name.split('的歌曲')[0]
-            elif play_singer := self.handler.try_find_element("play_singer"):
-                if singer_name_element := self.handler.try_find_element("singer_name"):
+            elif play_singer := self.handler.element_finder.try_find_element("play_singer"):
+                if singer_name_element := self.handler.element_finder.try_find_element("singer_name"):
                     singer_name = singer_name_element.text
 
         if play_singer:
@@ -104,7 +104,7 @@ class SingerCommand(BaseCommand):
             self.handler.logger.info("Selected singer play")
         else:
             self.select_singer_tab()
-            key, element = self.handler.wait_for_any_element(["singer_result", "not_found"])
+            key, element = self.handler.element_finder.wait_for_any_element(["singer_result", "not_found"])
             if not key or key == "not_found":
                 self.handler.logger.error(f'not found singer with query {query}')
                 return {
@@ -116,7 +116,7 @@ class SingerCommand(BaseCommand):
             self.handler.logger.info("Selected singer result")
             singer_name = singer_result.text
 
-            play_button = self.handler.wait_for_element_clickable("play_all")
+            play_button = self.handler.element_finder.wait_for_element_clickable("play_all")
             if not play_button:
                 self.handler.logger.error("Cannot find play singer button")
                 return {"error": "Failed to find play button"}

--- a/src/ushareiplay/commands/theme.py
+++ b/src/ushareiplay/commands/theme.py
@@ -13,7 +13,7 @@ class ThemeCommand(BaseCommand):
             dict: Result with theme info or error
         """
         # Switch to Soul app first
-        if not self.handler.switch_to_app():
+        if not self.handler.key_actions.switch_to_app():
             return {'error': 'Failed to switch to Soul app'}
         self.handler.logger.info("Switched to Soul app")
 

--- a/src/ushareiplay/commands/title.py
+++ b/src/ushareiplay/commands/title.py
@@ -16,7 +16,7 @@ class TitleCommand(BaseCommand):
             dict: Result with title info or error
         """
         # Switch to Soul app first
-        if not self.handler.switch_to_app():
+        if not self.handler.key_actions.switch_to_app():
             return {'error': 'Failed to switch to Soul app'}
         self.handler.logger.info("Switched to Soul app")
 

--- a/src/ushareiplay/core/app_controller.py
+++ b/src/ushareiplay/core/app_controller.py
@@ -263,7 +263,7 @@ class AppController(Singleton):
 
             # 5. 切换回应用
             if self.soul_handler:
-                self.soul_handler.switch_to_app()
+                self.soul_handler.key_actions.switch_to_app()
 
             if self.logger:
                 self.logger.info("==== Driver重建完成 ====")

--- a/src/ushareiplay/core/app_handler.py
+++ b/src/ushareiplay/core/app_handler.py
@@ -1,7 +1,7 @@
 import logging
 
 from ushareiplay.core.log_formatter import ColoredFormatter
-from ushareiplay.core.ui import ElementFinder, GestureHandler, KeyActions, Navigator
+from ushareiplay.core.ui import ElementFinder, GestureHandler, KeyActions, Navigator, UIActions
 
 _shared_handler_file_handler = None
 _shared_handler_file_path = None
@@ -21,6 +21,7 @@ class AppHandler:
         self.key_actions = KeyActions(self)
         self.gesture_handler = GestureHandler(self)
         self.navigator = Navigator(self)
+        self.ui_actions = UIActions(self)
         self.logger.debug(f"AppHandler.__init__ 完成: {self.__class__.__name__}")
 
     @property
@@ -112,148 +113,3 @@ class AppHandler:
     def log_warning(self, message):
         """Log warning level message"""
         self.logger.warning(message)
-
-    def wait_for_element(self, element_key: str, timeout: int = 10):
-        return self.element_finder.wait_for_element(element_key, timeout=timeout)
-
-    def is_element_clickable(self, element):
-        return self.element_finder.is_element_clickable(element)
-
-    def wait_for_element_clickable(self, element_key: str, timeout: int = 10):
-        return self.element_finder.wait_for_element_clickable(element_key, timeout=timeout)
-
-    def try_find_element(self, element_key: str, log=False, clickable=False):
-        return self.element_finder.try_find_element(element_key, log=log, clickable=clickable)
-
-    def wait_for_element_polling(
-            self, locator_type, locator_value, timeout=10, poll_frequency=0.5
-    ):
-        return self.element_finder.wait_for_element_polling(
-            locator_type,
-            locator_value,
-            timeout=timeout,
-            poll_frequency=poll_frequency,
-        )
-
-    def wait_for_element_clickable_polling(
-            self, locator_type, locator_value, timeout=10, poll_frequency=0.5
-    ):
-        return self.element_finder.wait_for_element_clickable_polling(
-            locator_type,
-            locator_value,
-            timeout=timeout,
-            poll_frequency=poll_frequency,
-        )
-
-    def get_element_text(self, element):
-        return self.element_finder.get_element_text(element)
-
-    def try_get_attribute(self, element, attribute):
-        return self.element_finder.try_get_attribute(element, attribute)
-
-    def _get_locator(self, element_key: str):
-        return self.element_finder._get_locator(element_key)
-
-    def find_elements(self, element_key: str):
-        return self.element_finder.find_elements(element_key)
-
-    def find_child_element(self, parent, element_key, log_failure: bool = True):
-        return self.element_finder.find_child_element(
-            parent, element_key, log_failure=log_failure
-        )
-
-    def find_child_elements(self, parent, element_key: str):
-        return self.element_finder.find_child_elements(parent, element_key)
-
-    def wait_for_any_element(self, element_keys: list, timeout: int = 10):
-        return self.element_finder.wait_for_any_element(element_keys, timeout=timeout)
-
-    def try_find_any_element(self, element_keys: list):
-        return self.element_finder.try_find_any_element(element_keys)
-
-    def switch_to_app(self):
-        return self.key_actions.switch_to_app()
-
-    def close_app(self):
-        return self.key_actions.close_app()
-
-    def switch_to_activity(self, activity):
-        return self.key_actions.switch_to_activity(activity)
-
-    def press_enter(self, element):
-        return self.key_actions.press_enter(element)
-
-    def press_back(self):
-        return self.key_actions.press_back()
-
-    def press_dpad_down(self):
-        return self.key_actions.press_dpad_down()
-
-    def press_volume_up(self):
-        return self.key_actions.press_volume_up()
-
-    def press_volume_down(self):
-        return self.key_actions.press_volume_down()
-
-    def press_right_key(self, times=1):
-        return self.key_actions.press_right_key(times=times)
-
-    def set_clipboard_text(self, text):
-        return self.key_actions.set_clipboard_text(text)
-
-    def paste_text(self):
-        return self.key_actions.paste_text()
-
-    def click_element_at(
-            self, element, x_ratio=0.5, y_ratio=0.5, x_offset=0, y_offset=0
-    ):
-        return self.gesture_handler.click_element_at(
-            element,
-            x_ratio=x_ratio,
-            y_ratio=y_ratio,
-            x_offset=x_offset,
-            y_offset=y_offset,
-        )
-
-    def _reversed_if_needed(self, lst: list, direction: str):
-        return self.gesture_handler._reversed_if_needed(lst, direction)
-
-    def _perform_swipe(
-            self, start_x: int, start_y: int, end_x: int, end_y: int, duration_ms: int = 300
-    ):
-        return self.gesture_handler._perform_swipe(
-            start_x,
-            start_y,
-            end_x,
-            end_y,
-            duration_ms=duration_ms,
-        )
-
-    def scroll_container_until_element(
-            self, element_key: str, container_key: str, direction: str = "up", attribute_name: str = None,
-            attribute_value: str = None, max_swipes: int = 10
-    ):
-        return self.gesture_handler.scroll_container_until_element(
-            element_key,
-            container_key,
-            direction=direction,
-            attribute_name=attribute_name,
-            attribute_value=attribute_value,
-            max_swipes=max_swipes,
-        )
-
-    def navigate_to_element(
-            self,
-            target_key: str,
-            interference_keys: list = None,
-            home_key: str = "home_nav",
-            back_keys=None,
-            max_attempts: int = 10,
-    ):
-        return self.navigator.navigate_to_element(
-            target_key,
-            interference_keys=interference_keys,
-            home_key=home_key,
-            back_keys=back_keys,
-            max_attempts=max_attempts,
-        )

--- a/src/ushareiplay/core/element_wrapper.py
+++ b/src/ushareiplay/core/element_wrapper.py
@@ -79,7 +79,7 @@ class ElementWrapper:
             return None
 
         # 通过 handler 获取真实的 WebElement
-        self._web_element = self._handler.try_find_element(self._element_key, log=False)
+        self._web_element = self._handler.element_finder.try_find_element(self._element_key, log=False)
         return self._web_element
 
     def click(self) -> bool:

--- a/src/ushareiplay/core/ui/__init__.py
+++ b/src/ushareiplay/core/ui/__init__.py
@@ -2,10 +2,12 @@ from ushareiplay.core.ui.element_finder import ElementFinder
 from ushareiplay.core.ui.gesture_handler import GestureHandler
 from ushareiplay.core.ui.key_actions import KeyActions
 from ushareiplay.core.ui.navigation import Navigator
+from ushareiplay.core.ui.ui_actions import UIActions
 
 __all__ = [
     "ElementFinder",
     "GestureHandler",
     "KeyActions",
     "Navigator",
+    "UIActions",
 ]

--- a/src/ushareiplay/core/ui/gesture_handler.py
+++ b/src/ushareiplay/core/ui/gesture_handler.py
@@ -192,9 +192,9 @@ class GestureHandler:
         attribute_values_list = []
         try:
             # 获取容器（横滑区等父节点可能不可点击，回退为仅存在即可）
-            container = self.wait_for_element_clickable(container_key)
+            container = self.owner.element_finder.wait_for_element_clickable(container_key)
             if not container:
-                container = self.wait_for_element(container_key)
+                container = self.owner.element_finder.wait_for_element(container_key)
             if not container:
                 self.logger.warning(
                     f"scroll_container_until_element: 容器未找到: {container_key}"
@@ -262,18 +262,18 @@ class GestureHandler:
             # 查找目标元素的辅助函数
             def find_target_element() -> Tuple[Optional[str], Optional[WebElement]]:
                 """在容器内查找目标元素，支持属性匹配（支持 | 分隔的多个属性）"""
-                found = self.find_child_element(
+                found = self.owner.element_finder.find_child_element(
                     container, element_key, log_failure=False
                 )
                 if found:
                     if attribute_name and attribute_value:
-                        elements = self.find_child_elements(container, element_key)
+                        elements = self.owner.element_finder.find_child_elements(container, element_key)
                         for element in elements:
                             # 收集所有找到的元素的 attribute 值（不管是否匹配）
                             attr_list = attribute_name.split('|')
                             collected_value = None
                             for attr in attr_list:
-                                value = self.try_get_attribute(element, attr)
+                                value = self.owner.element_finder.try_get_attribute(element, attr)
                                 if value is not None and value != 'null':
                                     collected_value = value
                                     break
@@ -283,7 +283,7 @@ class GestureHandler:
                             # 检查是否匹配目标值
                             any_match = False
                             for attr in attr_list:
-                                value = self.try_get_attribute(element, attr)
+                                value = self.owner.element_finder.try_get_attribute(element, attr)
                                 if value == attribute_value:
                                     any_match = True
                                     break
@@ -291,22 +291,24 @@ class GestureHandler:
                                 return element_key, element
                     else:
                         # 如果没有指定属性匹配，也收集所有找到的元素
-                        elements = self.find_child_elements(container, element_key)
+                        elements = self.owner.element_finder.find_child_elements(container, element_key)
                         for element in elements:
                             if attribute_name:
                                 attr_list = attribute_name.split('|')
                                 for attr in attr_list:
-                                    value = self.try_get_attribute(element, attr)
+                                    value = self.owner.element_finder.try_get_attribute(element, attr)
                                     if value is not None and value != 'null':
                                         attribute_values_list.append(value)
                                         break
                             else:
                                 # 如果没有指定属性名，优先使用 content-desc，如果没有则使用 text
-                                content_desc = self.try_get_attribute(element, "content-desc")
+                                content_desc = self.owner.element_finder.try_get_attribute(
+                                    element, "content-desc"
+                                )
                                 if content_desc is not None and content_desc != 'null':
                                     attribute_values_list.append(content_desc)
                                 else:
-                                    text = self.try_get_attribute(element, "text")
+                                    text = self.owner.element_finder.try_get_attribute(element, "text")
                                     if text is not None and text != 'null':
                                         attribute_values_list.append(text)
                         return element_key, found

--- a/src/ushareiplay/core/ui/gesture_handler.py
+++ b/src/ushareiplay/core/ui/gesture_handler.py
@@ -158,6 +158,12 @@ class GestureHandler:
             self.logger.error(f"Error performing swipe: {traceback.format_exc()}")
             return False
 
+    def swipe(
+            self, start_x: int, start_y: int, end_x: int, end_y: int, duration_ms: int = 300
+    ) -> bool:
+        """Perform one swipe using the gesture abstraction."""
+        return self._perform_swipe(start_x, start_y, end_x, end_y, duration_ms=duration_ms)
+
     @with_driver_recovery(op="read")
     def scroll_container_until_element(
             self, element_key: str, container_key: str, direction: str = "up", attribute_name: str = None,

--- a/src/ushareiplay/core/ui/navigation.py
+++ b/src/ushareiplay/core/ui/navigation.py
@@ -52,7 +52,7 @@ class Navigator:
             interference_keys = []
 
         self.logger.info(f"开始导航到目标元素: {target_key}")
-        self.press_back()
+        self.owner.key_actions.press_back()
 
         for attempt in range(max_attempts):
             self.logger.debug(f"导航尝试 {attempt + 1}/{max_attempts}")
@@ -61,23 +61,25 @@ class Navigator:
             check_keys = interference_keys + [target_key] + back_keys + [home_key]
 
             # 使用 wait_for_any_element 检测当前状态
-            found_key, found_element = self.wait_for_any_element(check_keys)
+            found_key, found_element = self.owner.element_finder.wait_for_any_element(check_keys)
 
             if not found_element:
                 self.logger.warning(f"第 {attempt + 1} 次尝试：未检测到任何元素")
                 # 按系统返回键尝试返回
-                self.press_back()
+                self.owner.key_actions.press_back()
                 return None, None
 
             # 根据找到的元素类型执行相应操作
             if found_key == target_key:
                 # 命中目标后仅做干扰元素复核（无等待），避免误判后直接返回
-                interference_key, interference_element = self.try_find_any_element(interference_keys)
+                interference_key, interference_element = self.owner.element_finder.try_find_any_element(
+                    interference_keys
+                )
                 if interference_element:
                     self.logger.info(
                         f"命中目标 {target_key} 后发现干扰元素 {interference_key}，先按返回键关闭后重试确认"
                     )
-                    if not self.press_back():
+                    if not self.owner.key_actions.press_back():
                         self.logger.error("按系统返回键失败")
                         return None, None
                     continue
@@ -86,16 +88,16 @@ class Navigator:
                 return found_key, found_element
 
             elif found_key in back_keys:
-                if self.click_element_at(found_element):
+                if self.owner.gesture_handler.click_element_at(found_element):
                     self.logger.info(f"找到返回按钮: {found_key}，点击返回")
                 else:
                     self.logger.warning(f"点击返回按钮失败: {found_key}")
                     # 尝试系统返回键作为备选
-                    self.press_back()
+                    self.owner.key_actions.press_back()
 
             elif found_key in interference_keys:
                 self.logger.info(f"发现干扰元素: {found_key}，按系统返回键隐藏")
-                if not self.press_back():
+                if not self.owner.key_actions.press_back():
                     self.logger.error("按系统返回键失败")
                     return None, None
 
@@ -105,7 +107,7 @@ class Navigator:
 
             else:
                 self.logger.warning(f"检测到未知元素: {found_key}")
-                self.press_back()
+                self.owner.key_actions.press_back()
                 return None, None
 
         # 达到最大尝试次数

--- a/src/ushareiplay/core/ui/ui_actions.py
+++ b/src/ushareiplay/core/ui/ui_actions.py
@@ -1,0 +1,49 @@
+class UIActions:
+    """Reusable UI action sequences for a single app handler."""
+
+    def __init__(self, owner):
+        self.owner = owner
+
+    @property
+    def logger(self):
+        return self.owner.logger
+
+    def switch_and_click(
+            self, element_key: str, *, error_message: str, timeout: int = 10,
+            click_kwargs: dict | None = None
+    ) -> dict:
+        """Switch to this handler's app, wait for an element, then click it."""
+        if not self.owner.key_actions.switch_to_app():
+            self.logger.error("Failed to switch to app before clicking %s", element_key)
+            return {"error": "Failed to switch to app"}
+
+        element = self.owner.element_finder.wait_for_element_clickable(element_key, timeout=timeout)
+        if not element:
+            self.logger.error("Failed to find clickable element: %s", element_key)
+            return {"error": error_message}
+
+        if not self.owner.gesture_handler.click_element_at(element, **(click_kwargs or {})):
+            self.logger.error("Failed to click element: %s", element_key)
+            return {"error": error_message}
+
+        return {"success": True}
+
+    def toggle_mic(self, enable: bool) -> dict:
+        """Toggle the microphone while retaining MicManager's result contract."""
+        try:
+            if not self.owner.key_actions.switch_to_app():
+                return {"error": "Failed to switch to app"}
+
+            mic_button = self.owner.element_finder.try_find_element("toggle_mic")
+            if not mic_button:
+                return {"error": "Microphone button not found"}
+
+            if not self.owner.gesture_handler.click_element_at(mic_button):
+                return {"error": "Failed to click microphone button"}
+
+            state = "开启" if enable else "关闭"
+            self.logger.info("Clicked microphone button to %s", state)
+            return {"state": state}
+        except Exception as error:
+            self.logger.error("Error toggling microphone: %s", error)
+            return {"error": str(error)}

--- a/src/ushareiplay/events/accidental_touch_locker.py
+++ b/src/ushareiplay/events/accidental_touch_locker.py
@@ -21,7 +21,7 @@ class AccidentalTouchLockerEvent(BaseEvent):
         max_attempts = 2
         for attempt in range(1, max_attempts + 1):
             try:
-                element = self.handler.wait_for_element(
+                element = self.handler.element_finder.wait_for_element(
                     "accidental_touch_locker", timeout=3
                 )
                 if not element:
@@ -58,7 +58,7 @@ class AccidentalTouchLockerEvent(BaseEvent):
                     screen_h,
                 )
 
-                ok = self.handler._perform_swipe(
+                ok = self.handler.gesture_handler.swipe(
                     start_x, start_y, start_x, end_y, duration_ms=400
                 )
                 if not ok:

--- a/src/ushareiplay/events/follower_message.py
+++ b/src/ushareiplay/events/follower_message.py
@@ -102,7 +102,7 @@ class FollowerMessageEvent(BaseEvent):
                 return True # 已处理，拦截后续（因为文本已记录且用户已创建）
 
             # 等待并点击打招呼按钮
-            greet_follower = self.handler.try_find_element('greet_follower')
+            greet_follower = self.handler.element_finder.try_find_element('greet_follower')
             if not greet_follower:
                 self.logger.warning("Failed to find greet button")
                 return False
@@ -111,10 +111,10 @@ class FollowerMessageEvent(BaseEvent):
             self.logger.info("Clicked greet button")
 
             # 等待并点击发送按钮
-            send_button = self.handler.wait_for_element_clickable('button_send', timeout=3)
+            send_button = self.handler.element_finder.wait_for_element_clickable('button_send', timeout=3)
             if not send_button:
                 self.logger.warning("Failed to find send button, pressing back")
-                self.handler.press_back()
+                self.handler.key_actions.press_back()
                 return False
 
             send_button.click()
@@ -127,7 +127,7 @@ class FollowerMessageEvent(BaseEvent):
             self.logger.error(f"Error processing follower message event: {str(e)}")
             # 出错时尝试按返回键退出
             try:
-                self.handler.press_back()
+                self.handler.key_actions.press_back()
             except Exception:
                 pass
             return False

--- a/src/ushareiplay/events/party_name_violation_later.py
+++ b/src/ushareiplay/events/party_name_violation_later.py
@@ -11,7 +11,7 @@ from ushareiplay.core.base_event import BaseEvent
 class PartyNameViolationLaterEvent(BaseEvent):
     async def handle(self, key: str, element_wrapper):
         try:
-            element = self.handler.wait_for_element_clickable("party_name_violation_later")
+            element = self.handler.element_finder.wait_for_element_clickable("party_name_violation_later")
             if not element:
                 self.logger.warning("party_name_violation_later present in page_source but not clickable")
                 return False

--- a/src/ushareiplay/events/risk_elements.py
+++ b/src/ushareiplay/events/risk_elements.py
@@ -57,7 +57,7 @@ class RiskElementsEvent(BaseEvent):
         """
         try:
             # 使用 wait_for 获取可点击的元素（因为 page_source 中已确认存在）
-            element = self.handler.wait_for_element_clickable(key)
+            element = self.handler.element_finder.wait_for_element_clickable(key)
             if not element:
                 self.logger.warning(f"Risk element {key} found in page_source but not clickable")
                 return False

--- a/src/ushareiplay/handlers/qq_music_handler.py
+++ b/src/ushareiplay/handlers/qq_music_handler.py
@@ -95,14 +95,14 @@ class QQMusicHandler(AppHandler, Singleton):
             if not ok:
                 return {'error': 'Cannot navigate to QQ Music home page'}
 
-            my_nav = self.wait_for_element_clickable('my_nav', timeout=timeout)
+            my_nav = self.element_finder.wait_for_element_clickable('my_nav', timeout=timeout)
             if not my_nav:
                 return {'error': 'Cannot find my_nav'}
 
             my_nav.click()
             self.logger.info("open_favorites_entry: Clicked my_nav")
 
-            fav_entry = self.wait_for_element_clickable('fav_entry', timeout=timeout)
+            fav_entry = self.element_finder.wait_for_element_clickable('fav_entry', timeout=timeout)
             if fav_entry:
                 fav_entry.click()
                 self.logger.info("open_favorites_entry: Clicked fav_entry")
@@ -112,12 +112,12 @@ class QQMusicHandler(AppHandler, Singleton):
             self.logger.warning(
                 "open_favorites_entry: fav_entry not found, retrying by clicking my_nav again to reset page"
             )
-            my_nav_retry = self.wait_for_element_clickable('my_nav', timeout=timeout)
+            my_nav_retry = self.element_finder.wait_for_element_clickable('my_nav', timeout=timeout)
             if my_nav_retry:
                 my_nav_retry.click()
                 time.sleep(0.3)
 
-            fav_entry = self.wait_for_element_clickable('fav_entry', timeout=timeout)
+            fav_entry = self.element_finder.wait_for_element_clickable('fav_entry', timeout=timeout)
             if fav_entry:
                 fav_entry.click()
                 self.logger.info("open_favorites_entry: Clicked fav_entry after my_nav reset")
@@ -131,13 +131,13 @@ class QQMusicHandler(AppHandler, Singleton):
             if not ok:
                 return {'error': 'Cannot navigate to QQ Music home page (retry)'}
 
-            my_nav = self.wait_for_element_clickable('my_nav', timeout=timeout)
+            my_nav = self.element_finder.wait_for_element_clickable('my_nav', timeout=timeout)
             if not my_nav:
                 return {'error': 'Cannot find my_nav (retry)'}
             my_nav.click()
             time.sleep(0.2)
 
-            fav_entry = self.wait_for_element_clickable('fav_entry', timeout=timeout)
+            fav_entry = self.element_finder.wait_for_element_clickable('fav_entry', timeout=timeout)
             if not fav_entry:
                 return {'error': 'Cannot find fav_entry after my_nav reset'}
             fav_entry.click()
@@ -156,19 +156,19 @@ class QQMusicHandler(AppHandler, Singleton):
             bool: True 表示已收藏或收藏成功；False 表示未能确认/未能完成收藏（不应阻断主流程）
         """
         try:
-            btn = self.wait_for_element('playing_favourite', timeout=timeout)
+            btn = self.element_finder.wait_for_element('playing_favourite', timeout=timeout)
             if not btn:
                 self.logger.warning(
                     f"ensure_favorited_in_playing_page: 收藏按钮未出现(>{timeout}s)"
                 )
                 return False
 
-            desc = self.try_get_attribute(btn, 'content-desc') or ''
+            desc = self.element_finder.try_get_attribute(btn, 'content-desc') or ''
             if '取消收藏' in desc:
                 self.logger.info("ensure_favorited_in_playing_page: 已收藏，跳过")
                 return True
 
-            clickable = self.wait_for_element_clickable(
+            clickable = self.element_finder.wait_for_element_clickable(
                 'playing_favourite', timeout=timeout
             )
             if clickable:
@@ -186,7 +186,7 @@ class QQMusicHandler(AppHandler, Singleton):
             return False
 
     def hide_player(self):
-        self.press_back()
+        self.key_actions.press_back()
         self.logger.info("Hide player panel")
         time.sleep(1)
 
@@ -194,15 +194,15 @@ class QQMusicHandler(AppHandler, Singleton):
         """Navigate back to home page"""
         # Keep clicking back until no more back buttons found
         n = 0
-        self.press_back()
+        self.key_actions.press_back()
         back_keys = ['go_back', 'minimize_screen']
         while n < 9:
-            key, element = self.wait_for_any_element(back_keys + ['home_nav'])
+            key, element = self.element_finder.wait_for_any_element(back_keys + ['home_nav'])
             if key in back_keys:
                 element.click()
             elif key == 'home_nav':
                 # 二次确认：命中 home_nav 后，先无等待检查是否仍有可点击返回键
-                back_key, back_element = self.try_find_any_element(back_keys)
+                back_key, back_element = self.element_finder.try_find_any_element(back_keys)
                 if back_element:
                     self.logger.info(
                         f"命中 home_nav 后仍检测到返回键 {back_key}，先点击返回再确认首页"
@@ -213,7 +213,7 @@ class QQMusicHandler(AppHandler, Singleton):
                 self.logger.info("Back to home page")
                 return True
             else:
-                self.press_back()
+                self.key_actions.press_back()
                 self.logger.warning("Unknown page")
                 return False
             n += 1
@@ -223,7 +223,7 @@ class QQMusicHandler(AppHandler, Singleton):
         """Get current playing song and singer info"""
         song_element = None
         singer_element = None
-        elements = self.find_elements('first_song')
+        elements = self.element_finder.find_elements('first_song')
         if elements:
             song_element = elements[0]
             if len(elements) > 1:
@@ -253,8 +253,8 @@ class QQMusicHandler(AppHandler, Singleton):
 
     def get_current_playing(self):
         """Get current playing song and singer info"""
-        song_element = self.try_find_element('current_song')
-        singer_element = self.try_find_element('current_singer')
+        song_element = self.element_finder.try_find_element('current_song')
+        singer_element = self.element_finder.try_find_element('current_singer')
         if not song_element or not singer_element:
             return None
         return {
@@ -264,28 +264,28 @@ class QQMusicHandler(AppHandler, Singleton):
 
     def query_music(self, music_query: str):
         """Common logic for preparing music playback"""
-        if not self.switch_to_app():
+        if not self.key_actions.switch_to_app():
             self.logger.info(f"Failed to switched to QQ Music app")
             return None
         self.logger.info(f"Switched to QQ Music app")
 
-        key, element = self.navigate_to_element(
+        key, element = self.navigator.navigate_to_element(
             'search_box',
             ['play_all', 'play_all_playlist', 'play_all_compact', 'fav_entry'],
         )
         if key == 'home_nav':
-            search_entry = self.wait_for_element('search_entry')
+            search_entry = self.element_finder.wait_for_element('search_entry')
             if not search_entry:
                 self.logger.info(f"Search entry not found")
                 return None
             search_entry.click()
         elif key == 'search_box':
-            clear_search = self.try_find_element('clear_search')
+            clear_search = self.element_finder.try_find_element('clear_search')
             if clear_search:
                 clear_search.click()
                 self.logger.info(f"Clear search")
 
-        search_box = self.wait_for_element_clickable('search_box')
+        search_box = self.element_finder.wait_for_element_clickable('search_box')
         if search_box:
             search_box.click()
             self.logger.info(f"Clicked search box")
@@ -294,8 +294,8 @@ class QQMusicHandler(AppHandler, Singleton):
             return None
 
         # Use clipboard operations from parent class
-        self.set_clipboard_text(music_query)
-        self.paste_text()
+        self.key_actions.set_clipboard_text(music_query)
+        self.key_actions.paste_text()
         return key
 
     def _prepare_music_playback(self, music_query):
@@ -309,14 +309,14 @@ class QQMusicHandler(AppHandler, Singleton):
 
         need_select_tab = True
         if from_key == 'home_nav':
-            if list_title := self.wait_for_element('list_title'):
+            if list_title := self.element_finder.wait_for_element('list_title'):
                 if list_title.text == '单曲':
                     need_select_tab = False
 
         if need_select_tab:
             self.select_song_tab()
 
-        key, element = self.wait_for_any_element(['first_song', 'not_found'])
+        key, element = self.element_finder.wait_for_any_element(['first_song', 'not_found'])
         if not key or key == 'not_found':
             self.logger.error(f"Failed to find music query: {music_query}")
             return {
@@ -328,20 +328,20 @@ class QQMusicHandler(AppHandler, Singleton):
             self.logger.error(f"Failed to find first song")
             return None
 
-        studio_version = self.try_find_element('studio_version')
+        studio_version = self.element_finder.try_find_element('studio_version')
         if not studio_version:
-            song_version = self.try_find_element('song_version')
+            song_version = self.element_finder.try_find_element('song_version')
             if song_version:
                 song_version.click()
                 self.logger.info(f"Clicked song version")
 
-                studio_version = self.wait_for_element_clickable('studio_version')
+                studio_version = self.element_finder.wait_for_element_clickable('studio_version')
 
         if studio_version:
             studio_version.click()
             self.logger.info("Alter to studio version")
 
-            first_song = self.wait_for_element('first_song')
+            first_song = self.element_finder.wait_for_element('first_song')
             if not first_song:
                 self.logger.error(f"Failed to find first song")
                 return None
@@ -372,10 +372,10 @@ class QQMusicHandler(AppHandler, Singleton):
         """Select the 'Songs' tab in search results"""
         try:
             # Try to find song tab first
-            song_tab = self.try_find_element('song_tab')
+            song_tab = self.element_finder.try_find_element('song_tab')
             if not song_tab:
                 # If not found, scroll music_tabs to left
-                music_tabs = self.try_find_element('music_tabs')
+                music_tabs = self.element_finder.try_find_element('music_tabs')
                 if not music_tabs:
                     self.logger.error("Failed to find music tabs")
                     return False
@@ -385,7 +385,7 @@ class QQMusicHandler(AppHandler, Singleton):
                 location = music_tabs.location
 
                 # Scroll to left
-                self.driver.swipe(
+                self.gesture_handler.swipe(
                     location['x'] + 200,  # Start from left
                     location['y'] + size['height'] // 2,
                     location['x'] + size['width'] - 10,  # End at right
@@ -394,7 +394,7 @@ class QQMusicHandler(AppHandler, Singleton):
                 )
 
                 # Try to find song tab again
-                song_tab = self.try_find_element('song_tab')
+                song_tab = self.element_finder.try_find_element('song_tab')
                 if not song_tab:
                     self.logger.error("Failed to find song tab after scrolling")
                     return False
@@ -416,7 +416,7 @@ class QQMusicHandler(AppHandler, Singleton):
                 return playing_info
 
             # Click next button
-            next_button = self.wait_for_element_clickable('next_button')
+            next_button = self.element_finder.wait_for_element_clickable('next_button')
             next_button.click()
             self.logger.info(f"Clicked next button")
 
@@ -612,22 +612,22 @@ class QQMusicHandler(AppHandler, Singleton):
         Returns:
             str: Formatted playlist info or error dict
         """
-        if not self.switch_to_app():
+        if not self.key_actions.switch_to_app():
             self.logger.error("Cannot switch to QQ music")
             return {'error': 'Failed to switch to QQ Music app'}
 
         # Try to find playlist entry in playing panel first
-        playlist_entry = self.try_find_element('playlist_entry')
+        playlist_entry = self.element_finder.try_find_element('playlist_entry')
         if not playlist_entry:
-            self.press_back()
+            self.key_actions.press_back()
 
-        playlist_entry = self.wait_for_element_clickable('playlist_entry')
+        playlist_entry = self.element_finder.wait_for_element_clickable('playlist_entry')
         if not playlist_entry:
             return {'error': 'Failed to find play list entry'}
         playlist_entry.click()
 
         detected = None
-        detected_key, _ = self.try_find_any_element(
+        detected_key, _ = self.element_finder.try_find_any_element(
             [
                 'play_mode_list_in_playlist',
                 'play_mode_single_in_playlist',
@@ -649,10 +649,10 @@ class QQMusicHandler(AppHandler, Singleton):
                 )
             self._update_play_mode_key(detected, reason='playlist_ui_self_heal')
 
-        items = self.find_elements('playlist_item_container')
+        items = self.element_finder.find_elements('playlist_item_container')
         playlist_info, song_titles = self._read_playlist_items(items)
 
-        playlist_current = self.try_find_element('playlist_current')
+        playlist_current = self.element_finder.try_find_element('playlist_current')
         if playlist_current:
             try:
                 playing_loc = playlist_current.location
@@ -663,8 +663,8 @@ class QQMusicHandler(AppHandler, Singleton):
                     start_y = playing_loc['y'] + playing_size['height'] // 2
                     end_y = playlist_first.location['y']
                     if start_y - end_y > playlist_first.size['height']:
-                        self.driver.swipe(start_x, start_y, start_x, end_y, 1000)
-                        items = self.find_elements('playlist_item_container')
+                        self.gesture_handler.swipe(start_x, start_y, start_x, end_y, 1000)
+                        items = self.element_finder.find_elements('playlist_item_container')
                         playlist_info, _ = self._read_playlist_items(items)
                         self.logger.info(f"Scrolled playlist from y={start_y} to y={end_y}")
 

--- a/src/ushareiplay/handlers/soul_handler.py
+++ b/src/ushareiplay/handlers/soul_handler.py
@@ -32,14 +32,14 @@ class SoulHandler(AppHandler, Singleton):
         are applied consistently.
         """
 
-        self.switch_to_app()
+        self.key_actions.switch_to_app()
 
         # Click on the input box entry first
-        input_box_entry = self.wait_for_element_clickable('input_box_entry')
+        input_box_entry = self.element_finder.wait_for_element_clickable('input_box_entry')
         if not input_box_entry:
             self.logger.error(f'cannot find input box entry, might be in loading')
             return {'error': 'cannot find input box entry, might be in loading'}
-        go_back = self.try_find_element('go_back_1', log=False)
+        go_back = self.element_finder.try_find_element('go_back_1', log=False)
         if go_back:
             go_back.click()
             self.logger.error("Clicked go back button, might be in chat screen")
@@ -48,7 +48,7 @@ class SoulHandler(AppHandler, Singleton):
         # self.logger.info("Clicked input box entry")
 
         # Now find and interact with the actual input box
-        input_box = self.wait_for_element_clickable('input_box')
+        input_box = self.element_finder.wait_for_element_clickable('input_box')
         if not input_box:
             self.logger.error(f'cannot find input box, might be in chat screen')
             return {
@@ -60,7 +60,7 @@ class SoulHandler(AppHandler, Singleton):
             self.logger.info(f"Entered message: {message}")
 
             # click send button
-            send_button = self.wait_for_element_clickable('button_send')
+            send_button = self.element_finder.wait_for_element_clickable('button_send')
             if not send_button:
                 self.logger.error(f'cannot find send button')
                 return {
@@ -70,18 +70,18 @@ class SoulHandler(AppHandler, Singleton):
             send_button.click()
             # self.logger.info("Clicked send button")
 
-        self.click_element_at(input_box, 0.5, -1)
+        self.gesture_handler.click_element_at(input_box, 0.5, -1)
         # self.logger.info("Hide input dialog")
 
     def grab_mic_and_confirm(self):
         """Wait for the grab mic button and confirm the action"""
         try:
             # Wait for the grab mic button to be clickable
-            grab_mic_button = self.wait_for_element_clickable('grab_mic')
+            grab_mic_button = self.element_finder.wait_for_element_clickable('grab_mic')
             grab_mic_button.click()
 
             # Wait for the confirmation dialog to appear
-            confirm_button = self.wait_for_element_clickable('confirm_mic')
+            confirm_button = self.element_finder.wait_for_element_clickable('confirm_mic')
             confirm_button.click()
 
         except Exception as e:
@@ -90,9 +90,9 @@ class SoulHandler(AppHandler, Singleton):
     def ensure_mic_active(self):
         """Ensure the microphone is active"""
         try:
-            self.switch_to_app()
+            self.key_actions.switch_to_app()
             # Check if the grab mic button is present
-            grab_mic_button = self.try_find_element('grab_mic', log=False)
+            grab_mic_button = self.element_finder.try_find_element('grab_mic', log=False)
 
             if grab_mic_button:
                 self.logger.info("Grab mic button found, grabbing mic...")
@@ -100,13 +100,13 @@ class SoulHandler(AppHandler, Singleton):
             else:
                 self.logger.info("Already on mic, checking toggle mic status...")
                 # Check the toggle mic button
-                toggle_mic_button = self.wait_for_element_clickable('toggle_mic')
+                toggle_mic_button = self.element_finder.wait_for_element_clickable('toggle_mic')
 
                 if not toggle_mic_button:
                     self.logger.error("Toggle mic button not found")
                     return
 
-                desc = self.try_get_attribute(toggle_mic_button, 'content-desc')
+                desc = self.element_finder.try_get_attribute(toggle_mic_button, 'content-desc')
                 if desc == "开麦按钮":  # If we see "开麦按钮", mic is currently off
                     self.logger.info("Mic is off, turning it on...")
                     toggle_mic_button.click()

--- a/src/ushareiplay/managers/admin_manager.py
+++ b/src/ushareiplay/managers/admin_manager.py
@@ -39,7 +39,7 @@ class AdminManager(Singleton):
         if 'error' in open_result:
             return open_result
 
-        manager_invite = self.handler.wait_for_element_clickable('manager_invite')
+        manager_invite = self.handler.element_finder.wait_for_element_clickable('manager_invite')
         if not manager_invite:
             return {'error': 'Failed to find manager invite button', 'user': target_nickname}
 
@@ -48,12 +48,12 @@ class AdminManager(Singleton):
         current_text = manager_invite.text
         if enable:
             if current_text == "解除管理":
-                self.handler.press_back()
+                self.handler.key_actions.press_back()
                 recovery_manager.close_drawer('online_drawer')
                 return {'error': '你已经是管理员了', 'user': target_nickname}
         else:
             if current_text == "管理邀请":
-                self.handler.press_back()
+                self.handler.key_actions.press_back()
                 recovery_manager.close_drawer('online_drawer')
                 return {'error': '你还不是管理员', 'user': target_nickname}
 
@@ -61,10 +61,10 @@ class AdminManager(Singleton):
         self.logger.info("Clicked manager invite button")
 
         if enable:
-            confirm_button = self.handler.wait_for_element_clickable('confirm_invite')
+            confirm_button = self.handler.element_finder.wait_for_element_clickable('confirm_invite')
             action = "Invited"
         else:
-            confirm_button = self.handler.wait_for_element_clickable('confirm_dismiss')
+            confirm_button = self.handler.element_finder.wait_for_element_clickable('confirm_dismiss')
             action = "Dismissed"
 
         if not confirm_button:

--- a/src/ushareiplay/managers/event_manager.py
+++ b/src/ushareiplay/managers/event_manager.py
@@ -431,7 +431,7 @@ class EventManager(Singleton):
                         "No events triggered, but UI is busy (ui_lock locked). Skip auto press_back.")
                 else:
                     recovery["attempted"] = True
-                    self.handler.switch_to_app()
+                    self.handler.key_actions.switch_to_app()
                     ready_source = await self._wait_page_source_ready_async(max_wait_s=2.5, interval_s=0.2)
                     if not ready_source:
                         recovery["suppressed"] = "page_source_not_ready"
@@ -442,7 +442,7 @@ class EventManager(Singleton):
                         recovery["ready_rechecked"] = True
                         second_triggered = await self._process_events_once(ready_source)
                         if second_triggered == 0:
-                            self.handler.press_back()
+                            self.handler.key_actions.press_back()
                             recovery["pressed_back"] = True
                             self.logger.warning("No events triggered, pressed back to exit unknown page")
                             self._consecutive_unknown_pages += 1
@@ -559,7 +559,7 @@ class EventManager(Singleton):
             try:
                 src = self.handler.driver.page_source
                 if not src:
-                    self.handler.switch_to_app()
+                    self.handler.key_actions.switch_to_app()
                     await asyncio.sleep(interval_s)
                     continue
 
@@ -577,7 +577,7 @@ class EventManager(Singleton):
                     self.logger.debug(
                         "PageSource foreground is not Soul (launcher detected); switching to Soul app"
                     )
-                self.handler.switch_to_app()
+                self.handler.key_actions.switch_to_app()
                 await asyncio.sleep(interval_s)
             except etree.XMLSyntaxError as e:
                 last_error = e

--- a/src/ushareiplay/managers/message_manager.py
+++ b/src/ushareiplay/managers/message_manager.py
@@ -96,7 +96,7 @@ class MessageManager(Singleton):
 
     async def process_missed_messages(self):
 
-        if not self.handler.switch_to_app():
+        if not self.handler.key_actions.switch_to_app():
             self.handler.logger.error("Failed to switch to Soul app")
             return None
 
@@ -115,7 +115,7 @@ class MessageManager(Singleton):
         # scroll back to the missing element
         self.handler.logger.critical(f"last_chat={last_chat}")
 
-        key, element, attribute_values = self.handler.scroll_container_until_element(
+        key, element, attribute_values = self.handler.gesture_handler.scroll_container_until_element(
             'message_content',
             'message_list',
             'down',
@@ -183,7 +183,7 @@ class MessageManager(Singleton):
         return command_set
 
     async def process_new_messages(self):
-        if not self.handler.switch_to_app():
+        if not self.handler.key_actions.switch_to_app():
             self.handler.logger.error("Failed to switch to Soul app")
             return None
 

--- a/src/ushareiplay/managers/mic_manager.py
+++ b/src/ushareiplay/managers/mic_manager.py
@@ -1,4 +1,3 @@
-import traceback
 from ushareiplay.core.singleton import Singleton
 
 
@@ -22,30 +21,10 @@ class MicManager(Singleton):
         Returns:
             dict: 操作结果
         """
-        try:
-            if not self.soul_handler.switch_to_app():
-                return {'error': 'Failed to switch to Soul app'}
-            
-            action = "开启" if enable else "关闭"
-            self.logger.info(f"Attempting to {action} microphone")
-            
-            # 查找麦克风切换按钮
-            mic_button = self.soul_handler.try_find_element('toggle_mic')
-            if not mic_button:
-                return {'error': 'Microphone button not found'}
-            
-            # 检查当前状态（通过按钮的可点击性或其他属性判断）
-            # 这里假设按钮总是可点击的，实际状态通过其他方式判断
-            
-            mic_button.click()
-            self.logger.info(f"Clicked microphone button to {action}")
-            
-            state = "开启" if enable else "关闭"
-            return {'state': state}
-            
-        except Exception as e:
-            self.logger.error(f"Error toggling microphone: {traceback.format_exc()}")
-            return {'error': str(e)}
+        result = self.soul_handler.ui_actions.toggle_mic(enable)
+        if result == {'error': 'Failed to switch to app'}:
+            return {'error': 'Failed to switch to Soul app'}
+        return result
     
     def get_mic_status(self) -> dict:
         """
@@ -54,11 +33,11 @@ class MicManager(Singleton):
             dict: 麦克风状态信息
         """
         try:
-            if not self.soul_handler.switch_to_app():
+            if not self.soul_handler.key_actions.switch_to_app():
                 return {'error': 'Failed to switch to Soul app'}
             
             # 查找麦克风按钮
-            mic_button = self.soul_handler.try_find_element('toggle_mic')
+            mic_button = self.soul_handler.element_finder.try_find_element('toggle_mic')
             if not mic_button:
                 return {'error': 'Microphone button not found'}
             

--- a/src/ushareiplay/managers/music_manager.py
+++ b/src/ushareiplay/managers/music_manager.py
@@ -34,7 +34,7 @@ class MusicManager(Singleton):
         try:
             self.logger.info(f"Attempting to play song: {song_query}")
             
-            if not self.music_handler.switch_to_app():
+            if not self.music_handler.key_actions.switch_to_app():
                 return {'error': 'Failed to switch to music app'}
             
             # 搜索歌曲
@@ -247,14 +247,14 @@ class MusicManager(Singleton):
             times = abs(delta)
             self.logger.info(f"Decreasing volume by {times} steps")
             for i in range(times):
-                self.music_handler.press_volume_down()
+                self.music_handler.key_actions.press_volume_down()
                 self.logger.info(f"Decreased volume ({i + 1}/{times})")
         else:
             # Increase volume
             times = delta
             self.logger.info(f"Increasing volume by {times} steps")
             for i in range(times):
-                self.music_handler.press_volume_up()
+                self.music_handler.key_actions.press_volume_up()
                 self.logger.info(f"Increased volume ({i + 1}/{times})")
 
         # Get final volume level

--- a/src/ushareiplay/managers/notice_manager.py
+++ b/src/ushareiplay/managers/notice_manager.py
@@ -92,26 +92,26 @@ class NoticeManager(Singleton):
             self.logger.info(f"准备设置notice: {notice}")
 
             # 点击小助手
-            chat_room_title = self.handler.wait_for_element_clickable('chat_room_title')
+            chat_room_title = self.handler.element_finder.wait_for_element_clickable('chat_room_title')
             if not chat_room_title:
                 return {'error': 'Failed to find room title'}
             chat_room_title.click()
             self.logger.info("点击了标题")
 
             # 点击编辑notice入口
-            edit_entry = self.handler.wait_for_element_clickable('edit_notice_entry')
+            edit_entry = self.handler.element_finder.wait_for_element_clickable('edit_notice_entry')
             if not edit_entry:
                 return {'error': 'Failed to find edit notice entry'}
             edit_entry.click()
             self.logger.info("点击了编辑notice入口")
 
             # 检查是否有关闭按钮
-            close_notice = self.handler.wait_for_element('close_notice')
+            close_notice = self.handler.element_finder.wait_for_element('close_notice')
             if not close_notice:
                 return {'error': 'Close notice not found'}
 
             # 点击自定义按钮
-            key, customize = self.handler.wait_for_any_element(['customize_notice_button', 'modify_notice_button'])
+            key, customize = self.handler.element_finder.wait_for_any_element(['customize_notice_button', 'modify_notice_button'])
             if not customize:
                 close_notice.click()
                 self.logger.warning('Bottom drawer is open, notice customization is disabled, hiding...')
@@ -120,7 +120,7 @@ class NoticeManager(Singleton):
             self.logger.info(f"点击了自定义按钮 {key}")
 
             # 输入新的notice
-            notice_input = self.handler.wait_for_element_clickable('edit_notice_input')
+            notice_input = self.handler.element_finder.wait_for_element_clickable('edit_notice_input')
             if not notice_input:
                 return {'error': 'Failed to find notice input'}
             notice_input.clear()
@@ -128,14 +128,14 @@ class NoticeManager(Singleton):
             self.logger.info(f"输入了notice内容: {notice}")
 
             # 点击确认
-            confirm = self.handler.wait_for_element_clickable('edit_notice_confirm')
+            confirm = self.handler.element_finder.wait_for_element_clickable('edit_notice_confirm')
             if not confirm:
                 return {'error': 'Failed to find confirm button'}
             confirm.click()
             self.logger.info("点击了确认按钮")
 
             # 关闭notice设置对话框
-            close_notice = self.handler.wait_for_element('close_notice')
+            close_notice = self.handler.element_finder.wait_for_element('close_notice')
             if close_notice:
                 self.logger.info("隐藏notice设置对话框")
                 close_notice.click()

--- a/src/ushareiplay/managers/party_manager.py
+++ b/src/ushareiplay/managers/party_manager.py
@@ -115,33 +115,33 @@ class PartyManager(Singleton):
             self.message_dispatch.send_screen_message('Ending party')
 
             # Switch to Soul app first
-            if not self.handler.switch_to_app():
+            if not self.handler.key_actions.switch_to_app():
                 return {'error': 'Failed to switch to Soul app'}
             self.logger.info("Switched to Soul app")
 
             # Try direct exit_room_btn first
-            exit_room_btn = self.handler.try_find_element('exit_room_btn', log=False)
+            exit_room_btn = self.handler.element_finder.try_find_element('exit_room_btn', log=False)
             if exit_room_btn:
                 exit_room_btn.click()
                 self.logger.info("Clicked exit room button directly")
             else:
                 self.logger.info("Direct exit room button not found, trying more menu...")
                 # Click more menu
-                more_menu = self.handler.wait_for_element_clickable('more_menu')
+                more_menu = self.handler.element_finder.wait_for_element_clickable('more_menu')
                 if not more_menu:
                     return {'error': 'Failed to find more menu'}
                 more_menu.click()
                 self.logger.info("Clicked more menu")
 
                 # Click end party option
-                end_party = self.handler.wait_for_element_clickable('end_party')
+                end_party = self.handler.element_finder.wait_for_element_clickable('end_party')
                 if not end_party:
                     return {'error': 'Failed to find end party option'}
                 end_party.click()
                 self.logger.info("Clicked end party option")
 
             # Click confirm end
-            confirm_end = self.handler.wait_for_element_clickable('confirm_end')
+            confirm_end = self.handler.element_finder.wait_for_element_clickable('confirm_end')
             if not confirm_end:
                 return {'error': 'Failed to find confirm end button'}
             confirm_end.click()
@@ -195,17 +195,17 @@ class PartyManager(Singleton):
         """
         try:
             # Check if we can directly close the room (we are the host)
-            exit_room_btn = self.handler.try_find_element('exit_room_btn', log=False)
+            exit_room_btn = self.handler.element_finder.try_find_element('exit_room_btn', log=False)
             if exit_room_btn:
                 exit_room_btn.click()
                 self.logger.info("Clicked exit room button directly")
-                confirm_end = self.handler.wait_for_element_clickable('confirm_end')
+                confirm_end = self.handler.element_finder.wait_for_element_clickable('confirm_end')
                 if confirm_end:
                     confirm_end.click()
                 self.handler.party_id = party_id
                 return {'party_id': party_id, 'user': message_info.nickname}
 
-            more_menu = self.handler.wait_for_element_clickable('more_menu')
+            more_menu = self.handler.element_finder.wait_for_element_clickable('more_menu')
             if not more_menu:
                 return {
                     'error': 'Failed to find more menu button',
@@ -214,18 +214,18 @@ class PartyManager(Singleton):
             more_menu.click()
             self.logger.info("Clicked more menu button")
 
-            self.handler.wait_for_element('more_menu_container')
+            self.handler.element_finder.wait_for_element('more_menu_container')
 
-            end_party = self.handler.try_find_element('end_party', log=False)
+            end_party = self.handler.element_finder.try_find_element('end_party', log=False)
             if end_party:
                 end_party.click()
-                confirm_end = self.handler.wait_for_element_clickable('confirm_end')
+                confirm_end = self.handler.element_finder.wait_for_element_clickable('confirm_end')
                 if confirm_end:
                     confirm_end.click()
                 self.handler.party_id = party_id
                 return {'party_id': party_id, 'user': message_info.nickname}
 
-            party_hall = self.handler.wait_for_element_clickable('party_hall')
+            party_hall = self.handler.element_finder.wait_for_element_clickable('party_hall')
             if not party_hall:
                 return {
                     'error': 'Failed to find party hall entry',
@@ -234,7 +234,7 @@ class PartyManager(Singleton):
             party_hall.click()
             self.logger.info("Clicked party hall entry")
 
-            search_entry = self.handler.wait_for_element_clickable('search_entry')
+            search_entry = self.handler.element_finder.wait_for_element_clickable('search_entry')
             if not search_entry:
                 return {
                     'error': 'Failed to find search entry',
@@ -243,7 +243,7 @@ class PartyManager(Singleton):
             search_entry.click()
             self.logger.info("Clicked search entry")
 
-            search_box = self.handler.wait_for_element_clickable('search_box')
+            search_box = self.handler.element_finder.wait_for_element_clickable('search_box')
             if not search_box:
                 return {
                     'error': 'Failed to find search box',
@@ -252,7 +252,7 @@ class PartyManager(Singleton):
             search_box.send_keys(party_id)
             self.logger.info(f"Entered party ID: {party_id}")
 
-            search_button = self.handler.wait_for_element_clickable('search_button')
+            search_button = self.handler.element_finder.wait_for_element_clickable('search_button')
             if not search_button:
                 return {
                     'error': 'Failed to find search button',
@@ -261,7 +261,7 @@ class PartyManager(Singleton):
             search_button.click()
             self.logger.info("Clicked search button")
 
-            parties_search = self.handler.wait_for_element('parties_search')
+            parties_search = self.handler.element_finder.wait_for_element('parties_search')
             if not parties_search:
                 return {
                     'error': 'Failed to find parties search',
@@ -270,10 +270,10 @@ class PartyManager(Singleton):
             self.logger.info("Found parties search result")
 
             time.sleep(1)
-            party_element = self.handler.find_child_element(parties_search, 'party_id')
+            party_element = self.handler.element_finder.find_child_element(parties_search, 'party_id')
             if not party_element:
                 self.logger.info("Party not found, returning to previous party")
-                floating_entry = self.handler.wait_for_element_clickable('floating_entry')
+                floating_entry = self.handler.element_finder.wait_for_element_clickable('floating_entry')
                 if floating_entry:
                     floating_entry.click()
                 return {
@@ -318,13 +318,13 @@ class PartyManager(Singleton):
         return False
 
     def _enter_party_hall_from_home(self) -> bool:
-        planet_tab = self.handler.try_find_element('planet_tab', log=False)
+        planet_tab = self.handler.element_finder.try_find_element('planet_tab', log=False)
         if not planet_tab:
             return False
         self.logger.info("发现首页，尝试进入派对")
         planet_tab.click()
 
-        party_hall_entry = self.handler.wait_for_element_clickable('party_hall_entry')
+        party_hall_entry = self.handler.element_finder.wait_for_element_clickable('party_hall_entry')
         if not party_hall_entry:
             self.logger.warning("未找到派对大厅入口")
             return False
@@ -333,7 +333,7 @@ class PartyManager(Singleton):
         return True
 
     def _search_and_try_enter_existing_party(self) -> bool:
-        key, element = self.handler.wait_for_any_element(['party_back', 'search_entry'])
+        key, element = self.handler.element_finder.wait_for_any_element(['party_back', 'search_entry'])
         if not element:
             self.logger.warning("未找到派对入口")
             return False
@@ -346,7 +346,7 @@ class PartyManager(Singleton):
         search_entry = element
         search_entry.click()
         self.logger.info("Clicked search entry")
-        search_box = self.handler.wait_for_element('search_box')
+        search_box = self.handler.element_finder.wait_for_element('search_box')
         if not search_box:
             self.logger.warning("未找到搜索框")
             return False
@@ -354,20 +354,20 @@ class PartyManager(Singleton):
         party_id = self.handler.party_id or self.handler.config['default_party_id']
         search_box.send_keys(party_id)
         self.logger.info(f"Entered party ID: {party_id}")
-        search_button = self.handler.wait_for_element('search_button')
+        search_button = self.handler.element_finder.wait_for_element('search_button')
         if not search_button:
             self.logger.warning("未找到搜索按钮")
             return False
         search_button.click()
         self.logger.info("Clicked search button")
 
-        room_card = self.handler.wait_for_element('room_card')
+        room_card = self.handler.element_finder.wait_for_element('room_card')
         if not room_card:
             self.logger.warning("未找到派对房间，视为派对关闭，准备重建派对")
             self._go_back_from_search()
             return False
 
-        party_online = self.handler.try_find_element('party_online')
+        party_online = self.handler.element_finder.try_find_element('party_online')
         if party_online:
             party_online.click()
             self.logger.info("Clicked party online")
@@ -378,16 +378,16 @@ class PartyManager(Singleton):
         return False
 
     def _go_back_from_search(self) -> None:
-        search_back = self.handler.wait_for_element('search_back')
+        search_back = self.handler.element_finder.wait_for_element('search_back')
         if search_back:
             search_back.click()
             self.logger.info("Clicked search back")
             return
         self.logger.warning("未找到搜索返回按钮，尝试系统返回")
-        self.handler.press_back()
+        self.handler.key_actions.press_back()
 
     def _create_party_flow(self) -> bool:
-        key, element = self.handler.wait_for_any_element(['create_party_entry', 'create_room_entry'])
+        key, element = self.handler.element_finder.wait_for_any_element(['create_party_entry', 'create_room_entry'])
         if not element:
             self.logger.warning("未找到派对入口")
             return False
@@ -399,7 +399,7 @@ class PartyManager(Singleton):
             wait_keys = ['restore_party', 'confirm_party', 'party_state_entry']
         else:
             wait_keys = ['new_party_entry', 'confirm_party', 'party_state_entry']
-        key, element = self.handler.wait_for_any_element(wait_keys)
+        key, element = self.handler.element_finder.wait_for_any_element(wait_keys)
         if not element:
             self.logger.warning("未找到派对创建或恢复按钮")
             return False
@@ -413,7 +413,7 @@ class PartyManager(Singleton):
         if key == 'new_party_entry' or key == 'confirm_party':
             element.click()
             self.logger.info(f"Clicked new party entry: {key}")
-            party_state_entry = self.handler.wait_for_element('party_state_entry')
+            party_state_entry = self.handler.element_finder.wait_for_element('party_state_entry')
         elif key == 'party_state_entry':
             party_state_entry = element
 
@@ -424,14 +424,14 @@ class PartyManager(Singleton):
         party_state_entry.click()
         self.logger.info("Clicked party state entry")
 
-        close_party_notification = self.handler.wait_for_element('close_party_notification')
+        close_party_notification = self.handler.element_finder.wait_for_element('close_party_notification')
         if not close_party_notification:
             self.logger.warning("未找到关闭派对推荐")
             return False
         close_party_notification.click()
         self.logger.info("Clicked close party notification")
 
-        create_party_button = self.handler.wait_for_element('create_party_button')
+        create_party_button = self.handler.element_finder.wait_for_element('create_party_button')
         if not create_party_button:
             self.logger.warning("<UNK>")
             return False

--- a/src/ushareiplay/managers/recovery_manager.py
+++ b/src/ushareiplay/managers/recovery_manager.py
@@ -27,7 +27,7 @@ class RecoveryManager(Singleton):
         try:
             for attempt in range(1, max_attempts + 1):
                 # 使用 wait_for 获取可点击的元素
-                element = self.handler.wait_for_element_clickable(drawer_key)
+                element = self.handler.element_finder.wait_for_element_clickable(drawer_key)
                 if not element:
                     if not self._is_drawer_visible(drawer_key):
                         return self._confirm_drawer_closed(drawer_key, wait_element)
@@ -37,7 +37,7 @@ class RecoveryManager(Singleton):
                     return False
 
                 # 点击抽屉上方区域来关闭
-                click_success = self.handler.click_element_at(
+                click_success = self.handler.gesture_handler.click_element_at(
                     element, x_ratio=0.3, y_ratio=0, y_offset=-200
                 )
                 if not click_success:
@@ -60,7 +60,7 @@ class RecoveryManager(Singleton):
             return False
 
     def _is_drawer_visible(self, drawer_key: str) -> bool:
-        element = self.handler.try_find_element(drawer_key, log=False)
+        element = self.handler.element_finder.try_find_element(drawer_key, log=False)
         if not element:
             return False
         try:
@@ -70,11 +70,11 @@ class RecoveryManager(Singleton):
 
     def _confirm_drawer_closed(self, drawer_key: str, wait_element: str) -> bool:
         # 等待指定元素出现，确认界面已恢复正常；成功条件仍以抽屉消失为准。
-        target_element = self.handler.wait_for_element(wait_element)
+        target_element = self.handler.element_finder.wait_for_element(wait_element)
         if target_element:
             self.logger.info(f"Closed drawer: {drawer_key}, {wait_element} confirmed")
         else:
-            self.handler.press_back()
+            self.handler.key_actions.press_back()
             self.logger.warning(f"Closed drawer: {drawer_key}, but {wait_element} not found")
         return not self._is_drawer_visible(drawer_key)
 

--- a/src/ushareiplay/managers/seat_manager/seat_check.py
+++ b/src/ushareiplay/managers/seat_manager/seat_check.py
@@ -106,11 +106,11 @@ class SeatCheckManager(SeatManagerBase):
 
         # Find the specific seat element
         if is_left_seat:
-            seat_element = self.handler.find_child_element(desk, 'left_seat')
-            seat_label = self.handler.find_child_element(seat_element, 'left_label')
+            seat_element = self.handler.element_finder.find_child_element(desk, 'left_seat')
+            seat_label = self.handler.element_finder.find_child_element(seat_element, 'left_label')
         else:
-            seat_element = self.handler.find_child_element(desk, 'right_seat')
-            seat_label = self.handler.find_child_element(seat_element, 'right_label')
+            seat_element = self.handler.element_finder.find_child_element(desk, 'right_seat')
+            seat_label = self.handler.element_finder.find_child_element(seat_element, 'right_label')
 
         if not seat_element:
             self.handler.logger.error(f"Cannot find seat element for seat {seat_number}")
@@ -132,13 +132,13 @@ class SeatCheckManager(SeatManagerBase):
         self.handler.logger.info(f"Clicked seat {seat_number} to remove occupant")
 
         # Wait for seat off button
-        seat_off = self.handler.wait_for_element_clickable('seat_off')
+        seat_off = self.handler.element_finder.wait_for_element_clickable('seat_off')
         if not seat_off:
             self.handler.logger.error(f"Failed to find seat off button for seat {seat_number}")
             self.message_dispatch.send_screen_message(f"Unable to manage seat {seat_number} for {username}")
             return
 
-        found_key, souler_name = self.handler.wait_for_any_element(['souler_name', 'user_name'])
+        found_key, souler_name = self.handler.element_finder.wait_for_any_element(['souler_name', 'user_name'])
         if not souler_name:
             self.handler.logger.error(f"No souler name found for seat {seat_number}")
             self.message_dispatch.send_screen_message(f"Failed to verify occupant on seat {seat_number}")
@@ -148,7 +148,7 @@ class SeatCheckManager(SeatManagerBase):
         if souler_name_text == username:
             self.handler.logger.error(f"Souler {username} is already in seat {seat_number}")
             # No message needed - user is already seated successfully
-            self.handler.press_back()
+            self.handler.key_actions.press_back()
             return
 
         user = await UserDAO.get_by_username(username)
@@ -156,7 +156,7 @@ class SeatCheckManager(SeatManagerBase):
         if user and souler and user.level <= souler.level:
             self.handler.logger.info(
                 f"Souler {souler_name_text} has higher or equal level ({souler.level}) than {username} ({user.level}), skipping")
-            self.handler.press_back()
+            self.handler.key_actions.press_back()
             self.message_dispatch.send_screen_message(f"Cannot seat {username}: Seat {seat_number} occupied by higher level user")
             return
 

--- a/src/ushareiplay/managers/seat_manager/seat_ui.py
+++ b/src/ushareiplay/managers/seat_manager/seat_ui.py
@@ -20,7 +20,7 @@ class SeatUIManager(SeatManagerBase):
         # self.handler.logger.info(f"检查座位状态，当前 is_expanded={self.is_expanded}")
 
         # 获取元素
-        expand_seats = self.handler.try_find_element('expand_seats', log=False)
+        expand_seats = self.handler.element_finder.try_find_element('expand_seats', log=False)
         if not expand_seats:
             # self.handler.logger.warning("未找到座位按钮，无法确定当前状态")
             return self.is_expanded
@@ -62,7 +62,7 @@ class SeatUIManager(SeatManagerBase):
         # 添加详细日志，查看找到的元素
         # self.handler.logger.info("尝试展开座位...")
         try:
-            expand_seats = self.handler.try_find_element('expand_seats', log=False)
+            expand_seats = self.handler.element_finder.try_find_element('expand_seats', log=False)
 
             # 记录按钮的实际文本内容
             if expand_seats:
@@ -93,7 +93,7 @@ class SeatUIManager(SeatManagerBase):
             return None
 
         await asyncio.sleep(0.5)
-        seat_desks = self.handler.find_elements('seat_desk')
+        seat_desks = self.handler.element_finder.find_elements('seat_desk')
         if not seat_desks:
             self.handler.logger.error("Failed to find seat desks")
             return None
@@ -119,12 +119,12 @@ class SeatUIManager(SeatManagerBase):
         desk_height = reference_desk.size['height']
 
         if row_index == 0:
-            self.handler.driver.swipe(
+            self.handler.gesture_handler.swipe(
                 center_x, center_y, center_x, center_y + desk_height, duration
             )
             self.handler.logger.info(f"Scrolled to show first row for desk {desk_index + 1}")
         elif row_index == 2:
-            self.handler.driver.swipe(
+            self.handler.gesture_handler.swipe(
                 center_x, center_y, center_x, center_y - desk_height, duration
             )
             self.handler.logger.info(f"Scrolled to show third row for desk {desk_index + 1}")
@@ -145,7 +145,7 @@ class SeatUIManager(SeatManagerBase):
             return True
 
         try:
-            expand_seats = self.handler.try_find_element('expand_seats', log=False)
+            expand_seats = self.handler.element_finder.try_find_element('expand_seats', log=False)
 
             if expand_seats:
                 actual_text = expand_seats.text

--- a/src/ushareiplay/managers/seat_manager/seating.py
+++ b/src/ushareiplay/managers/seat_manager/seating.py
@@ -189,7 +189,7 @@ class SeatingManager(SeatManagerBase):
 
                 # Click the state element to open user profile popup
                 state_key = f'{side}_state'
-                state_element = self.handler.find_child_element(
+                state_element = self.handler.element_finder.find_child_element(
                     desk, state_key, log_failure=False
                 )
                 if not state_element:
@@ -199,12 +199,12 @@ class SeatingManager(SeatManagerBase):
                 self.handler.logger.info(f"Clicked {side} seat at desk {desk_index + 1} to check user")
 
                 # Read the user name from the popup
-                found_key, name_element = self.handler.wait_for_any_element(
+                found_key, name_element = self.handler.element_finder.wait_for_any_element(
                     ['souler_name', 'user_name']
                 )
                 if not name_element:
                     self.handler.logger.warning(f"No user name found for {side} seat at desk {desk_index + 1}")
-                    self.handler.press_back()
+                    self.handler.key_actions.press_back()
                     continue
 
                 actual_username = name_element.text
@@ -214,12 +214,12 @@ class SeatingManager(SeatManagerBase):
 
                 if actual_username != target_username:
                     # Not the target user, close popup and continue
-                    self.handler.press_back()
+                    self.handler.key_actions.press_back()
                     await asyncio.sleep(0.3)
                     continue
 
                 # Found the target user! Close the popup first
-                self.handler.press_back()
+                self.handler.key_actions.press_back()
                 await asyncio.sleep(0.3)
 
                 # Check if the adjacent seat is available
@@ -331,12 +331,12 @@ class SeatingManager(SeatManagerBase):
         return None
 
     def _collect_desk_info(self, desk):
-        left_seat = self.handler.find_child_element(desk, 'left_seat', log_failure=False)
-        right_seat = self.handler.find_child_element(desk, 'right_seat', log_failure=False)
-        left_state = self.handler.find_child_element(desk, 'left_state', log_failure=False)
-        right_state = self.handler.find_child_element(desk, 'right_state', log_failure=False)
-        left_label_element = self.handler.find_child_element(desk, 'left_label', log_failure=False)
-        right_label_element = self.handler.find_child_element(desk, 'right_label', log_failure=False)
+        left_seat = self.handler.element_finder.find_child_element(desk, 'left_seat', log_failure=False)
+        right_seat = self.handler.element_finder.find_child_element(desk, 'right_seat', log_failure=False)
+        left_state = self.handler.element_finder.find_child_element(desk, 'left_state', log_failure=False)
+        right_state = self.handler.element_finder.find_child_element(desk, 'right_state', log_failure=False)
+        left_label_element = self.handler.element_finder.find_child_element(desk, 'left_label', log_failure=False)
+        right_label_element = self.handler.element_finder.find_child_element(desk, 'right_label', log_failure=False)
 
         left_label = left_label_element.text if left_label_element else ''
         right_label = right_label_element.text if right_label_element else ''
@@ -412,12 +412,12 @@ class SeatingManager(SeatManagerBase):
             seat_info['element'].click()
             self.handler.logger.info(f"Clicked seat {seat_number} to remove occupant")
 
-            seat_off = self.handler.wait_for_element_clickable('seat_off')
+            seat_off = self.handler.element_finder.wait_for_element_clickable('seat_off')
             if not seat_off:
                 self.handler.logger.error(f"Failed to find seat off button for seat {seat_number}")
                 return {'error': f'Unable to manage seat {seat_number}'}
 
-            found_key, souler_name = self.handler.wait_for_any_element(['souler_name', 'user_name'])
+            found_key, souler_name = self.handler.element_finder.wait_for_any_element(['souler_name', 'user_name'])
             if not souler_name:
                 self.handler.logger.error(f"No souler name found for seat {seat_number}")
                 return {'error': f'Failed to verify occupant on seat {seat_number}'}
@@ -438,16 +438,16 @@ class SeatingManager(SeatManagerBase):
 
         try:
             # Wait for confirmation dialog
-            confirm_button = self.handler.wait_for_element_clickable('confirm_seat')
+            confirm_button = self.handler.element_finder.wait_for_element_clickable('confirm_seat')
             if not confirm_button:
                 self.handler.logger.error("Failed to find confirm button")
                 return {'error': 'Failed to find confirm button'}
 
             confirm_button.click()
             self.handler.logger.info("Confirmed seat selection")
-            bottom_drawer = self.handler.wait_for_element_clickable('bottom_drawer')
+            bottom_drawer = self.handler.element_finder.wait_for_element_clickable('bottom_drawer')
             if bottom_drawer:
-                self.handler.click_element_at(bottom_drawer, 0.5, -0.1)
+                self.handler.gesture_handler.click_element_at(bottom_drawer, 0.5, -0.1)
                 self.handler.logger.info("Hide bottom drawer")
             return {'success': 'Successfully took a seat'}
 

--- a/src/ushareiplay/managers/theme_manager.py
+++ b/src/ushareiplay/managers/theme_manager.py
@@ -118,13 +118,13 @@ class ThemeManager(Singleton):
 
         try:
             # Find room title element
-            room_title_element = self.handler.try_find_element('chat_room_title', log=False)
+            room_title_element = self.handler.element_finder.try_find_element('chat_room_title', log=False)
             if not room_title_element:
                 self.logger.info("Room title element not found for initialization")
                 return {'error': 'Room title element not found'}
 
             # Get room title text
-            room_title_text = self.handler.get_element_text(room_title_element)
+            room_title_text = self.handler.element_finder.get_element_text(room_title_element)
             if not room_title_text:
                 self.logger.info("Room title text is empty for initialization")
                 return {'error': 'Room title text is empty'}

--- a/src/ushareiplay/managers/title_manager.py
+++ b/src/ushareiplay/managers/title_manager.py
@@ -97,13 +97,13 @@ class TitleManager(Singleton):
 
         try:
             # Find room title element
-            room_title_element = self.handler.try_find_element('chat_room_title', log=False)
+            room_title_element = self.handler.element_finder.try_find_element('chat_room_title', log=False)
             if not room_title_element:
                 self.logger.info("Room title element not found")
                 return None
 
             # Get room title text
-            room_title_text = self.handler.get_element_text(room_title_element)
+            room_title_text = self.handler.element_finder.get_element_text(room_title_element)
             if not room_title_text:
                 self.logger.info("Room title text is empty")
                 return None
@@ -155,10 +155,10 @@ class TitleManager(Singleton):
             str: 房名文本，获取失败返回 None
         """
         try:
-            room_title_element = self.handler.try_find_element('chat_room_title', log=False)
+            room_title_element = self.handler.element_finder.try_find_element('chat_room_title', log=False)
             if not room_title_element:
                 return None
-            text = self.handler.get_element_text(room_title_element)
+            text = self.handler.element_finder.get_element_text(room_title_element)
             return (text or "").strip() or None
         except Exception:
             return None
@@ -170,12 +170,12 @@ class TitleManager(Singleton):
         """
         try:
             # 获取当前房间notice
-            notice_element = self.handler.wait_for_element('chat_room_notice')
+            notice_element = self.handler.element_finder.wait_for_element('chat_room_notice')
             if not notice_element:
                 self.logger.info("Chat room notice element not found, skipping notice check")
                 return {'skipped': 'Notice element not found'}
 
-            current_notice = self.handler.get_element_text(notice_element)
+            current_notice = self.handler.element_finder.get_element_text(notice_element)
             if not current_notice:
                 self.logger.info("Current notice is empty, skipping notice check")
                 return {'skipped': 'Current notice is empty'}
@@ -283,8 +283,11 @@ class TitleManager(Singleton):
             dict: Result with title info or error
         """
         # Switch to Soul app first
-        if not self.handler.switch_to_app():
-            return {'error': 'Failed to switch to Soul app'}
+        result = self.handler.ui_actions.switch_and_click(
+            'chat_room_title', error_message='Failed to find room title'
+        )
+        if 'error' in result:
+            return result
         self.logger.info("Switched to Soul app")
 
         new_title = title.split('|')[0].split('(')[0].strip()[:12]
@@ -322,7 +325,7 @@ class TitleManager(Singleton):
         Returns:
             dict: Result with error or success
         """
-        if not self.handler.switch_to_app():
+        if not self.handler.key_actions.switch_to_app():
             return {'error': 'Failed to switch to Soul app'}
 
         try:
@@ -340,12 +343,6 @@ class TitleManager(Singleton):
                 current_theme = theme if theme else "享乐"
                 self.logger.info(f"Using fallback theme (no theme_manager): {current_theme}")
 
-            # Click room title
-            room_title = self.handler.wait_for_element_clickable('chat_room_title')
-            if not room_title:
-                return {'error': 'Failed to find room title'}
-            room_title.click()
-
             # 在点击编辑入口之前，检查notice是否需要恢复
             self.logger.info("Checking room notice before editing title")
             notice_check_result = self._check_notice_reset()
@@ -360,21 +357,21 @@ class TitleManager(Singleton):
                 self.logger.info(f"Notice check skipped: {notice_check_result['skipped']}")
 
             # Click edit entry
-            edit_entry = self.handler.wait_for_element_clickable('title_edit_entry')
+            edit_entry = self.handler.element_finder.wait_for_element_clickable('title_edit_entry')
             if not edit_entry:
                 return {'error': 'Failed to find edit title entry'}
-            if not self.handler.click_element_at(edit_entry, y_ratio=0.25):
+            if not self.handler.gesture_handler.click_element_at(edit_entry, y_ratio=0.25):
                 return {'error': 'Failed to click edit entry'}
 
             # Input new title
-            title_input = self.handler.wait_for_element_clickable('title_edit_input')
+            title_input = self.handler.element_finder.wait_for_element_clickable('title_edit_input')
             if not title_input:
                 return {'error': 'Failed to find title input'}
             title_input.clear()
             title_input.send_keys(f"{current_theme}｜" + title)
 
             # Click confirm
-            confirm = self.handler.wait_for_element_clickable('title_edit_confirm')
+            confirm = self.handler.element_finder.wait_for_element_clickable('title_edit_confirm')
             if not confirm:
                 return {'error': 'Failed to find confirm button'}
             confirm.click()
@@ -383,7 +380,7 @@ class TitleManager(Singleton):
             time.sleep(1)
 
             # Check if update was successful by looking for edit entry or confirm button
-            key, element = self.handler.wait_for_any_element(['title_edit_entry', 'title_edit_confirm'])
+            key, element = self.handler.element_finder.wait_for_any_element(['title_edit_entry', 'title_edit_confirm'])
 
             if key == 'title_edit_entry':
                 # Update successful - we're back to edit entry page
@@ -397,7 +394,7 @@ class TitleManager(Singleton):
                     self.current_title = title
                     self.logger.info(f'UI updated successfully, current title: {self.current_title}')
 
-                self.handler.press_back()
+                self.handler.key_actions.press_back()
                 self.logger.info('Hide edit title dialog')
 
                 # 仅在真正设置成功后检测：房名不含「｜」说明审核未通过、系统随机取名，则重设为 日推
@@ -428,12 +425,12 @@ class TitleManager(Singleton):
 
             elif key == 'title_edit_confirm':
                 # Update failed - still on confirm page
-                go_back = self.handler.wait_for_element('go_back')
+                go_back = self.handler.element_finder.wait_for_element('go_back')
                 if go_back:
                     go_back.click()
                     self.logger.warning('Update title failed, going back to chat room info screen')
 
-                self.handler.press_back()
+                self.handler.key_actions.press_back()
                 self.logger.info('Hide edit title dialog')
 
                 # 标题更新成功后，检查是否需要恢复notice
@@ -455,7 +452,7 @@ class TitleManager(Singleton):
                 return {'error': 'Update failed - still in cooldown period'}
             else:
                 self.logger.warning('Failed to update title, unknown error')
-                self.handler.press_back()
+                self.handler.key_actions.press_back()
 
                 # 标题更新失败，清除notice恢复标记
                 self.pending_notice_restore = False

--- a/src/ushareiplay/managers/topic_manager.py
+++ b/src/ushareiplay/managers/topic_manager.py
@@ -77,7 +77,7 @@ class TopicManager(Singleton):
         Returns:
             dict: 操作结果
         """
-        if not self.soul_handler.switch_to_app():
+        if not self.soul_handler.key_actions.switch_to_app():
             return {'error': 'Failed to switch to Soul app'}
         
         self.logger.info("Switched to Soul app")
@@ -120,26 +120,26 @@ class TopicManager(Singleton):
         """
         try:
             # Click room topic
-            room_topic = self.soul_handler.wait_for_element_clickable('room_topic')
+            room_topic = self.soul_handler.element_finder.wait_for_element_clickable('room_topic')
             if not room_topic:
                 return {'error': 'Failed to find room topic'}
             room_topic.click()
 
             # Click edit entry
-            edit_entry = self.soul_handler.wait_for_element_clickable('edit_topic_entry')
+            edit_entry = self.soul_handler.element_finder.wait_for_element_clickable('edit_topic_entry')
             if not edit_entry:
                 return {'error': 'Failed to find edit topic entry'}
             edit_entry.click()
 
             # Input new topic
-            topic_input = self.soul_handler.wait_for_element_clickable('edit_topic_input')
+            topic_input = self.soul_handler.element_finder.wait_for_element_clickable('edit_topic_input')
             if not topic_input:
                 return {'error': 'Failed to find topic input'}
             topic_input.clear()
             topic_input.send_keys(topic)
 
             # Click confirm
-            confirm = self.soul_handler.wait_for_element_clickable('edit_topic_confirm')
+            confirm = self.soul_handler.element_finder.wait_for_element_clickable('edit_topic_confirm')
             if not confirm:
                 return {'error': 'Failed to find confirm button'}
             confirm.click()
@@ -149,11 +149,11 @@ class TopicManager(Singleton):
             time.sleep(1)
 
             # Check if update was successful
-            key, element = self.soul_handler.wait_for_any_element(['input_box_entry', 'edit_topic_confirm'])
+            key, element = self.soul_handler.element_finder.wait_for_any_element(['input_box_entry', 'edit_topic_confirm'])
             if key == 'edit_topic_confirm':
-                self.soul_handler.press_back()
-                self.soul_handler.press_back()
-                self.soul_handler.press_back()
+                self.soul_handler.key_actions.press_back()
+                self.soul_handler.key_actions.press_back()
+                self.soul_handler.key_actions.press_back()
                 self.logger.warning('Update topic too frequently, hide edit topic dialog')
                 return {'error': 'update topic too frequently'}
             elif key == 'input_box_entry':

--- a/src/ushareiplay/managers/user_manager.py
+++ b/src/ushareiplay/managers/user_manager.py
@@ -35,7 +35,7 @@ class UserManager(Singleton):
         Returns:
             dict: 成功时返回 {}；失败时返回 {'error': str, 'user': nickname}。
         """
-        user_count_elem = self.handler.wait_for_element('user_count')
+        user_count_elem = self.handler.element_finder.wait_for_element('user_count')
         if not user_count_elem:
             self.logger.warning("未找到在线用户人数")
             return {
@@ -46,7 +46,7 @@ class UserManager(Singleton):
         user_count_elem.click()
         self.logger.info("Opened online users list")
 
-        online_container = self.handler.wait_for_element('online_users')
+        online_container = self.handler.element_finder.wait_for_element('online_users')
         if not online_container:
             self.logger.warning("未找到在线用户列表")
             return {
@@ -54,7 +54,7 @@ class UserManager(Singleton):
                 'user': nickname,
             }
 
-        key, user_elem, _ = self.handler.scroll_container_until_element(
+        key, user_elem, _ = self.handler.gesture_handler.scroll_container_until_element(
             'online_user',
             'online_users',
             'up',
@@ -96,46 +96,46 @@ class UserManager(Singleton):
         if 'error' in open_result:
             return open_result
 
-        send_gift_btn = self.handler.wait_for_element_clickable('send_gift')
+        send_gift_btn = self.handler.element_finder.wait_for_element_clickable('send_gift')
         if not send_gift_btn:
             self.logger.info("未找到送礼物按钮")
             return {'error': '未找到送礼物入口'}
 
-        self.handler.click_element_at(send_gift_btn)
+        self.handler.gesture_handler.click_element_at(send_gift_btn)
         self.logger.info("已点击送礼物")
 
-        found_key, found_element = self.handler.wait_for_any_element(['give_gift', 'use_item'])
+        found_key, found_element = self.handler.element_finder.wait_for_any_element(['give_gift', 'use_item'])
         if not found_element:
             self.logger.info("送礼界面未出现或超时")
             return {'error': '送礼界面未出现'}
 
-        luck_item = self.handler.try_find_element('luck_item')
+        luck_item = self.handler.element_finder.try_find_element('luck_item')
         if not luck_item:
             self.logger.warning('Failed to find gift')
-            self.handler.press_back()
+            self.handler.key_actions.press_back()
             return {'error': 'Failed to find gift'}
 
         gift_name = luck_item.text
         if (parts := gift_name.split('x')) and len(parts) > 1:
             gift_name = parts[0]
 
-        soul_power = self.handler.try_find_element('soul_power')
+        soul_power = self.handler.element_finder.try_find_element('soul_power')
         soul_points = soul_power.text if soul_power else '0'
 
         # 礼物列表兜底：背包为空时展示礼物列表，小黄鸭不会默认选中，直接点击即送出，无需点"赠送"
         if gift_name.strip() == YELLOW_DUCK_NAME:
-            self.handler.click_element_at(luck_item)
+            self.handler.gesture_handler.click_element_at(luck_item)
             self.logger.info(f"已点击{YELLOW_DUCK_NAME}，送出后关闭在线列表")
             self._close_online_drawer()
             return {'success': f'{gift_name} 送你啦'}
 
-        self.handler.click_element_at(found_element)
+        self.handler.gesture_handler.click_element_at(found_element)
         self.logger.info(f"已点击赠送, gift_name: {gift_name} soul_points: {soul_points}")
 
         if found_key == 'use_item':
-            confirm_use = self.handler.wait_for_element('confirm_use')
+            confirm_use = self.handler.element_finder.wait_for_element('confirm_use')
             if not confirm_use:
-                self.handler.press_back()
+                self.handler.key_actions.press_back()
                 self.logger.warning("未找到确认使用按钮")
                 return {'error': '未找到确认使用按钮'}
 
@@ -159,24 +159,24 @@ class UserManager(Singleton):
         任意一步失败返回 False，不抛异常。
         """
         try:
-            self.handler.switch_to_app()
+            self.handler.key_actions.switch_to_app()
             open_result = self.open_user_profile_from_online_list(nickname)
             if 'error' in open_result:
                 self.logger.warning(f"打开用户资料页失败: {nickname}, error={open_result['error']}")
                 return False
 
-            avatar = self.handler.wait_for_element_clickable(
+            avatar = self.handler.element_finder.wait_for_element_clickable(
                 'sender_avatar',
                 timeout=5,
             )
             if not avatar:
                 self.logger.warning(f"未找到头像入口: {nickname}")
                 return False
-            if not self.handler.click_element_at(avatar, y_ratio=0.7):
+            if not self.handler.gesture_handler.click_element_at(avatar, y_ratio=0.7):
                 self.logger.warning(f"点击头像入口失败: {nickname}")
                 return False
 
-            private_chat_btn = self.handler.wait_for_element_clickable(
+            private_chat_btn = self.handler.element_finder.wait_for_element_clickable(
                 'private_chat_button',
                 timeout=5,
             )
@@ -185,7 +185,7 @@ class UserManager(Singleton):
                 return False
             private_chat_btn.click()
 
-            input_box = self.handler.wait_for_element_clickable(
+            input_box = self.handler.element_finder.wait_for_element_clickable(
                 'private_message_input',
                 timeout=5,
             )
@@ -194,7 +194,7 @@ class UserManager(Singleton):
                 return False
             input_box.send_keys(message)
 
-            send_button = self.handler.wait_for_element_clickable(
+            send_button = self.handler.element_finder.wait_for_element_clickable(
                 'private_message_send',
                 timeout=5,
             )
@@ -211,14 +211,14 @@ class UserManager(Singleton):
     def _return_to_room_after_private_chat(self, nickname: str) -> bool:
         """私聊发送后返回聊天室。"""
         try:
-            _key, entry = self.handler.wait_for_any_element(
+            _key, entry = self.handler.element_finder.wait_for_any_element(
                 ['private_room_entry', 'floating_entry', 'item_left_back'],
                 timeout=3,
             )
             if entry:
                 entry.click()
                 if _key == 'item_left_back':
-                    titlebar_back = self.handler.wait_for_element_clickable(
+                    titlebar_back = self.handler.element_finder.wait_for_element_clickable(
                         'titlebar_back_ivbtn',
                         timeout=3,
                     )

--- a/src/ushareiplay/state/online_list_scraper.py
+++ b/src/ushareiplay/state/online_list_scraper.py
@@ -37,13 +37,13 @@ class OnlineListScraper(Singleton):
             target_count = RoomState.instance().user_count
 
             # 打开在线用户列表
-            user_count_elem = self.handler.try_find_element('user_count', log=False)
+            user_count_elem = self.handler.element_finder.try_find_element('user_count', log=False)
             if not user_count_elem:
                 return
             user_count_elem.click()
             self.logger.info("Clicked user count element")
 
-            online_container = self.handler.wait_for_element('online_users')
+            online_container = self.handler.element_finder.wait_for_element('online_users')
             if not online_container:
                 self.logger.error("Online users container not found")
                 return
@@ -73,11 +73,11 @@ class OnlineListScraper(Singleton):
                 end_y = None
 
             for swipe_idx in range(max_swipes + 1):
-                visible_containers = self.handler.find_child_elements(online_container, 'user_container')
+                visible_containers = self.handler.element_finder.find_child_elements(online_container, 'user_container')
                 if visible_containers:
                     for container in visible_containers:
                         try:
-                            user_elem = self.handler.find_child_element(container, 'online_user')
+                            user_elem = self.handler.element_finder.find_child_element(container, 'online_user')
                             if not user_elem:
                                 continue
                             username = user_elem.text
@@ -89,7 +89,7 @@ class OnlineListScraper(Singleton):
                                 continue
                             all_online_user_names.add(username)
 
-                            follow_state_elem = self.handler.find_child_element(container, 'follow_state')
+                            follow_state_elem = self.handler.element_finder.find_child_element(container, 'follow_state')
                             follow_state = follow_state_elem.text if follow_state_elem else None
 
                             if follow_state:
@@ -106,7 +106,7 @@ class OnlineListScraper(Singleton):
 
                 # 停止条件 1：到底提示出现
                 try:
-                    no_more = self.handler.try_find_element('no_more_data', log=False)
+                    no_more = self.handler.element_finder.try_find_element('no_more_data', log=False)
                     if no_more and no_more.is_displayed():
                         self.logger.info("Detected no_more_data, stop scrolling online users.")
                         break
@@ -134,12 +134,12 @@ class OnlineListScraper(Singleton):
 
                 try:
                     if swipe_x is not None:
-                        ok = self.handler._perform_swipe(swipe_x, start_y, swipe_x, end_y, duration_ms=400)
+                        ok = self.handler.gesture_handler.swipe(swipe_x, start_y, swipe_x, end_y, duration_ms=400)
                         if not ok:
                             self.logger.warning("Swipe failed, stop scrolling online users.")
                             break
                     else:
-                        self.handler.driver.swipe(500, 1500, 500, 800, 600)
+                        self.handler.gesture_handler.swipe(500, 1500, 500, 800, 600)
                 except Exception as e:
                     self.logger.error(f"Error during swipe operation: {str(e)}")
                     break
@@ -151,9 +151,9 @@ class OnlineListScraper(Singleton):
 
             PresenceTracker.instance().update_online_users(list(all_online_user_names))
 
-            bottom_drawer = self.handler.wait_for_element('bottom_drawer')
+            bottom_drawer = self.handler.element_finder.wait_for_element('bottom_drawer')
             if bottom_drawer:
                 self.logger.info('Hide online users dialog')
-                self.handler.click_element_at(bottom_drawer, 0.5, -0.1)
+                self.handler.gesture_handler.click_element_at(bottom_drawer, 0.5, -0.1)
         except Exception:
             self.logger.error(f"Error refreshing online users: {traceback.format_exc()}")

--- a/tests/state/test_online_list_scraper.py
+++ b/tests/state/test_online_list_scraper.py
@@ -53,17 +53,17 @@ async def test_refresh_online_users_parses_and_updates_presence(scraper, reset_s
     follow_state_elem = MagicMock()
     follow_state_elem.text = ""
 
-    scraper._handler.try_find_element.side_effect = lambda key, **kwargs: {
+    scraper._handler.element_finder.try_find_element.side_effect = lambda key, **kwargs: {
         "user_count": user_count_elem,
         "online_users": online_container,
         "bottom_drawer": MagicMock(),
     }.get(key)
-    scraper._handler.find_child_elements.return_value = [user_container]
-    scraper._handler.find_child_element.side_effect = lambda parent, key, **kwargs: {
+    scraper._handler.element_finder.find_child_elements.return_value = [user_container]
+    scraper._handler.element_finder.find_child_element.side_effect = lambda parent, key, **kwargs: {
         "online_user": user_elem,
         "follow_state": follow_state_elem,
     }.get(key)
-    scraper._handler.wait_for_element.side_effect = lambda key: {
+    scraper._handler.element_finder.wait_for_element.side_effect = lambda key: {
         "online_users": online_container,
         "bottom_drawer": MagicMock(),
     }.get(key)
@@ -78,8 +78,8 @@ async def test_refresh_online_users_parses_and_updates_presence(scraper, reset_s
 def test_refresh_online_users_no_op_when_user_count_element_missing(scraper):
     RoomState.initialize()
     PresenceTracker.initialize()
-    scraper._handler.try_find_element.return_value = None
+    scraper._handler.element_finder.try_find_element.return_value = None
     # Should return early without raising
     import asyncio
     asyncio.run(scraper.refresh_online_users())
-    scraper._handler.try_find_element.assert_called_once_with("user_count", log=False)
+    scraper._handler.element_finder.try_find_element.assert_called_once_with("user_count", log=False)

--- a/tests/test_accidental_touch_locker_event.py
+++ b/tests/test_accidental_touch_locker_event.py
@@ -45,6 +45,16 @@ class FakeHandler:
         self.swipes.append((start_x, start_y, end_x, end_y, duration_ms))
         return True
 
+    @property
+    def element_finder(self):
+        return self
+
+    @property
+    def gesture_handler(self):
+        return self
+
+    swipe = _perform_swipe
+
 
 @pytest.mark.asyncio
 async def test_accidental_touch_locker_uses_configured_element_key(monkeypatch):

--- a/tests/test_app_controller_driver_subscribers.py
+++ b/tests/test_app_controller_driver_subscribers.py
@@ -58,6 +58,10 @@ class FakeSoulHandler(DriverAware):
     def switch_to_app(self):
         self.switch_to_app_called = True
 
+    @property
+    def key_actions(self):
+        return self
+
 
 def controller_without_init(driver=None):
     controller = AppController.__new__(AppController)

--- a/tests/test_app_handler_ui_delegates.py
+++ b/tests/test_app_handler_ui_delegates.py
@@ -1,69 +1,22 @@
 from ushareiplay.core.app_handler import AppHandler
-from ushareiplay.core.ui import ElementFinder, GestureHandler, KeyActions, Navigator
+from ushareiplay.core.ui import ElementFinder, GestureHandler, KeyActions, Navigator, UIActions
 
 
-class RecordingHelper:
-    def __init__(self):
-        self.calls = []
-
-    def __getattr__(self, name):
-        def method(*args, **kwargs):
-            self.calls.append((name, args, kwargs))
-            return name, args, kwargs
-
-        return method
-
-
-def test_app_handler_delegates_ui_helper_methods():
+def test_app_handler_exposes_components_without_ui_delegate_methods():
     handler = object.__new__(AppHandler)
-    handler.element_finder = RecordingHelper()
-    handler.key_actions = RecordingHelper()
-    handler.gesture_handler = RecordingHelper()
-    handler.navigator = RecordingHelper()
+    handler.element_finder = object()
+    handler.key_actions = object()
+    handler.gesture_handler = object()
+    handler.navigator = object()
+    handler.ui_actions = object()
 
-    cases = [
-        ("element_finder", "wait_for_element", ("search_box",), {"timeout": 3}, ("wait_for_element", ("search_box",), {"timeout": 3})),
-        ("element_finder", "wait_for_element", ("search_box",), {}, ("wait_for_element", ("search_box",), {"timeout": 10})),
-        ("element_finder", "is_element_clickable", ("element",), {}, ("is_element_clickable", ("element",), {})),
-        ("element_finder", "wait_for_element_clickable", ("search_box",), {}, ("wait_for_element_clickable", ("search_box",), {"timeout": 10})),
-        ("element_finder", "try_find_element", ("search_box",), {"log": True}, ("try_find_element", ("search_box",), {"log": True, "clickable": False})),
-        ("element_finder", "try_find_element", ("search_box",), {}, ("try_find_element", ("search_box",), {"log": False, "clickable": False})),
-        ("element_finder", "wait_for_element_polling", ("id", "value"), {}, ("wait_for_element_polling", ("id", "value"), {"timeout": 10, "poll_frequency": 0.5})),
-        ("element_finder", "wait_for_element_clickable_polling", ("id", "value"), {}, ("wait_for_element_clickable_polling", ("id", "value"), {"timeout": 10, "poll_frequency": 0.5})),
-        ("element_finder", "find_child_element", ("parent", "child"), {}, ("find_child_element", ("parent", "child"), {"log_failure": True})),
-        ("element_finder", "find_child_element", ("parent", "child"), {"log_failure": False}, ("find_child_element", ("parent", "child"), {"log_failure": False})),
-        ("element_finder", "find_child_elements", ("parent", "child"), {}, ("find_child_elements", ("parent", "child"), {})),
-        ("element_finder", "get_element_text", ("element",), {}, ("get_element_text", ("element",), {})),
-        ("element_finder", "try_get_attribute", ("element", "text"), {}, ("try_get_attribute", ("element", "text"), {})),
-        ("element_finder", "_get_locator", ("search_box",), {}, ("_get_locator", ("search_box",), {})),
-        ("element_finder", "find_elements", ("search_box",), {}, ("find_elements", ("search_box",), {})),
-        ("element_finder", "find_child_element", ("parent", "child"), {}, ("find_child_element", ("parent", "child"), {"log_failure": True})),
-        ("element_finder", "find_child_elements", ("parent", "child"), {}, ("find_child_elements", ("parent", "child"), {})),
-        ("element_finder", "wait_for_any_element", (["a", "b"],), {}, ("wait_for_any_element", (["a", "b"],), {"timeout": 10})),
-        ("element_finder", "try_find_any_element", (["a", "b"],), {}, ("try_find_any_element", (["a", "b"],), {})),
-        ("key_actions", "switch_to_app", (), {}, ("switch_to_app", (), {})),
-        ("key_actions", "close_app", (), {}, ("close_app", (), {})),
-        ("key_actions", "switch_to_activity", ("Activity",), {}, ("switch_to_activity", ("Activity",), {})),
-        ("key_actions", "press_enter", ("element",), {}, ("press_enter", ("element",), {})),
-        ("key_actions", "press_back", (), {}, ("press_back", (), {})),
-        ("key_actions", "press_dpad_down", (), {}, ("press_dpad_down", (), {})),
-        ("key_actions", "press_volume_up", (), {}, ("press_volume_up", (), {})),
-        ("key_actions", "press_volume_down", (), {}, ("press_volume_down", (), {})),
-        ("key_actions", "press_right_key", (), {"times": 2}, ("press_right_key", (), {"times": 2})),
-        ("key_actions", "set_clipboard_text", ("hello",), {}, ("set_clipboard_text", ("hello",), {})),
-        ("key_actions", "paste_text", (), {}, ("paste_text", (), {})),
-        ("gesture_handler", "click_element_at", ("element",), {"x_ratio": 0.2}, ("click_element_at", ("element",), {"x_ratio": 0.2, "y_ratio": 0.5, "x_offset": 0, "y_offset": 0})),
-        ("gesture_handler", "_perform_swipe", (1, 2, 3, 4), {}, ("_perform_swipe", (1, 2, 3, 4), {"duration_ms": 300})),
-        ("gesture_handler", "_reversed_if_needed", ([1, 2], "down"), {}, ("_reversed_if_needed", ([1, 2], "down"), {})),
-        ("gesture_handler", "scroll_container_until_element", ("item", "container"), {}, ("scroll_container_until_element", ("item", "container"), {"direction": "up", "attribute_name": None, "attribute_value": None, "max_swipes": 10})),
-        ("navigator", "navigate_to_element", ("target",), {"max_attempts": 1}, ("navigate_to_element", ("target",), {"interference_keys": None, "home_key": "home_nav", "back_keys": None, "max_attempts": 1})),
-    ]
+    for attribute in (
+            "element_finder", "key_actions", "gesture_handler", "navigator", "ui_actions"
+    ):
+        assert getattr(handler, attribute) is not None
 
-    for helper_name, method_name, args, kwargs, expected_call in cases:
-        result = getattr(handler, method_name)(*args, **kwargs)
-        assert result == expected_call
-        helper = getattr(handler, helper_name)
-        assert helper.calls[-1] == expected_call
+    for method in ("wait_for_element", "switch_to_app", "click_element_at", "navigate_to_element"):
+        assert not hasattr(handler, method)
 
 
 def test_ui_helper_methods_keep_driver_recovery_wrappers():

--- a/tests/test_command_execution_interface.py
+++ b/tests/test_command_execution_interface.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from collections import deque
+from types import SimpleNamespace
 
 from ushareiplay.managers.command_manager import CommandManager
 from ushareiplay.models.message_info import MessageInfo
@@ -15,6 +16,7 @@ class _FakeHandler:
         self.sent = []
         self.logger = logging.getLogger("test_command_execution_interface")
         self.config = {"logging": {"directory": "logs"}}
+        self.key_actions = SimpleNamespace(switch_to_app=lambda: True)
 
     def send_message(self, message):
         self.sent.append(message)

--- a/tests/test_event_manager_runtime_context.py
+++ b/tests/test_event_manager_runtime_context.py
@@ -46,6 +46,10 @@ class FakeHandler:
         self.press_back_calls += 1
         return True
 
+    @property
+    def key_actions(self):
+        return self
+
 
 class FakeRuntime:
     def __init__(self, busy):
@@ -107,8 +111,8 @@ def test_event_manager_skips_auto_back_when_runtime_ui_busy():
 
     assert triggered == 0
     assert runtime.calls == 1
-    assert manager.handler.switch_to_app_calls == 0
-    assert manager.handler.press_back_calls == 0
+    assert manager.handler.key_actions.switch_to_app_calls == 0
+    assert manager.handler.key_actions.press_back_calls == 0
     assert manager._consecutive_unknown_pages == 0
 
 
@@ -120,8 +124,8 @@ def test_event_manager_switches_to_app_and_presses_back_when_runtime_ui_not_busy
 
     assert triggered == 0
     assert runtime.calls == 1
-    assert manager.handler.switch_to_app_calls >= 1
-    assert manager.handler.press_back_calls == 1
+    assert manager.handler.key_actions.switch_to_app_calls >= 1
+    assert manager.handler.key_actions.press_back_calls == 1
     assert manager._consecutive_unknown_pages == 1
 
 

--- a/tests/test_event_processing_interface.py
+++ b/tests/test_event_processing_interface.py
@@ -55,6 +55,7 @@ def make_event_manager(config=None):
             },
         },
     )
+    manager._handler.key_actions = SimpleNamespace(switch_to_app=lambda: True, press_back=lambda: True)
     manager._logger = manager._handler.logger
     manager._config = manager._handler.config
     manager._runtime = SimpleNamespace(is_ui_busy=lambda: False)
@@ -179,10 +180,10 @@ def test_process_current_screen_reports_ui_busy_suppressed_recovery(monkeypatch)
 
     manager._process_events_once = fake_process_once
     manager._wait_page_source_ready_async = fail_wait_ready
-    manager.handler.switch_to_app = lambda: (_ for _ in ()).throw(
+    manager.handler.key_actions.switch_to_app = lambda: (_ for _ in ()).throw(
         AssertionError("should not switch app while ui is busy")
     )
-    manager.handler.press_back = lambda: (_ for _ in ()).throw(
+    manager.handler.key_actions.press_back = lambda: (_ for _ in ()).throw(
         AssertionError("should not press back while ui is busy")
     )
 
@@ -222,8 +223,8 @@ def test_process_current_screen_reports_unknown_page_recovery_actions(monkeypatc
 
     manager._process_events_once = fake_process_once
     manager._wait_page_source_ready_async = fake_wait_ready
-    manager.handler.switch_to_app = lambda: switch_calls.append(True)
-    manager.handler.press_back = lambda: pressed_back.append(True)
+    manager.handler.key_actions.switch_to_app = lambda: switch_calls.append(True)
+    manager.handler.key_actions.press_back = lambda: pressed_back.append(True)
     monkeypatch.setattr("ushareiplay.managers.event_manager.asyncio.sleep", fake_sleep)
 
     outcome = asyncio.run(manager.react_to_page("<initial />"))
@@ -259,8 +260,8 @@ def test_react_to_page_reports_second_pass_trigger_count_when_ready_recheck_hand
 
     manager._process_events_once = fake_process_once
     manager._wait_page_source_ready_async = fake_wait_ready
-    manager.handler.switch_to_app = lambda: switch_calls.append(True)
-    manager.handler.press_back = lambda: (_ for _ in ()).throw(
+    manager.handler.key_actions.switch_to_app = lambda: switch_calls.append(True)
+    manager.handler.key_actions.press_back = lambda: (_ for _ in ()).throw(
         AssertionError("should not press back when ready recheck already handled an event")
     )
 

--- a/tests/test_fav_filter_stale_option.py
+++ b/tests/test_fav_filter_stale_option.py
@@ -68,6 +68,10 @@ class FakeHandler:
         assert key == "filter_favourite"
         return self.filter
 
+    @property
+    def element_finder(self):
+        return self
+
 
 class FakeController:
     def __init__(self):

--- a/tests/test_gesture_handler.py
+++ b/tests/test_gesture_handler.py
@@ -107,7 +107,7 @@ def test_perform_swipe_uses_driver_swipe():
         SimpleNamespace(driver=driver, logger=FakeLogger(), config={})
     )
 
-    assert handler._perform_swipe(10, 20, 30, 40, duration_ms=250) is True
+    assert handler.swipe(10, 20, 30, 40, duration_ms=250) is True
     assert driver.swipes == [(10, 20, 30, 40, 250)]
 
 

--- a/tests/test_gesture_handler.py
+++ b/tests/test_gesture_handler.py
@@ -115,13 +115,12 @@ def test_scroll_container_uses_deliberate_swipe_duration():
     driver = MagicMock()
     driver.page_source = "<page />"
     handler = _make_handler(driver)
-    handler.wait_for_element_clickable = MagicMock(
-        return_value=SimpleNamespace(
+    handler.owner.element_finder = MagicMock()
+    handler.owner.element_finder.wait_for_element_clickable.return_value = SimpleNamespace(
             location={"x": 0, "y": 0},
             size={"width": 100, "height": 100},
-        )
     )
-    handler.find_child_element = MagicMock(return_value=None)
+    handler.owner.element_finder.find_child_element.return_value = None
     handler._perform_swipe = MagicMock(return_value=False)
 
     handler.scroll_container_until_element("message_content", "message_list")

--- a/tests/test_party_manager_create_mode.py
+++ b/tests/test_party_manager_create_mode.py
@@ -41,6 +41,10 @@ class _Handler:
             return _Element()
         return None
 
+    @property
+    def element_finder(self):
+        return self
+
 
 def test_party_create_mode_restore_clicks_restore_only():
     manager = PartyManager.instance()

--- a/tests/test_party_manager_end_party.py
+++ b/tests/test_party_manager_end_party.py
@@ -46,6 +46,14 @@ class _MockHandler:
     def wait_for_element_clickable(self, key):
         return self.elements.get(key)
 
+    @property
+    def element_finder(self):
+        return self
+
+    @property
+    def key_actions(self):
+        return self
+
 
 def test_end_party_direct_success():
     manager = PartyManager.instance()

--- a/tests/test_playlist_playback_warning.py
+++ b/tests/test_playlist_playback_warning.py
@@ -56,6 +56,10 @@ class _MusicHandler:
     def get_playlist_info(self):
         return {"error": "No songs found in playlist"}
 
+    @property
+    def element_finder(self):
+        return self
+
 
 class _TitleManager:
     def __init__(self):

--- a/tests/test_private_reply_sender.py
+++ b/tests/test_private_reply_sender.py
@@ -20,14 +20,14 @@ def test_send_private_message_to_user_success_path():
     send_btn = MagicMock()
     room_back = MagicMock()
 
-    manager.handler.wait_for_element_clickable.side_effect = [
+    manager.handler.element_finder.wait_for_element_clickable.side_effect = [
         avatar,
         private_btn,
         input_box,
         send_btn,
     ]
-    manager.handler.wait_for_any_element.return_value = ("private_room_entry", room_back)
-    manager.handler.click_element_at.return_value = True
+    manager.handler.element_finder.wait_for_any_element.return_value = ("private_room_entry", room_back)
+    manager.handler.gesture_handler.click_element_at.return_value = True
 
     ok = manager.send_private_message_to_user("Alice", "hello")
 
@@ -35,14 +35,14 @@ def test_send_private_message_to_user_success_path():
     manager.open_user_profile_from_online_list.assert_called_once_with("Alice")
     input_box.send_keys.assert_called_once_with("hello")
     avatar.click.assert_not_called()
-    manager.handler.click_element_at.assert_called_once_with(avatar, y_ratio=0.7)
+    manager.handler.gesture_handler.click_element_at.assert_called_once_with(avatar, y_ratio=0.7)
     private_btn.click.assert_called_once()
     send_btn.click.assert_called_once()
     room_back.click.assert_called_once()
-    manager.handler.wait_for_element_clickable.assert_any_call(
+    manager.handler.element_finder.wait_for_element_clickable.assert_any_call(
         'sender_avatar', timeout=5
     )
-    manager.handler.wait_for_any_element.assert_called_once_with(
+    manager.handler.element_finder.wait_for_any_element.assert_called_once_with(
         ['private_room_entry', 'floating_entry', 'item_left_back'], timeout=3
     )
 
@@ -57,19 +57,19 @@ def test_send_private_message_to_user_fallback_to_floating_entry():
     send_btn = MagicMock()
     floating_entry = MagicMock()
 
-    manager.handler.wait_for_element_clickable.side_effect = [
+    manager.handler.element_finder.wait_for_element_clickable.side_effect = [
         avatar,
         private_btn,
         input_box,
         send_btn,
     ]
-    manager.handler.wait_for_any_element.return_value = ("floating_entry", floating_entry)
-    manager.handler.click_element_at.return_value = True
+    manager.handler.element_finder.wait_for_any_element.return_value = ("floating_entry", floating_entry)
+    manager.handler.gesture_handler.click_element_at.return_value = True
 
     ok = manager.send_private_message_to_user("Bob", "hi")
 
     assert ok is True
-    manager.handler.wait_for_any_element.assert_called_once_with(
+    manager.handler.element_finder.wait_for_any_element.assert_called_once_with(
         ['private_room_entry', 'floating_entry', 'item_left_back'], timeout=3
     )
     floating_entry.click.assert_called_once()
@@ -85,20 +85,20 @@ def test_send_private_message_to_user_fallback_to_left_back_and_titlebar_back():
     send_btn = MagicMock()
     titlebar_back = MagicMock()
 
-    manager.handler.wait_for_element_clickable.side_effect = [
+    manager.handler.element_finder.wait_for_element_clickable.side_effect = [
         avatar,
         private_btn,
         input_box,
         send_btn,
         titlebar_back,
     ]
-    manager.handler.wait_for_any_element.return_value = ("item_left_back", MagicMock())
-    manager.handler.click_element_at.return_value = True
+    manager.handler.element_finder.wait_for_any_element.return_value = ("item_left_back", MagicMock())
+    manager.handler.gesture_handler.click_element_at.return_value = True
 
     ok = manager.send_private_message_to_user("Eve", "hi")
 
     assert ok is True
-    manager.handler.wait_for_any_element.assert_called_once_with(
+    manager.handler.element_finder.wait_for_any_element.assert_called_once_with(
         ['private_room_entry', 'floating_entry', 'item_left_back'], timeout=3
     )
     titlebar_back.click.assert_called_once()
@@ -109,17 +109,17 @@ def test_send_private_message_to_user_failure_returns_false():
     manager.open_user_profile_from_online_list = MagicMock(return_value={})
 
     avatar = MagicMock()
-    manager.handler.wait_for_element_clickable.side_effect = [
+    manager.handler.element_finder.wait_for_element_clickable.side_effect = [
         avatar,
         None,
     ]
-    manager.handler.click_element_at.return_value = True
+    manager.handler.gesture_handler.click_element_at.return_value = True
 
     ok = manager.send_private_message_to_user("Carol", "hey")
 
     assert ok is False
     avatar.click.assert_not_called()
-    manager.handler.click_element_at.assert_called_once_with(avatar, y_ratio=0.7)
+    manager.handler.gesture_handler.click_element_at.assert_called_once_with(avatar, y_ratio=0.7)
     manager.logger.warning.assert_called()
 
 
@@ -128,11 +128,11 @@ def test_send_private_message_to_user_returns_false_when_avatar_offset_click_fai
     manager.open_user_profile_from_online_list = MagicMock(return_value={})
 
     avatar = MagicMock()
-    manager.handler.wait_for_element_clickable.return_value = avatar
-    manager.handler.click_element_at.return_value = False
+    manager.handler.element_finder.wait_for_element_clickable.return_value = avatar
+    manager.handler.gesture_handler.click_element_at.return_value = False
 
     ok = manager.send_private_message_to_user("Dana", "hey")
 
     assert ok is False
-    manager.handler.click_element_at.assert_called_once_with(avatar, y_ratio=0.7)
+    manager.handler.gesture_handler.click_element_at.assert_called_once_with(avatar, y_ratio=0.7)
     manager.logger.warning.assert_called()

--- a/tests/test_qq_music_playlist_info.py
+++ b/tests/test_qq_music_playlist_info.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from ushareiplay.handlers.qq_music_handler import QQMusicHandler
 
 
@@ -44,7 +46,8 @@ def _playlist_item(song, singer):
 def test_get_current_playing_treats_missing_playback_nodes_as_optional():
     handler = QQMusicHandler.__new__(QQMusicHandler)
     handler.logger = _Logger()
-    handler.try_find_element = lambda key: None
+    handler.element_finder = SimpleNamespace()
+    handler.element_finder.try_find_element = lambda key: None
 
     result = handler.get_current_playing()
 
@@ -57,15 +60,20 @@ def _make_handler(monkeypatch, visible_items, current_song, updated_items=None, 
     handler.logger = _Logger()
     handler.play_mode_key = "unknown"
     handler.driver = _Driver()
+    handler.element_finder = SimpleNamespace()
+    handler.key_actions = SimpleNamespace()
+    handler.gesture_handler = SimpleNamespace(
+        swipe=lambda *args: handler.driver.swipe(*args)
+    )
     handler.playlist_entry = _Element("entry")
     handler.playlist_current_queries = 0
-    handler.find_elements_calls = 0
+    handler.element_finder.find_elements_calls = 0
 
-    monkeypatch.setattr(handler, "switch_to_app", lambda: True)
-    monkeypatch.setattr(handler, "press_back", lambda: None)
+    handler.key_actions.switch_to_app = lambda: True
+    handler.key_actions.press_back = lambda: None
     monkeypatch.setattr(handler, "get_current_playing", lambda: {"song": current_song})
-    monkeypatch.setattr(handler, "wait_for_element_clickable", lambda key: handler.playlist_entry)
-    monkeypatch.setattr(handler, "try_find_any_element", lambda keys: (None, None))
+    handler.element_finder.wait_for_element_clickable = lambda key: handler.playlist_entry
+    handler.element_finder.try_find_any_element = lambda keys: (None, None)
 
     def try_find_element(key):
         if key == "playlist_entry":
@@ -79,13 +87,13 @@ def _make_handler(monkeypatch, visible_items, current_song, updated_items=None, 
 
     def find_elements(key):
         assert key == "playlist_item_container"
-        handler.find_elements_calls += 1
-        if handler.find_elements_calls == 1 or updated_items is None:
+        handler.element_finder.find_elements_calls += 1
+        if handler.element_finder.find_elements_calls == 1 or updated_items is None:
             return visible_items
         return updated_items
 
-    monkeypatch.setattr(handler, "try_find_element", try_find_element)
-    monkeypatch.setattr(handler, "find_elements", find_elements)
+    handler.element_finder.try_find_element = try_find_element
+    handler.element_finder.find_elements = find_elements
     return handler
 
 
@@ -105,7 +113,7 @@ def test_get_playlist_info_returns_initial_list_when_current_marker_is_absent(mo
     assert result == {"playlist": "第一首 - 歌手A\n第二首 - 歌手B"}
     assert handler.playlist_current_queries == 1
     assert handler.driver.swipes == []
-    assert handler.find_elements_calls == 1
+    assert handler.element_finder.find_elements_calls == 1
 
 
 def test_get_playlist_info_scrolls_when_marker_exists_but_current_title_is_not_visible(monkeypatch):
@@ -127,7 +135,7 @@ def test_get_playlist_info_scrolls_when_marker_exists_but_current_title_is_not_v
     assert result == {"playlist": "当前歌 - 歌手C\n第一首 - 歌手A"}
     assert handler.playlist_current_queries == 1
     assert handler.driver.swipes == [(50, 320, 50, 0, 1000)]
-    assert handler.find_elements_calls == 2
+    assert handler.element_finder.find_elements_calls == 2
 
 
 def test_get_playlist_info_scrolls_and_updates_playlist_when_current_title_visible(monkeypatch):
@@ -149,4 +157,4 @@ def test_get_playlist_info_scrolls_and_updates_playlist_when_current_title_visib
     assert result == {"playlist": "上一首 - 歌手Z\n当前歌 - 歌手A"}
     assert handler.playlist_current_queries == 1
     assert handler.driver.swipes == [(50, 320, 50, 0, 1000)]
-    assert handler.find_elements_calls == 2
+    assert handler.element_finder.find_elements_calls == 2

--- a/tests/test_radio_old_song_filter.py
+++ b/tests/test_radio_old_song_filter.py
@@ -100,6 +100,13 @@ class _MusicHandler:
     def get_playlist_info(self):
         return {"playlist": self.playlists.pop(0)}
 
+    @property
+    def element_finder(self):
+        return self
+
+    @property
+    def key_actions(self):
+        return self
 
 class _SoulHandler:
     def __init__(self):
@@ -114,6 +121,14 @@ class _SoulHandler:
     def try_get_attribute(self, element, attribute):
         assert attribute == "content-desc"
         return element.content_desc
+
+    @property
+    def element_finder(self):
+        return self
+
+    @property
+    def key_actions(self):
+        return self
 
 
 class _TitleManager:
@@ -321,6 +336,10 @@ class _PlayMusicHandler:
     def wait_for_element_clickable(self, key):
         assert key == "result_item"
         return self.result_item
+
+    @property
+    def element_finder(self):
+        return self
 
     def ensure_favorited_in_playing_page(self, timeout=10):
         assert timeout == 10

--- a/tests/test_recovery_manager.py
+++ b/tests/test_recovery_manager.py
@@ -22,6 +22,14 @@ class FakeHandler:
         self.drawer_element = SimpleNamespace(is_displayed=lambda: True)
         self.room_element = object()
         self.press_back = MagicMock()
+        self.element_finder = SimpleNamespace(
+            wait_for_element_clickable=self.wait_for_element_clickable,
+            try_find_element=self.try_find_element,
+            wait_for_element=self.wait_for_element,
+        )
+        self.key_actions = SimpleNamespace(press_back=self.press_back)
+        self.ui_actions = SimpleNamespace(perform_click=self.click_element_at)
+        self.gesture_handler = SimpleNamespace(click_element_at=self.click_element_at)
 
     def wait_for_element_clickable(self, key):
         if key == "input_drawer" and self.clicks >= self.close_after_clicks:
@@ -54,7 +62,7 @@ def test_close_drawer_succeeds_after_second_tap(monkeypatch):
 
     assert manager.close_drawer("input_drawer") is True
     assert handler.clicks == 2
-    handler.press_back.assert_not_called()
+    handler.key_actions.press_back.assert_not_called()
 
 
 def test_close_drawer_does_not_treat_room_id_as_success_when_drawer_remains(monkeypatch):
@@ -63,7 +71,7 @@ def test_close_drawer_does_not_treat_room_id_as_success_when_drawer_remains(monk
 
     assert manager.close_drawer("input_drawer") is False
     assert handler.clicks == 2
-    handler.press_back.assert_not_called()
+    handler.key_actions.press_back.assert_not_called()
 
 
 def test_close_drawer_succeeds_after_first_tap(monkeypatch):

--- a/tests/test_runtime_queue_pipeline.py
+++ b/tests/test_runtime_queue_pipeline.py
@@ -1,10 +1,18 @@
 import asyncio
+from types import SimpleNamespace
 import logging
 from collections import deque
 
 
 def _run(coro):
     return asyncio.run(coro)
+
+
+def _with_ui_components(handler):
+    handler.key_actions = handler
+    handler.gesture_handler = handler
+    handler.element_finder = handler
+    return handler
 
 
 class _FakeObs:
@@ -233,7 +241,7 @@ def test_process_new_messages_accepts_dollar_prefix_and_keeps_content():
         fake_command_manager = _FakeCommandManager()
         CommandManager.instance = classmethod(lambda cls: fake_command_manager)
         manager = object.__new__(MessageManager)
-        manager._handler = _FakeSoulHandler()
+        manager._handler = _with_ui_components(_FakeSoulHandler())
         manager._chat_logger = logging.getLogger("test_chat_logger_new")
         manager.recent_chats = deque(maxlen=3)
         manager.latest_chats = deque(maxlen=3)
@@ -266,7 +274,7 @@ def test_process_new_messages_accepts_fullwidth_dollar_prefix_and_keeps_content(
         fake_command_manager = _FakeCommandManager()
         CommandManager.instance = classmethod(lambda cls: fake_command_manager)
         manager = object.__new__(MessageManager)
-        manager._handler = _FakeSoulHandler()
+        manager._handler = _with_ui_components(_FakeSoulHandler())
         manager._chat_logger = logging.getLogger("test_chat_logger_new_fullwidth")
         manager.recent_chats = deque(maxlen=3)
         manager.latest_chats = deque(maxlen=3)
@@ -299,7 +307,7 @@ def test_process_new_messages_skips_non_command_and_keeps_following_dollar_comma
         fake_command_manager = _FakeCommandManager()
         CommandManager.instance = classmethod(lambda cls: fake_command_manager)
         manager = object.__new__(MessageManager)
-        manager._handler = _FakeSoulHandler()
+        manager._handler = _with_ui_components(_FakeSoulHandler())
         manager._chat_logger = logging.getLogger("test_chat_logger_new_mixed")
         manager.recent_chats = deque(maxlen=3)
         manager.latest_chats = deque(maxlen=3)
@@ -332,7 +340,7 @@ def test_process_new_messages_accepts_ascii_colon_in_chat_prefix():
         fake_command_manager = _FakeCommandManager()
         CommandManager.instance = classmethod(lambda cls: fake_command_manager)
         manager = object.__new__(MessageManager)
-        manager._handler = _FakeSoulHandler()
+        manager._handler = _with_ui_components(_FakeSoulHandler())
         manager._chat_logger = logging.getLogger("test_chat_logger_ascii_colon")
         manager.recent_chats = deque(maxlen=3)
         manager.latest_chats = deque(maxlen=3)
@@ -370,7 +378,7 @@ def test_process_missed_messages_accepts_dollar_prefix_and_queues_command():
             return None
 
     manager = object.__new__(MessageManager)
-    manager._handler = _FakeSoulHandler()
+    manager._handler = _with_ui_components(_FakeSoulHandler())
     manager._chat_logger = logging.getLogger("test_chat_logger_missed")
     manager._recovery_manager = None
     manager.recent_chats = deque(maxlen=3)
@@ -408,7 +416,7 @@ def test_process_missed_messages_sends_empty_message_after_finding_anchor():
         def send_message(self, message):
             self.sent_messages.append(message)
 
-    handler = _FakeSoulHandler()
+    handler = _with_ui_components(_FakeSoulHandler())
     manager = object.__new__(MessageManager)
     manager._handler = handler
     manager._chat_logger = logging.getLogger("test_chat_logger_missed_anchor")

--- a/tests/test_seat_check.py
+++ b/tests/test_seat_check.py
@@ -35,13 +35,17 @@ class DummyHandler:
             return object()
         return None
 
+    @property
+    def element_finder(self):
+        return self
+
 
 class DummySeatUI:
     def __init__(self, handler):
         self.handler = handler
 
     async def expand_and_find_desks(self):
-        seat_desks = self.handler.find_elements("seat_desk")
+        seat_desks = self.handler.element_finder.find_elements("seat_desk")
         if len(seat_desks) != 6:
             self.handler.log_error(
                 f"seat expansion incomplete: found {len(seat_desks)} desks, expected 6"

--- a/tests/test_seat_management_interface.py
+++ b/tests/test_seat_management_interface.py
@@ -110,9 +110,9 @@ async def test_message_manager_prepares_chat_scan_through_seat_management(monkey
     seat_management = _FakeSeatManagement()
     manager = object.__new__(MessageManager)
     manager._handler = SimpleNamespace(
-        switch_to_app=lambda: True,
         logger=SimpleNamespace(error=lambda message: None, critical=lambda message: None),
     )
+    manager._handler.key_actions = SimpleNamespace(switch_to_app=lambda: True)
     manager._chat_logger = None
     manager.previous_messages = {}
     manager.recent_chats = deque(maxlen=3)

--- a/tests/test_seat_off_command.py
+++ b/tests/test_seat_off_command.py
@@ -84,13 +84,21 @@ class DummyHandler:
     def log_error(self, message):
         self.logger.error(message)
 
+    @property
+    def element_finder(self):
+        return self
+
+    @property
+    def key_actions(self):
+        return self
+
 
 class DummySeatUI:
     def __init__(self, handler):
         self.handler = handler
 
     async def expand_and_find_desks(self):
-        return self.handler.find_elements("seat_desk")
+        return self.handler.element_finder.find_elements("seat_desk")
 
     def scroll_to_row(self, desk_index, seat_desks, duration=100):
         pass

--- a/tests/test_ui_actions.py
+++ b/tests/test_ui_actions.py
@@ -1,0 +1,48 @@
+from unittest.mock import Mock
+
+from ushareiplay.core.ui.ui_actions import UIActions
+
+
+def make_owner():
+    owner = Mock()
+    owner.key_actions.switch_to_app.return_value = True
+    owner.element_finder.wait_for_element_clickable.return_value = Mock()
+    owner.gesture_handler.click_element_at.return_value = True
+    return owner
+
+
+def test_switch_and_click_switches_the_owner_app_and_clicks_element():
+    owner = make_owner()
+
+    result = UIActions(owner).switch_and_click(
+        "confirm", error_message="Could not confirm", timeout=3, click_kwargs={"y_ratio": 0.25}
+    )
+
+    assert result == {"success": True}
+    owner.key_actions.switch_to_app.assert_called_once_with()
+    owner.element_finder.wait_for_element_clickable.assert_called_once_with("confirm", timeout=3)
+    owner.gesture_handler.click_element_at.assert_called_once_with(
+        owner.element_finder.wait_for_element_clickable.return_value, y_ratio=0.25
+    )
+
+
+def test_switch_and_click_returns_switch_error_without_finding_an_element():
+    owner = make_owner()
+    owner.key_actions.switch_to_app.return_value = False
+
+    result = UIActions(owner).switch_and_click("confirm", error_message="Could not confirm")
+
+    assert result == {"error": "Failed to switch to app"}
+    owner.element_finder.wait_for_element_clickable.assert_not_called()
+    owner.gesture_handler.click_element_at.assert_not_called()
+
+
+def test_switch_and_click_maps_missing_or_unclickable_elements_to_caller_error():
+    owner = make_owner()
+    owner.element_finder.wait_for_element_clickable.return_value = None
+
+    result = UIActions(owner).switch_and_click("confirm", error_message="Could not confirm")
+
+    assert result == {"error": "Could not confirm"}
+    owner.gesture_handler.click_element_at.assert_not_called()
+

--- a/tests/test_ui_component_boundaries.py
+++ b/tests/test_ui_component_boundaries.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from ushareiplay.core.ui.gesture_handler import GestureHandler
+from ushareiplay.core.ui.navigation import Navigator
+
+
+def test_navigator_uses_explicit_ui_components_after_delegate_removal():
+    target = object()
+    owner = SimpleNamespace(
+        driver=Mock(),
+        config={},
+        logger=Mock(),
+        key_actions=Mock(),
+        element_finder=Mock(),
+        gesture_handler=Mock(),
+    )
+    owner.element_finder.wait_for_any_element.return_value = ("search_box", target)
+    owner.element_finder.try_find_any_element.return_value = (None, None)
+
+    assert Navigator(owner).navigate_to_element("search_box") == ("search_box", target)
+
+    owner.key_actions.press_back.assert_called_once_with()
+    owner.element_finder.wait_for_any_element.assert_called_once()
+
+
+def test_gesture_handler_uses_element_finder_for_container_lookup():
+    container = SimpleNamespace(
+        location={"x": 0, "y": 0}, size={"width": 100, "height": 100}
+    )
+    owner = SimpleNamespace(
+        driver=Mock(page_source="<page />"),
+        config={},
+        logger=Mock(),
+        element_finder=Mock(),
+    )
+    owner.element_finder.wait_for_element_clickable.return_value = container
+    owner.element_finder.find_child_element.return_value = None
+
+    assert GestureHandler(owner).scroll_container_until_element("message", "message_list") == (
+        None, None, []
+    )
+
+    owner.element_finder.wait_for_element_clickable.assert_called_once_with("message_list")


### PR DESCRIPTION
## Summary
- Remove AppHandler UI pass-through methods and expose component APIs directly.
- Add UIActions for shared switch/wait/click behavior and preserve MicManager outcomes.
- Move swipe callers behind GestureHandler.swipe and update affected tests.

## Validation
- uv run pytest -q (305 passed)
- python -m py_compile on changed Python files
- git diff --check