### PR TITLE
[codex] Improve agent E2E skill

### DIFF
--- a/.agents/skills/agent-e2e-test/SKILL.md
+++ b/.agents/skills/agent-e2e-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-e2e-test
-description: Use when the user asks to validate UShareIPlay behavior through the real running service, Android device, Appium session, UI state, command input, timers, database, logs, or runtime artifacts; also use after a change whose risk requires runtime evidence.
+description: Use when validating UShareIPlay through a real local or remote service, shared Android/Appium device, runtime logs, artifacts, timers, database, or UI state; also use after a change whose risk requires runtime evidence.
 license: MIT
 ---
 
@@ -15,6 +15,8 @@ Run a real UShareIPlay workflow and make the pass/fail decision from fresh runti
 - Inject through the console/queue path (`.agent/commands/*.cmd` is the background channel). Do not create a second Appium session or mutate the device UI from the test agent.
 - Treat a live PID, successful file injection, old logs, or a stale screenshot as insufficient evidence.
 - Use structured events first; use logs, DB, page source, and screenshots to answer the test-specific oracle. Read [agent/event_taxonomy.md](../../../agent/event_taxonomy.md).
+- Establish exclusive Device Lease ownership before starting a service. The cleanup unit is the whole E2E Session, including service, runner, toolbelt, and session helpers.
+- When production state matters, collect a remote status/log snapshot before pausing it. A remote pause uses graceful stop; only the user can authorize remote force-stop.
 
 ## Workflow
 
@@ -42,7 +44,17 @@ Before execution, record the current time and latest artifact run. For a reused 
 
 Never promote an old `CommandReady`, log line, screenshot, or artifact to current evidence merely because the process is alive.
 
-### 3. Self-check required capabilities
+### 3. Coordinate the shared device
+
+Treat the Android/Appium target as a shared resource across every local worktree and remote deployment. Before any local start, inspect and clear prior local E2E Sessions, including manually started UShareIPlay processes, then acquire the user-wide Device Lease. The toolbelt reports every cleared PID, group, command, and worktree.
+
+When production behavior, remote logs, a changed remote configuration, or an expired remote-silence proof makes the remote state relevant, run `remote-status` and `remote-logs` before local execution. Pause the discovered remote service with `remote-pause`; if it remains alive, preserve evidence, report the candidate processes, and request approval before `remote-force-stop --confirm`.
+
+Remote setup needs only `agent_e2e.remote.host` and `deploy_path` in the ignored `config.local.yaml`. Read [remote-operations.md](remote-operations.md) whenever remote access, pause, recovery, or logs are in scope.
+
+Completion criterion: the local Device Lease is held, no conflicting local E2E Session remains, and the required remote state is evidenced or explicitly blocked.
+
+### 4. Self-check required capabilities
 
 Run the self-check after the plan and before the real action. Request only the needed capabilities plus shared basics:
 
@@ -55,14 +67,14 @@ Remove categories the plan does not need. A non-zero result, missing config/run 
 
 Completion criterion: every capability named in the plan is available, or the run is explicitly reported blocked with the doctor output.
 
-### 4. Select the lifecycle
+### 5. Select the lifecycle
 
 - `dev`: restart the managed process and start the latest code with `start --scenario dev` (or the equivalent composed runner command).
 - `test`: reuse the managed process only after the freshness and readiness checks above. If it is missing, run `start --scenario test`; if it is alive but unhealthy, run `stop` first and then `start --scenario test` because the toolbelt reuses any live PID.
 
 After starting or reusing, wait for the readiness gate. If it does not arrive, use `request-dump` for a read-only page source/screenshot and stop as blocked; do not inject early.
 
-### 5. Execute and collect evidence
+### 6. Execute and collect evidence
 
 Use the narrowest tool action that exercises the requested behavior:
 
@@ -84,7 +96,7 @@ For command E2E, assert the event chain `queue.enqueue → queue.drain.start →
 
 Completion criterion: each planned assertion has a cited artifact, event, log excerpt, DB result, or UI file from this run.
 
-### 6. Decide and report
+### 7. Decide and report
 
 Pass only when the expected behavior is observed and every required assertion is backed by fresh, causally connected evidence. Report:
 
@@ -92,11 +104,12 @@ Pass only when the expected behavior is observed and every required assertion is
 - readiness state and anchors;
 - assertion results for events, status, logs, DB, and UI as applicable;
 - artifact paths and relevant timestamps/run IDs;
+- Device Lease owner, local sessions cleared, remote status/pause/log snapshot, and any remote recovery state;
 - failures, uncertainty, and the next action.
 
 Report a blocker instead of success when the device/Appium/account/app state, process health, readiness, injection path, artifact freshness, expected behavior, or required evidence is missing. A deadline does not lower the evidence bar.
 
-### 7. Recover or evolve
+### 8. Recover or evolve
 
 If evidence identifies a repo defect, fix it, run focused unit/script checks, then repeat the E2E with a fresh boundary. If the failure is environmental or the expected behavior is underspecified, preserve the evidence and report the blocker.
 
@@ -107,8 +120,14 @@ After a difficult or repeated run, record a reusable gap with `record-gap`. Use 
 ```text
 doctor --needs <csv>                 capability preflight
 process-status                       managed PID and latest artifact run
-start --scenario dev|test            restart or start/reuse service
+cleanup-local                        clear other local E2E sessions for the shared device
+start --scenario dev|test            clear conflicts, acquire lease, then restart or start service
 stop                                 stop managed service
+remote-status                        inspect configured remote deployment (read-only)
+remote-logs                          save redacted recent remote logs as a local artifact
+remote-pause                         gracefully pause the configured remote deployment
+remote-force-stop --confirm          force-stop remote only after user approval
+remote-resume                        restore a deployment paused by this E2E session
 inject --text '...'                  background console/queue input
 request-dump                         current process page source + screenshot
 adb-devices | adb-current            device and focused activity

--- a/.agents/skills/agent-e2e-test/SKILL.md
+++ b/.agents/skills/agent-e2e-test/SKILL.md
@@ -1,163 +1,122 @@
 ---
 name: agent-e2e-test
-description: Use when the user asks to manually or automatically run a real end-to-end test of UShareIPlay behavior through the running app, Android device, logs, DB, artifacts, screenshots, page source, or backend input. This skill is an Agent-led test orchestration workflow, not a fixed command runner.
+description: Use when the user asks to validate UShareIPlay behavior through the real running service, Android device, Appium session, UI state, command input, timers, database, logs, or runtime artifacts; also use after a change whose risk requires runtime evidence.
 license: MIT
 ---
 
 # Agent E2E Test
 
-Use this skill for real runtime validation. The Agent owns the test plan and pass/fail judgment. Scripts are only a toolbelt for deterministic low-level actions.
+Run a real UShareIPlay workflow and make the pass/fail decision from fresh runtime evidence. The Agent owns the oracle and reasoning; scripts only provide deterministic actions.
 
-## Core Rule
+## Hard Rules
 
-Do not call unit tests, static inspection, or `scripts/agent_e2e.py --mode smoke` an end-to-end test. Smoke mode is only a runner self-check and does not start `run.sh` or exercise Android.
+- Unit tests, static inspection, and `scripts/agent_e2e.py --mode smoke` are not E2E. Smoke only self-checks the runner.
+- For command tests, satisfy `CommandReady` before injection. Read [agent/preconditions.md](../../../agent/preconditions.md).
+- Inject through the console/queue path (`.agent/commands/*.cmd` is the background channel). Do not create a second Appium session or mutate the device UI from the test agent.
+- Treat a live PID, successful file injection, old logs, or a stale screenshot as insufficient evidence.
+- Use structured events first; use logs, DB, page source, and screenshots to answer the test-specific oracle. Read [agent/event_taxonomy.md](../../../agent/event_taxonomy.md).
 
 ## Workflow
 
-1. Restate the user's test intent in concrete terms.
-2. Classify the surfaces involved: process, Android/ADB, UI, input/command, DB, logs, timers, recovery, artifacts, or mixed.
-3. Create a short test plan:
-   - preconditions
-   - whether to restart or reuse the service
-   - tool actions to perform
-   - evidence to collect
-   - success criteria
-   - failure/blocker handling
-4. Before executing the plan, run a tool/resource self-check for the actions the plan needs.
-   - Check only required capabilities, plus shared basics.
-   - Prepare directories/files when safe.
-   - Stop with a blocker if required tools, config, permissions, or resources are missing.
-5. Start or reuse the real service:
-   - `dev`: restart managed process and start via `./run.sh`
-   - `test`: reuse a healthy managed process; if missing or unhealthy, start via `./run.sh`
-6. Execute the plan using toolbelt actions.
-7. Read runtime evidence and decide pass/fail with reasoning.
-8. If failing and fixable in repo, fix code and rerun focused checks plus E2E.
-9. If blocked by device/Appium/account/page state/missing evidence, report a blocker with collected evidence.
-10. After each difficult or repetitive test, decide whether the E2E toolbelt or the system's testability should evolve.
+### 1. Define the oracle
 
-## Toolbelt
+Restate the request as one observable behavior. Classify the required surfaces: process, Android/ADB, UI, command/input, DB, logs, timers, recovery, artifacts, or a combination.
 
-Use the bundled toolbelt for atomic operations:
+Write a compact plan containing:
+
+- `trigger`: `manual` for an explicit user request, `auto` for a risk-based validation after tests;
+- `scenario`: `dev` when code/config changed, `test` when validating the current build;
+- preconditions and readiness gate;
+- lifecycle action, input channel, evidence sources, timeout, and pass/fail criteria.
+
+Completion criterion: the plan names the expected result and the evidence that would prove or disprove it.
+
+### 2. Establish a freshness boundary
+
+Before execution, record the current time and latest artifact run. For a reused process, verify all of these are current and connected:
+
+- managed PID is alive and is the intended process;
+- `status.json` and `events.jsonl` are fresh after the boundary or carry the current `run_id`;
+- readiness matches the requested surface, including `CommandReady` anchors and `pipeline.ui_lock == unlocked` for command tests;
+- the background input spool is writable.
+
+Never promote an old `CommandReady`, log line, screenshot, or artifact to current evidence merely because the process is alive.
+
+### 3. Self-check required capabilities
+
+Run the self-check after the plan and before the real action. Request only the needed capabilities plus shared basics:
 
 ```bash
 source .venv/bin/activate
-python .agents/skills/agent-e2e-test/scripts/e2e_toolbelt.py <subcommand> [args]
+python .agents/skills/agent-e2e-test/scripts/e2e_toolbelt.py doctor --needs process,input,adb,db,logs,artifacts
 ```
 
-Common subcommands:
+Remove categories the plan does not need. A non-zero result, missing config/run script, unavailable ADB, unreadable DB, or unwritable input/log/artifact path is a blocker. Resolve it or report it before starting the test.
 
-- `doctor --needs adb,db,logs,artifacts,input,process`: self-check required tools/resources before running the plan.
-- `process-status`: show managed PID, whether alive, latest artifact run.
-- `start --scenario test|dev`: start or restart the real service through `./run.sh`.
-- `stop`: stop the managed process.
-- `inject --text '...'`: write backend input into `.agent/commands/*.cmd`.
-- `adb-devices`: list Android devices through `adb devices`.
-- `adb-current`: show current focused package/activity through `adb shell dumpsys window`.
-- `adb-screenshot --out <png>`: capture a device screenshot through ADB.
-- `adb-logcat --seconds <n> --out <txt>`: capture recent logcat output.
-- `artifacts-latest`: print latest `artifacts/<run_id>` paths.
-- `read-status`: print latest `status.json`.
-- `tail-events --limit <n>`: print recent structured events.
-- `tail-logs --pattern <regex>`: inspect workspace logs.
-- `db-query --sql 'select ...'`: run a SQLite query against `data/soul_bot.db`.
-- `request-dump`: inject `!dump` so the running process exports page source/screenshot using its existing Appium session.
-- `record-gap --kind missing-tool|repeatable-flow|temporary-helper|testability-gap|architecture-upgrade --title '...' --detail '...'`: record a toolbelt or system testability evolution opportunity.
+Completion criterion: every capability named in the plan is available, or the run is explicitly reported blocked with the doctor output.
 
-`scripts/agent_e2e.py` is also available as a low-level runner. Its `--command` argument means “inject this text into the backend input path.” It is not the skill interface and not the whole E2E process.
+### 4. Select the lifecycle
 
-## Evidence Rules
+- `dev`: restart the managed process and start the latest code with `start --scenario dev` (or the equivalent composed runner command).
+- `test`: reuse the managed process only after the freshness and readiness checks above. If it is missing, run `start --scenario test`; if it is alive but unhealthy, run `stop` first and then `start --scenario test` because the toolbelt reuses any live PID.
 
-Prefer evidence from the real runtime:
+After starting or reusing, wait for the readiness gate. If it does not arrive, use `request-dump` for a read-only page source/screenshot and stop as blocked; do not inject early.
 
-- `artifacts/<run_id>/events.jsonl`
-- `artifacts/<run_id>/status.json`
-- `artifacts/<run_id>/page_source.xml`
-- `artifacts/<run_id>/screenshot.png`
-- workspace logs
-- SQLite query results
-- ADB current activity / screenshots / logcat
+### 5. Execute and collect evidence
 
-Static source/config reads can support analysis, but they cannot replace runtime evidence for a manual E2E request.
-
-## Self-Check Rule
-
-After drafting the test plan and before executing it, identify the required tool categories and run `doctor`.
-
-Examples:
+Use the narrowest tool action that exercises the requested behavior:
 
 ```bash
-python .agents/skills/agent-e2e-test/scripts/e2e_toolbelt.py doctor --needs process,adb,artifacts,logs
-python .agents/skills/agent-e2e-test/scripts/e2e_toolbelt.py doctor --needs process,input,db,logs
+python .agents/skills/agent-e2e-test/scripts/e2e_toolbelt.py inject --text ':help'
 ```
 
-If `doctor` reports missing config, unavailable ADB, unreadable DB, missing `run.sh`, unwritable `.agent/commands`, unavailable logs/artifacts paths, or extra authorization/resource needs, resolve or report the blocker before starting the actual test.
+For composed command scenarios, `scripts/agent_e2e.py` may be used with `--scenario dev|test`, `--trigger auto|manual`, and `--command`; do not use its `--mode smoke` as the test.
 
-## Toolbelt And Testability Evolution
+Collect evidence from the same run boundary:
 
-The toolbelt and the system under test must evolve through real collaboration. After drafting or running a test plan, check whether the current tools or the application's architecture made the work slower, weaker, ambiguous, or impossible.
+- `artifacts/<run_id>/events.jsonl` and `status.json`;
+- relevant workspace logs;
+- SQLite queries when the plan includes DB behavior;
+- `page_source.xml` and `screenshot.png`, requested through `!dump` or `request-dump` when UI evidence is required;
+- ADB activity, screenshot, or logcat when the plan requires device evidence.
 
-Use five levels:
+For command E2E, assert the event chain `queue.enqueue → queue.drain.start → command.received → command.dispatch → command.result → queue.drain.end`, correlated to the current run/trace where available. For timers, also assert the relevant timer event or queue entry and the expected DB mutation. Follow the scenario-specific details in [agent/playbooks/command_e2e.md](../../../agent/playbooks/command_e2e.md) or [agent/playbooks/timer_e2e.md](../../../agent/playbooks/timer_e2e.md).
 
-1. **Fill tool gaps**: if a required observation/action cannot be performed with current tools, add or propose a reusable tool.
-2. **Script repeatable flows**: if Agent repeatedly performs the same monitor/collect/compare sequence, promote it into a script while keeping Agent responsible for pass/fail reasoning.
-3. **Temporary targeted helpers**: if one specific test would be inefficient through manual orchestration, create a temporary helper under `.agent/e2e-tools/`; promote it into the skill only if it becomes generally useful.
-4. **Expose testability gaps**: if Agent can observe behavior only through fragile log scraping, screenshots, or timing guesses, record the missing structured state/report/event that would make the system testable.
-5. **Propose architecture upgrades**: if repeated tool calls still cannot prove behavior reliably, propose concrete system changes such as structured intermediate reports, stronger event taxonomy, stable state anchors, explicit health/readiness endpoints, or better DB/log correlation IDs.
+Completion criterion: each planned assertion has a cited artifact, event, log excerpt, DB result, or UI file from this run.
 
-Record discoveries with:
+### 6. Decide and report
 
-```bash
-python .agents/skills/agent-e2e-test/scripts/e2e_toolbelt.py record-gap \
-  --kind testability-gap \
-  --title "Need focused room-entry state report" \
-  --detail "Current tools require fragile manual correlation of ADB activity, status, and logs."
-```
+Pass only when the expected behavior is observed and every required assertion is backed by fresh, causally connected evidence. Report:
 
-When adding durable tools, prefer extending `.agents/skills/agent-e2e-test/scripts/e2e_toolbelt.py` or adding a small script under `.agents/skills/agent-e2e-test/scripts/`. Keep tools business-neutral when possible. If a helper is scenario-specific, mark it temporary first and only promote it after reuse.
+- trigger, scenario, lifecycle action, and injection channel;
+- readiness state and anchors;
+- assertion results for events, status, logs, DB, and UI as applicable;
+- artifact paths and relevant timestamps/run IDs;
+- failures, uncertainty, and the next action.
 
-When proposing architecture upgrades, be specific: name the missing signal, where it should be emitted, how Agent would use it, and what tests it would make possible. Do not keep adding scripts when the real issue is missing system observability or unstable architecture.
+Report a blocker instead of success when the device/Appium/account/app state, process health, readiness, injection path, artifact freshness, expected behavior, or required evidence is missing. A deadline does not lower the evidence bar.
 
-## Blockers
+### 7. Recover or evolve
 
-Stop and report a blocker instead of claiming success if:
+If evidence identifies a repo defect, fix it, run focused unit/script checks, then repeat the E2E with a fresh boundary. If the failure is environmental or the expected behavior is underspecified, preserve the evidence and report the blocker.
 
-- `./run.sh` was not executed and no healthy real process was reused
-- no Android device is connected/responding
-- Appium is unavailable
-- required app package/activity cannot be observed
-- artifacts are missing or stale
-- `CommandReady` or the required UI state is not reached in time
-- page source/screenshot cannot be produced when needed
-- the expected behavior is ambiguous
-- required tool/resource self-check fails
+After a difficult or repeated run, record a reusable gap with `record-gap`. Use `agent/known_issues.md` for deferred failures, `agent/questions.md` for missing user input, or propose an infrastructure change when the missing signal is architectural. Add a tool only when it removes a repeatable observation/action gap; do not script away the Agent's pass/fail judgment.
 
-## Examples
-
-### Command-Like Behavior
-
-For “test Help command output freshness,” command injection is one action in the plan:
+## Toolbelt Quick Reference
 
 ```text
-Plan:
-- start/reuse real service
-- inject ":help"
-- read events/logs/status and runtime output evidence
-- compare observed output against current command capability
-- fix and retest if stale
-```
-
-Do not stop at “the inject script returned ok.” The Agent must inspect evidence.
-
-### Non-Command Behavior
-
-For “test behavior before entering a room,” no command is required:
-
-```text
-Plan:
-- start/reuse real service
-- observe Android current activity
-- read status/events/logs
-- request or inspect screenshot/page_source
-- decide whether pre-room behavior matches the requirement
+doctor --needs <csv>                 capability preflight
+process-status                       managed PID and latest artifact run
+start --scenario dev|test            restart or start/reuse service
+stop                                 stop managed service
+inject --text '...'                  background console/queue input
+request-dump                         current process page source + screenshot
+adb-devices | adb-current            device and focused activity
+adb-screenshot --out <png>           device screenshot
+adb-logcat --seconds <n> --out <txt> recent device logs
+artifacts-latest | read-status       latest run paths/status
+tail-events --limit <n>              structured runtime events
+tail-logs --pattern <regex>          workspace logs
+db-query --sql '...'                 SQLite evidence
+record-gap --kind ...                durable testability feedback
 ```

--- a/.agents/skills/agent-e2e-test/remote-operations.md
+++ b/.agents/skills/agent-e2e-test/remote-operations.md
@@ -1,0 +1,13 @@
+# Remote E2E Operations
+
+Remote access needs only `agent_e2e.remote.host` and `deploy_path` in the ignored `config.local.yaml`. SSH authentication comes from the local SSH agent or `~/.ssh/config`.
+
+## State and logs
+
+Run `remote-status` when production behavior, a stale remote-silence proof, or remote logs make the remote state relevant. `remote-logs` saves a read-only, redacted tail of recent `logs/`, `artifacts/`, and `.agent/` evidence in a local artifact directory.
+
+## Pause and recovery
+
+Before a local run that could contend for the shared device, use `remote-pause`. It discovers UShareIPlay processes rooted at the deployment path and sends `SIGINT`; a successful pause records a local session receipt. When it cannot pause every discovered process, preserve the status and logs, report the PIDs, and ask the user before `remote-force-stop --confirm`.
+
+Restore only a remote service paused by the current E2E session. If automatic discovery cannot prove a safe restart method, leave it paused and report the recovery blocker.

--- a/.agents/skills/agent-e2e-test/scripts/e2e_coordination.py
+++ b/.agents/skills/agent-e2e-test/scripts/e2e_coordination.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import shlex
@@ -202,17 +203,26 @@ def remote_command(target: RemoteTarget, action: str) -> list[str]:
         else shlex.quote(target.deploy_path)
     )
     find_pids = (
-        "find_pids() { ps -eo pid=,args= | awk -v root=\"$PWD\" "
-        "'index($0, root) || /ushareiplay|agent_e2e|e2e_toolbelt|run\\.sh/ {print $1}'; }"
+        "find_processes() { ps -eo pid=,ppid=,pgid=,args= | awk -v root=\"$PWD\" -v self=\"$$\" "
+        "'$1 != self && $2 != self && $4 != \"awk\" && (index($0, root) || /bash \\.\\/run\\.sh$/ || /uv run ushareiplay/) {print $1, $3}'; }; "
+        "find_pids() { find_processes | awk '{print $1}'; }; "
+        "find_pgids() { find_processes | awk '{print $2}' | sort -u; }"
     )
     if action == "status":
         script = f"set -eu; cd -- {root}; {find_pids}; printf 'cwd=%s\\n' \"$PWD\"; find_pids"
     elif action == "pause":
-        script = f"set -eu; cd -- {root}; {find_pids}; pids=$(find_pids); for pid in $pids; do kill -INT \"$pid\" || true; done; sleep 2; remaining=$(find_pids); test -z \"$remaining\" || {{ printf '%s\\n' \"$remaining\"; exit 3; }}"
+        script = f"set -eu; cd -- {root}; {find_pids}; pgids=$(find_pgids); for pgid in $pgids; do kill -INT -- -\"$pgid\" || true; done; for _ in {{1..8}}; do remaining=$(find_pids); test -z \"$remaining\" && exit 0; sleep 1; done; printf '%s\\n' \"$remaining\"; exit 3"
     elif action == "force-stop":
         script = f"set -eu; cd -- {root}; {find_pids}; for pid in $(find_pids); do kill -KILL \"$pid\" || true; done"
     elif action == "resume":
-        script = f"set -eu; cd -- {root}; mkdir -p .agent; nohup bash ./run.sh > .agent/e2e-remote-resume.log 2>&1 & printf 'pid=%s\\n' \"$!\""
+        script = (
+            f"set -eu; cd -- {root}; mkdir -p .agent; "
+            "if command -v uv >/dev/null 2>&1; then "
+            "nohup bash ./run.sh > .agent/e2e-remote-resume.log 2>&1 & "
+            "else test -x ./.venv/bin/ushareiplay; "
+            "nohup ./.venv/bin/ushareiplay > .agent/e2e-remote-resume.log 2>&1 & fi; "
+            "printf 'pid=%s\\n' \"$!\""
+        )
     elif action == "logs":
         script = (
             f"set -eu; cd -- {root}; "
@@ -222,4 +232,5 @@ def remote_command(target: RemoteTarget, action: str) -> list[str]:
         )
     else:
         raise ValueError(f"unknown remote action: {action}")
-    return ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", target.host, script]
+    encoded = base64.b64encode(script.encode("utf-8")).decode("ascii")
+    return ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", target.host, f"echo {encoded} | base64 -d | bash"]

--- a/.agents/skills/agent-e2e-test/scripts/e2e_coordination.py
+++ b/.agents/skills/agent-e2e-test/scripts/e2e_coordination.py
@@ -1,0 +1,225 @@
+"""Shared coordination primitives for the UShareIPlay E2E toolbelt."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import signal
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+LEASE_ROOT = Path.home() / ".ushareiplay" / "device-leases"
+LEASE_TTL_S = 30 * 60
+
+
+@dataclass(frozen=True)
+class RemoteTarget:
+    host: str
+    deploy_path: str
+
+
+class LeaseConflict(RuntimeError):
+    def __init__(self, lease: dict[str, Any]):
+        self.lease = lease
+        super().__init__(f"device lease is held by pid {lease.get('owner_pid')}")
+
+
+def pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def lease_path(device_id: str) -> Path:
+    safe = "".join(ch if ch.isalnum() or ch in ".-_" else "_" for ch in device_id)
+    return LEASE_ROOT / f"{safe}.json"
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else None
+    except Exception:
+        return None
+
+
+def _lease_is_live(lease: dict[str, Any]) -> bool:
+    heartbeat = float(lease.get("heartbeat_at", 0))
+    owner_pid = int(lease.get("owner_pid", lease.get("pid", 0)) or 0)
+    return heartbeat >= time.time() - LEASE_TTL_S and owner_pid > 0 and pid_alive(owner_pid)
+
+
+def acquire_lease(device_id: str, *, session_id: str, worktree: str) -> dict[str, Any]:
+    """Acquire a user-wide device lease, reclaiming only dead or expired owners."""
+    path = lease_path(device_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    previous = _read_json(path)
+    if previous and _lease_is_live(previous):
+        raise LeaseConflict(previous)
+    if previous:
+        path.unlink(missing_ok=True)
+
+    now = time.time()
+    lease = {
+        "device_id": device_id,
+        "session_id": session_id,
+        "owner_pid": os.getpid(),
+        "worktree": worktree,
+        "created_at": now,
+        "heartbeat_at": now,
+    }
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        current = _read_json(path) or {"device_id": device_id}
+        raise LeaseConflict(current) from None
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        json.dump(lease, f, ensure_ascii=False)
+    return lease
+
+
+def release_lease(device_id: str, *, session_id: str) -> bool:
+    path = lease_path(device_id)
+    current = _read_json(path)
+    if not current or current.get("session_id") != session_id:
+        return False
+    path.unlink(missing_ok=True)
+    return True
+
+
+def transfer_lease_owner(device_id: str, *, session_id: str, owner_pid: int) -> dict[str, Any]:
+    """Bind a provisional CLI lease to the long-lived service process."""
+    path = lease_path(device_id)
+    current = _read_json(path)
+    if not current or current.get("session_id") != session_id:
+        raise LeaseConflict(current or {"device_id": device_id})
+    current["owner_pid"] = owner_pid
+    current["heartbeat_at"] = time.time()
+    path.write_text(json.dumps(current, ensure_ascii=False), encoding="utf-8")
+    return current
+
+
+def load_remote_target(config_path: Path) -> RemoteTarget | None:
+    if not config_path.exists():
+        return None
+    try:
+        loaded = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        remote = loaded.get("agent_e2e", {}).get("remote", {})
+        host = remote.get("host")
+        deploy_path = remote.get("deploy_path")
+    except Exception as exc:
+        raise ValueError(f"invalid remote configuration: {exc}") from exc
+    if not host and not deploy_path:
+        return None
+    if not isinstance(host, str) or not isinstance(deploy_path, str) or not host or not deploy_path:
+        raise ValueError("agent_e2e.remote requires non-empty host and deploy_path")
+    return RemoteTarget(host=host, deploy_path=deploy_path)
+
+
+def run_text(args: list[str], *, timeout: float = 10) -> str:
+    result = subprocess.run(args, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout, check=False)
+    return result.stdout
+
+
+def process_cwd(pid: int) -> str | None:
+    try:
+        return os.readlink(f"/proc/{pid}/cwd")
+    except OSError:
+        return None
+
+
+def _process_matches(command: str, cwd: str | None, device_id: str) -> bool:
+    text = f"{command} {cwd or ''}".lower()
+    # The shared Android/Appium target permits only one UShareIPlay service per
+    # machine. A manually started process often omits the device from argv, so
+    # repository identity is the safe, useful discriminator here.
+    return "ushareiplay" in text and ("main.py" in text or "run.sh" in text or "agent_e2e" in text or "e2e_toolbelt" in text)
+
+
+def discover_local_sessions(device_id: str) -> list[dict[str, Any]]:
+    """Find both managed and manually-started E2E process roots for one device."""
+    output = run_text(["ps", "-axo", "pid=,pgid=,lstart=,command="], timeout=5)
+    sessions: list[dict[str, Any]] = []
+    for line in output.splitlines():
+        parts = line.strip().split(None, 8)
+        if len(parts) < 9 or not parts[0].isdigit() or not parts[1].isdigit():
+            continue
+        pid = int(parts[0])
+        if pid in {os.getpid(), os.getppid()}:
+            continue
+        command = parts[8]
+        cwd = process_cwd(pid)
+        if _process_matches(command, cwd, device_id):
+            sessions.append({
+                "kind": "external/orphan",
+                "pid": pid,
+                "pgid": int(parts[1]),
+                "started": " ".join(parts[2:7]),
+                "command": command,
+                "cwd": cwd,
+            })
+    return sessions
+
+
+def terminate_sessions(sessions: list[dict[str, Any]], *, timeout_s: float, force: bool) -> list[dict[str, Any]]:
+    """Stop distinct process groups and optionally escalate after the grace period."""
+    groups = {int(item["pgid"]) for item in sessions if item.get("pgid")}
+    for pgid in groups:
+        try:
+            os.killpg(pgid, signal.SIGINT)
+        except OSError:
+            pass
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        alive = [item for item in sessions if pid_alive(int(item["pid"]))]
+        if not alive:
+            return []
+        time.sleep(0.2)
+    alive = [item for item in sessions if pid_alive(int(item["pid"]))]
+    if force:
+        for pgid in {int(item["pgid"]) for item in alive if item.get("pgid")}:
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except OSError:
+                pass
+    return [item for item in sessions if pid_alive(int(item["pid"]))]
+
+
+def remote_command(target: RemoteTarget, action: str) -> list[str]:
+    """Build a non-interactive SSH action without deployment-manager configuration."""
+    root = (
+        "$HOME/" + shlex.quote(target.deploy_path[2:])
+        if target.deploy_path.startswith("~/")
+        else shlex.quote(target.deploy_path)
+    )
+    find_pids = (
+        "find_pids() { ps -eo pid=,args= | awk -v root=\"$PWD\" "
+        "'index($0, root) || /ushareiplay|agent_e2e|e2e_toolbelt|run\\.sh/ {print $1}'; }"
+    )
+    if action == "status":
+        script = f"set -eu; cd -- {root}; {find_pids}; printf 'cwd=%s\\n' \"$PWD\"; find_pids"
+    elif action == "pause":
+        script = f"set -eu; cd -- {root}; {find_pids}; pids=$(find_pids); for pid in $pids; do kill -INT \"$pid\" || true; done; sleep 2; remaining=$(find_pids); test -z \"$remaining\" || {{ printf '%s\\n' \"$remaining\"; exit 3; }}"
+    elif action == "force-stop":
+        script = f"set -eu; cd -- {root}; {find_pids}; for pid in $(find_pids); do kill -KILL \"$pid\" || true; done"
+    elif action == "resume":
+        script = f"set -eu; cd -- {root}; mkdir -p .agent; nohup bash ./run.sh > .agent/e2e-remote-resume.log 2>&1 & printf 'pid=%s\\n' \"$!\""
+    elif action == "logs":
+        script = (
+            f"set -eu; cd -- {root}; "
+            "find logs artifacts .agent -type f \\( -name '*.log' -o -name 'events.jsonl' -o -name 'status.json' \\) -mmin -30 -print "
+            "| while IFS= read -r file; do printf '==> %s\\n' \"$file\"; "
+            "tail -c 65536 \"$file\" | sed -E 's/((token|password|secret|cookie|authorization)[=:])[[:graph:]]+/\\1REDACTED/Ig'; done"
+        )
+    else:
+        raise ValueError(f"unknown remote action: {action}")
+    return ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", target.host, script]

--- a/.agents/skills/agent-e2e-test/scripts/e2e_coordination.py
+++ b/.agents/skills/agent-e2e-test/scripts/e2e_coordination.py
@@ -211,7 +211,7 @@ def remote_command(target: RemoteTarget, action: str) -> list[str]:
     if action == "status":
         script = f"set -eu; cd -- {root}; {find_pids}; printf 'cwd=%s\\n' \"$PWD\"; find_pids"
     elif action == "pause":
-        script = f"set -eu; cd -- {root}; {find_pids}; pgids=$(find_pgids); for pgid in $pgids; do kill -INT -- -\"$pgid\" || true; done; for _ in {{1..8}}; do remaining=$(find_pids); test -z \"$remaining\" && exit 0; sleep 1; done; printf '%s\\n' \"$remaining\"; exit 3"
+        script = f"set -eu; cd -- {root}; mkdir -p .agent/commands; target=.agent/commands/$(date +%s%N)-remote-stop.cmd; tmp=\"$target.tmp.$$\"; printf '!stop\\n' > \"$tmp\"; mv \"$tmp\" \"$target\"; printf 'queued=%s\\n' \"$target\""
     elif action == "force-stop":
         script = f"set -eu; cd -- {root}; {find_pids}; for pid in $(find_pids); do kill -KILL \"$pid\" || true; done"
     elif action == "resume":

--- a/.agents/skills/agent-e2e-test/scripts/e2e_toolbelt.py
+++ b/.agents/skills/agent-e2e-test/scripts/e2e_toolbelt.py
@@ -16,6 +16,17 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+from e2e_coordination import (
+    LeaseConflict,
+    acquire_lease,
+    discover_local_sessions,
+    load_remote_target,
+    release_lease,
+    remote_command,
+    terminate_sessions,
+    transfer_lease_owner,
+)
+
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 ARTIFACTS_ROOT = REPO_ROOT / "artifacts"
@@ -23,6 +34,8 @@ AGENT_DIR = REPO_ROOT / ".agent"
 PID_FILE = AGENT_DIR / "ushareiplay.pid"
 COMMAND_DIR = AGENT_DIR / "commands"
 EVOLUTION_LOG = AGENT_DIR / "e2e-toolbelt-evolution.jsonl"
+CONFIG_LOCAL = REPO_ROOT / "config.local.yaml"
+REMOTE_SESSION_FILE = AGENT_DIR / "remote-session.json"
 
 
 def _now() -> float:
@@ -31,6 +44,41 @@ def _now() -> float:
 
 def _run(cmd: list[str], *, timeout: float | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, cwd=REPO_ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout)
+
+
+def _device_id(args: argparse.Namespace) -> str:
+    if getattr(args, "device_id", ""):
+        return args.device_id
+    try:
+        import yaml
+
+        for path in (CONFIG_LOCAL, REPO_ROOT / "config.yaml"):
+            if not path.exists():
+                continue
+            config = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            name = config.get("device", {}).get("name")
+            if isinstance(name, str) and name:
+                return name
+    except Exception:
+        pass
+    raise RuntimeError("device id is required: configure device.name or pass --device-id")
+
+
+def _cleanup_local_sessions(args: argparse.Namespace) -> list[dict[str, Any]]:
+    sessions = discover_local_sessions(_device_id(args))
+    if not sessions:
+        return []
+    remaining = terminate_sessions(sessions, timeout_s=args.stop_timeout, force=True)
+    if remaining:
+        raise RuntimeError(f"local E2E sessions remain after cleanup: {json.dumps(remaining, ensure_ascii=False)}")
+    return sessions
+
+
+def _remote_target():
+    target = load_remote_target(CONFIG_LOCAL)
+    if not target:
+        raise RuntimeError("remote configuration missing: add agent_e2e.remote.host and deploy_path to config.local.yaml")
+    return target
 
 
 def _pid_alive(pid: int) -> bool:
@@ -67,6 +115,15 @@ def _managed_pgid() -> int | None:
     except Exception:
         return None
     return None
+
+
+def _managed_session() -> tuple[str | None, str | None]:
+    try:
+        raw = PID_FILE.read_text(encoding="utf-8").strip()
+        obj = json.loads(raw) if raw.startswith("{") else {}
+        return obj.get("session_id"), obj.get("device_id")
+    except Exception:
+        return None, None
 
 
 def _safe_getpgid(pid: int) -> int | None:
@@ -240,7 +297,10 @@ def _stop(timeout_s: float) -> None:
 
 
 def cmd_stop(args: argparse.Namespace) -> int:
+    session_id, device_id = _managed_session()
     _stop(args.timeout)
+    if session_id and device_id:
+        release_lease(device_id, session_id=session_id)
     return cmd_process_status(args)
 
 
@@ -307,13 +367,90 @@ def cmd_stop_all(args: argparse.Namespace) -> int:
 
     return cmd_process_status(args)
 
+
+def cmd_cleanup_local(args: argparse.Namespace) -> int:
+    cleaned = _cleanup_local_sessions(args)
+    print(json.dumps({"device_id": _device_id(args), "cleaned": cleaned}, ensure_ascii=False, indent=2))
+    return 0
+
+
+def _run_remote(action: str) -> subprocess.CompletedProcess[str]:
+    return _run(remote_command(_remote_target(), action), timeout=30)
+
+
+def cmd_remote_status(_: argparse.Namespace) -> int:
+    result = _run_remote("status")
+    print(result.stdout.rstrip())
+    return result.returncode
+
+
+def cmd_remote_pause(_: argparse.Namespace) -> int:
+    result = _run_remote("pause")
+    payload = {
+        "target": _remote_target().host,
+        "deploy_path": _remote_target().deploy_path,
+        "paused_at": datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds"),
+        "pause_output": result.stdout,
+    }
+    if result.returncode == 0:
+        AGENT_DIR.mkdir(parents=True, exist_ok=True)
+        REMOTE_SESSION_FILE.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return result.returncode
+
+
+def cmd_remote_force_stop(args: argparse.Namespace) -> int:
+    if not args.confirm:
+        print("remote force-stop requires --confirm", file=sys.stderr)
+        return 2
+    result = _run_remote("force-stop")
+    print(result.stdout.rstrip())
+    return result.returncode
+
+
+def cmd_remote_resume(_: argparse.Namespace) -> int:
+    if not REMOTE_SESSION_FILE.exists():
+        print("remote resume requires a successful remote-pause from this E2E session", file=sys.stderr)
+        return 2
+    receipt = json.loads(REMOTE_SESSION_FILE.read_text(encoding="utf-8"))
+    target = _remote_target()
+    if receipt.get("target") != target.host or receipt.get("deploy_path") != target.deploy_path:
+        print("remote target changed since pause; refusing automatic resume", file=sys.stderr)
+        return 2
+    result = _run_remote("resume")
+    print(result.stdout.rstrip())
+    if result.returncode == 0:
+        REMOTE_SESSION_FILE.unlink(missing_ok=True)
+    return result.returncode
+
+
+def cmd_remote_logs(args: argparse.Namespace) -> int:
+    result = _run_remote("logs")
+    if result.returncode:
+        print(result.stdout.rstrip(), file=sys.stderr)
+        return result.returncode
+    run_id = datetime.now(timezone.utc).strftime("remote-logs-%Y%m%dT%H%M%SZ")
+    out = ARTIFACTS_ROOT / run_id / "remote-log-files.txt"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(result.stdout, encoding="utf-8")
+    files = [line.removeprefix("==> ") for line in result.stdout.splitlines() if line.startswith("==> ")]
+    print(json.dumps({"remote": _remote_target().host, "captured_at": datetime.now(timezone.utc).isoformat(), "path": str(out), "files": files, "bytes": len(result.stdout.encode("utf-8"))}, ensure_ascii=False, indent=2))
+    return 0
+
 def cmd_start(args: argparse.Namespace) -> int:
     AGENT_DIR.mkdir(parents=True, exist_ok=True)
+    cleaned = _cleanup_local_sessions(args)
+    session_id = uuid.uuid4().hex
+    try:
+        lease = acquire_lease(_device_id(args), session_id=session_id, worktree=str(REPO_ROOT))
+    except LeaseConflict as exc:
+        raise RuntimeError(f"device remains leased after cleanup: {json.dumps(exc.lease, ensure_ascii=False)}") from exc
     pid = _managed_pid()
     if args.scenario == "dev":
         _stop(args.stop_timeout)
     elif pid and _pid_alive(pid):
-        print(json.dumps({"action": "reused", "pid": pid}, ensure_ascii=False))
+        lease = transfer_lease_owner(_device_id(args), session_id=session_id, owner_pid=pid)
+        print(json.dumps({"action": "reused", "pid": pid, "session_id": session_id, "lease": lease, "cleaned": cleaned}, ensure_ascii=False))
         return 0
 
     log_path = AGENT_DIR / "run.log"
@@ -330,8 +467,9 @@ def cmd_start(args: argparse.Namespace) -> int:
         pgid = os.getpgid(proc.pid)
     except Exception:
         pgid = proc.pid
-    PID_FILE.write_text(json.dumps({"pid": proc.pid, "pgid": pgid}, ensure_ascii=False), encoding="utf-8")
-    print(json.dumps({"action": "started", "pid": proc.pid, "log": str(log_path)}, ensure_ascii=False))
+    lease = transfer_lease_owner(_device_id(args), session_id=session_id, owner_pid=proc.pid)
+    PID_FILE.write_text(json.dumps({"pid": proc.pid, "pgid": pgid, "session_id": session_id, "device_id": _device_id(args)}, ensure_ascii=False), encoding="utf-8")
+    print(json.dumps({"action": "started", "pid": proc.pid, "log": str(log_path), "session_id": session_id, "lease": lease, "cleaned": cleaned}, ensure_ascii=False))
     return 0
 
 
@@ -486,6 +624,7 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("start")
     p.add_argument("--scenario", choices=["dev", "test"], default="test")
     p.add_argument("--stop-timeout", type=float, default=8.0)
+    p.add_argument("--device-id", default="", help="Shared Android device identifier; defaults to device.name")
     p.set_defaults(func=cmd_start)
 
     p = sub.add_parser("stop")
@@ -495,6 +634,19 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("stop-all")
     p.add_argument("--timeout", type=float, default=8.0)
     p.set_defaults(func=cmd_stop_all)
+
+    p = sub.add_parser("cleanup-local")
+    p.add_argument("--device-id", default="", help="Shared Android device identifier; defaults to device.name")
+    p.add_argument("--stop-timeout", type=float, default=8.0)
+    p.set_defaults(func=cmd_cleanup_local)
+
+    sub.add_parser("remote-status").set_defaults(func=cmd_remote_status)
+    sub.add_parser("remote-pause").set_defaults(func=cmd_remote_pause)
+    p = sub.add_parser("remote-force-stop")
+    p.add_argument("--confirm", action="store_true", help="Required after reporting a failed remote pause")
+    p.set_defaults(func=cmd_remote_force_stop)
+    sub.add_parser("remote-resume").set_defaults(func=cmd_remote_resume)
+    sub.add_parser("remote-logs").set_defaults(func=cmd_remote_logs)
 
     p = sub.add_parser("inject")
     p.add_argument("--text", required=True)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,3 +23,11 @@ _Avoid_: Event loop, page-source helper, fallback navigation
 **Chat Intake**:
 The pure classification and normalization boundary for raw chat text and runtime queue grammar. It turns a single raw chat line into a frozen, typed result (user enter/return, keyword mention, command, or plain chat) and expands `;`-separated queue text with `{user_name}` substitution, silent-prefix detection, and private-reply detection. Chat Intake has no side effects and owns the regex families so that CommandManager, MessageManager, MessageContentEvent, and KeywordManager do not duplicate them.
 _Avoid_: Message parser, chat classifier, command matcher
+
+**E2E Session**:
+One owned run of UShareIPlay validation, including the service and every helper process that can contend for its Android/Appium target.
+_Avoid_: Test PID, runner process
+
+**Device Lease**:
+The machine-wide ownership record that grants one E2E Session exclusive use of a shared Android/Appium target.
+_Avoid_: Lock file, local PID

--- a/config.local.yaml.example
+++ b/config.local.yaml.example
@@ -15,6 +15,13 @@ appium:
   host: "localhost"
   port: 4723
 
+# E2E 远程协同。实际值写入 config.local.yaml（该文件已忽略）。
+# host 可为 SSH config alias，也可为 user@host；部署方式和日志路径由 toolbelt 自动发现。
+agent_e2e:
+  remote:
+    host: "tony@192.168.8.103"
+    deploy_path: "~/github.com/forchain/UShareIPlay"
+
 # Soul App 派对 ID（开发环境使用测试派对）
 soul:
   default_party_id: "FM00000000"   # 替换为你的测试派对 ID

--- a/docs/adr/0002-e2e-device-lease.md
+++ b/docs/adr/0002-e2e-device-lease.md
@@ -1,0 +1,3 @@
+# Device leases coordinate E2E ownership
+
+UShareIPlay shares an Android/Appium target across local worktrees and production, so E2E coordination uses a user-wide device lease plus process-family discovery instead of a worktree PID file alone. Remote access remains optional and uses only SSH host and deployment path, preserving local-only validation while requiring fresh remote evidence when production state matters.

--- a/src/ushareiplay/core/element_wrapper.py
+++ b/src/ushareiplay/core/element_wrapper.py
@@ -156,6 +156,25 @@ class ElementWrapper:
             return clickable.lower() == 'true'
         return False
 
+    def context_text(self, *, ancestor_levels: int = 3) -> str:
+        """Return nearby snapshot text for events that need dialog context."""
+        try:
+            container = self._xml_element
+            for _ in range(ancestor_levels):
+                parent = container.getparent()
+                if parent is None:
+                    break
+                container = parent
+            values = []
+            for node in container.iter():
+                for attribute in ("text", "content-desc"):
+                    value = node.get(attribute)
+                    if value and value != "null":
+                        values.append(value)
+            return "\n".join(values)
+        except Exception:
+            return ""
+
     @property
     def bounds(self) -> Optional[dict]:
         """
@@ -188,4 +207,3 @@ class ElementWrapper:
         resource_id = self.get_attribute('resource-id') or ''
         text = self.text[:20] if self.text else ''
         return f"<ElementWrapper tag={self.tag} resource-id={resource_id} text={text}>"
-

--- a/src/ushareiplay/events/chat_room_title.py
+++ b/src/ushareiplay/events/chat_room_title.py
@@ -34,8 +34,8 @@ class ChatRoomTitleEvent(BaseEvent):
             room_title_text = ""
             if element_wrapper is not None:
                 room_title_text = (
-                    getattr(element_wrapper, "content", None)
-                    or getattr(element_wrapper, "text", None)
+                    getattr(element_wrapper, "text", None)
+                    or getattr(element_wrapper, "content", None)
                     or ""
                 ).strip()
             if not room_title_text:

--- a/src/ushareiplay/events/party_name_violation_later.py
+++ b/src/ushareiplay/events/party_name_violation_later.py
@@ -1,5 +1,5 @@
 """
-派对名违规等弹窗：检测到「稍后再说」时先关闭弹窗，并将房间标题排队为「日推」。
+派对名违规弹窗：关闭「稍后再说」，仅在快照明确证明名称违规时重设房名。
 """
 
 __event__ = "PartyNameViolationLaterEvent"
@@ -9,6 +9,16 @@ from ushareiplay.core.base_event import BaseEvent
 
 
 class PartyNameViolationLaterEvent(BaseEvent):
+    _NAME_MARKERS = ("派对名", "派对名称", "房间名", "房间名称")
+    _VIOLATION_MARKERS = ("违规", "不符合规范", "审核")
+
+    @classmethod
+    def _is_party_name_violation(cls, element_wrapper) -> bool:
+        context = element_wrapper.context_text() if element_wrapper else ""
+        return any(marker in context for marker in cls._NAME_MARKERS) and any(
+            marker in context for marker in cls._VIOLATION_MARKERS
+        )
+
     async def handle(self, key: str, element_wrapper):
         try:
             element = self.handler.element_finder.wait_for_element_clickable("party_name_violation_later")
@@ -17,6 +27,10 @@ class PartyNameViolationLaterEvent(BaseEvent):
                 return False
             element.click()
             self.logger.info("Clicked party_name_violation_later (稍后再说)")
+
+            if not self._is_party_name_violation(element_wrapper):
+                self.logger.info("Skipped title reset: tvLater snapshot has no party-name violation evidence")
+                return True
 
             from ushareiplay.managers.title_manager import TitleManager
 

--- a/tests/test_agent_e2e_coordination.py
+++ b/tests/test_agent_e2e_coordination.py
@@ -90,14 +90,15 @@ def test_process_inventory_marks_manual_repo_process_as_external_session(monkeyp
     assert sessions[0]["pid"] == 123
 
 
-def test_remote_pause_command_is_graceful_and_force_is_explicit():
+def test_remote_pause_queues_stop_command_and_force_is_explicit():
     coordination = _load_coordination()
     target = coordination.RemoteTarget(host="tony@192.168.8.103", deploy_path="~/github.com/forchain/UShareIPlay")
 
     graceful = coordination.remote_command(target, "pause")
     force = coordination.remote_command(target, "force-stop")
 
-    assert "kill -INT" in _remote_script(graceful)
+    assert "!stop" in _remote_script(graceful)
+    assert "commands" in _remote_script(graceful)
     assert "kill -KILL" not in _remote_script(graceful)
     assert "kill -KILL" in _remote_script(force)
 
@@ -129,7 +130,7 @@ def test_remote_command_expands_a_home_relative_deploy_path():
     assert "$HOME/github.com/forchain/UShareIPlay" in _remote_script(command)
 
 
-def test_remote_pause_runs_under_bash_and_excludes_its_own_pid():
+def test_remote_pause_uses_safe_bash_transport():
     coordination = _load_coordination()
     target = coordination.RemoteTarget(host="tony@192.168.8.103", deploy_path="~/github.com/forchain/UShareIPlay")
 
@@ -137,10 +138,5 @@ def test_remote_pause_runs_under_bash_and_excludes_its_own_pid():
 
     assert command[-1].endswith("| base64 -d | bash")
     script = _remote_script(command)
-    assert "-v self=" in script
-    assert "$1 != self" in script
-    assert "$2 != self" in script
-    assert "$4 != \"awk\"" in script
-    assert "find_pgids" in script
-    assert "kill -INT -- -" in script
-    assert "/bash \\.\\/run\\.sh$/" in script
+    assert "!stop" in script
+    assert "commands" in script

--- a/tests/test_agent_e2e_coordination.py
+++ b/tests/test_agent_e2e_coordination.py
@@ -3,6 +3,7 @@ import json
 import os
 import sys
 import time
+import base64
 from pathlib import Path
 
 
@@ -14,6 +15,11 @@ def _load_coordination():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _remote_script(command):
+    payload = command[-1].split()[1]
+    return base64.b64decode(payload).decode("utf-8")
 
 
 def test_load_remote_target_requires_only_host_and_deploy_path(tmp_path):
@@ -91,9 +97,9 @@ def test_remote_pause_command_is_graceful_and_force_is_explicit():
     graceful = coordination.remote_command(target, "pause")
     force = coordination.remote_command(target, "force-stop")
 
-    assert "kill -INT" in graceful[-1]
-    assert "kill -KILL" not in graceful[-1]
-    assert "kill -KILL" in force[-1]
+    assert "kill -INT" in _remote_script(graceful)
+    assert "kill -KILL" not in _remote_script(graceful)
+    assert "kill -KILL" in _remote_script(force)
 
 
 def test_remote_resume_uses_the_deployment_run_script():
@@ -102,7 +108,16 @@ def test_remote_resume_uses_the_deployment_run_script():
 
     command = coordination.remote_command(target, "resume")
 
-    assert "nohup bash ./run.sh" in command[-1]
+    assert "nohup bash ./run.sh" in _remote_script(command)
+
+
+def test_remote_resume_falls_back_to_the_project_virtualenv():
+    coordination = _load_coordination()
+    target = coordination.RemoteTarget(host="tony@192.168.8.103", deploy_path="~/github.com/forchain/UShareIPlay")
+
+    command = coordination.remote_command(target, "resume")
+
+    assert "./.venv/bin/ushareiplay" in _remote_script(command)
 
 
 def test_remote_command_expands_a_home_relative_deploy_path():
@@ -111,4 +126,21 @@ def test_remote_command_expands_a_home_relative_deploy_path():
 
     command = coordination.remote_command(target, "status")
 
-    assert "$HOME/github.com/forchain/UShareIPlay" in command[-1]
+    assert "$HOME/github.com/forchain/UShareIPlay" in _remote_script(command)
+
+
+def test_remote_pause_runs_under_bash_and_excludes_its_own_pid():
+    coordination = _load_coordination()
+    target = coordination.RemoteTarget(host="tony@192.168.8.103", deploy_path="~/github.com/forchain/UShareIPlay")
+
+    command = coordination.remote_command(target, "pause")
+
+    assert command[-1].endswith("| base64 -d | bash")
+    script = _remote_script(command)
+    assert "-v self=" in script
+    assert "$1 != self" in script
+    assert "$2 != self" in script
+    assert "$4 != \"awk\"" in script
+    assert "find_pgids" in script
+    assert "kill -INT -- -" in script
+    assert "/bash \\.\\/run\\.sh$/" in script

--- a/tests/test_agent_e2e_coordination.py
+++ b/tests/test_agent_e2e_coordination.py
@@ -1,0 +1,114 @@
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def _load_coordination():
+    path = Path(__file__).resolve().parents[1] / ".agents" / "skills" / "agent-e2e-test" / "scripts" / "e2e_coordination.py"
+    spec = importlib.util.spec_from_file_location("agent_e2e_coordination", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_remote_target_requires_only_host_and_deploy_path(tmp_path):
+    coordination = _load_coordination()
+    config = tmp_path / "config.local.yaml"
+    config.write_text(
+        "agent_e2e:\n  remote:\n    host: tony@192.168.8.103\n    deploy_path: ~/github.com/forchain/UShareIPlay\n",
+        encoding="utf-8",
+    )
+
+    target = coordination.load_remote_target(config)
+
+    assert target.host == "tony@192.168.8.103"
+    assert target.deploy_path == "~/github.com/forchain/UShareIPlay"
+
+
+def test_device_lease_reclaims_expired_dead_owner(tmp_path, monkeypatch):
+    coordination = _load_coordination()
+    monkeypatch.setattr(coordination, "LEASE_ROOT", tmp_path / "leases")
+    lease_path = coordination.lease_path("device-1")
+    lease_path.parent.mkdir(parents=True)
+    lease_path.write_text(json.dumps({"device_id": "device-1", "pid": 999999, "heartbeat_at": 0}), encoding="utf-8")
+    monkeypatch.setattr(coordination, "pid_alive", lambda pid: False)
+
+    lease = coordination.acquire_lease("device-1", session_id="session-1", worktree="/tmp/worktree")
+
+    assert lease["session_id"] == "session-1"
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["owner_pid"] == os.getpid()
+
+
+def test_device_lease_rejects_live_owner(tmp_path, monkeypatch):
+    coordination = _load_coordination()
+    monkeypatch.setattr(coordination, "LEASE_ROOT", tmp_path / "leases")
+    lease_path = coordination.lease_path("device-1")
+    lease_path.parent.mkdir(parents=True)
+    lease_path.write_text(json.dumps({"device_id": "device-1", "owner_pid": 1234, "heartbeat_at": time.time()}), encoding="utf-8")
+    monkeypatch.setattr(coordination, "pid_alive", lambda pid: pid == 1234)
+
+    try:
+        coordination.acquire_lease("device-1", session_id="session-2", worktree="/tmp/worktree")
+    except coordination.LeaseConflict as exc:
+        assert exc.lease["owner_pid"] == 1234
+    else:
+        raise AssertionError("expected live lease to block acquisition")
+
+
+def test_device_lease_transfers_ownership_to_the_service_pid(tmp_path, monkeypatch):
+    coordination = _load_coordination()
+    monkeypatch.setattr(coordination, "LEASE_ROOT", tmp_path / "leases")
+    lease = coordination.acquire_lease("device-1", session_id="session-1", worktree="/tmp/worktree")
+
+    updated = coordination.transfer_lease_owner("device-1", session_id="session-1", owner_pid=4321)
+
+    assert updated["owner_pid"] == 4321
+    assert json.loads(coordination.lease_path("device-1").read_text(encoding="utf-8"))["owner_pid"] == 4321
+
+
+def test_process_inventory_marks_manual_repo_process_as_external_session(monkeypatch):
+    coordination = _load_coordination()
+    output = "123 123 Mon Jan  1 00:00:00 2026 python /tmp/UShareIPlay/main.py --device emulator-1\n"
+    monkeypatch.setattr(coordination, "run_text", lambda *args, **kwargs: output)
+    monkeypatch.setattr(coordination, "process_cwd", lambda pid: "/tmp/UShareIPlay")
+
+    sessions = coordination.discover_local_sessions("emulator-1")
+
+    assert len(sessions) == 1
+    assert sessions[0]["kind"] == "external/orphan"
+    assert sessions[0]["pid"] == 123
+
+
+def test_remote_pause_command_is_graceful_and_force_is_explicit():
+    coordination = _load_coordination()
+    target = coordination.RemoteTarget(host="tony@192.168.8.103", deploy_path="~/github.com/forchain/UShareIPlay")
+
+    graceful = coordination.remote_command(target, "pause")
+    force = coordination.remote_command(target, "force-stop")
+
+    assert "kill -INT" in graceful[-1]
+    assert "kill -KILL" not in graceful[-1]
+    assert "kill -KILL" in force[-1]
+
+
+def test_remote_resume_uses_the_deployment_run_script():
+    coordination = _load_coordination()
+    target = coordination.RemoteTarget(host="tony@192.168.8.103", deploy_path="~/github.com/forchain/UShareIPlay")
+
+    command = coordination.remote_command(target, "resume")
+
+    assert "nohup bash ./run.sh" in command[-1]
+
+
+def test_remote_command_expands_a_home_relative_deploy_path():
+    coordination = _load_coordination()
+    target = coordination.RemoteTarget(host="tony@192.168.8.103", deploy_path="~/github.com/forchain/UShareIPlay")
+
+    command = coordination.remote_command(target, "status")
+
+    assert "$HOME/github.com/forchain/UShareIPlay" in command[-1]

--- a/tests/test_chat_room_title_runtime_context.py
+++ b/tests/test_chat_room_title_runtime_context.py
@@ -96,6 +96,23 @@ def test_chat_room_title_uses_event_snapshot_instead_of_live_lookup(monkeypatch)
     assert live_lookup_calls == 0
 
 
+def test_chat_room_title_prefers_visible_title_over_content_description(monkeypatch):
+    queued_titles = []
+
+    class FakeTitleManager:
+        next_title = None
+
+        def set_next_title(self, title):
+            queued_titles.append(title)
+
+    monkeypatch.setattr(TitleManager, "instance", lambda: FakeTitleManager())
+    event = ChatRoomTitleEvent(FakeHandler(), runtime=FakeRuntime(busy=False))
+    wrapper = type("Wrapper", (), {"text": "享乐｜即兴的华彩", "content": "房间名称：Joyer"})()
+
+    assert asyncio.run(event.handle("chat_room_title", wrapper)) is False
+    assert queued_titles == []
+
+
 def test_chat_room_title_does_not_overwrite_pending_business_title(monkeypatch):
     runtime = FakeRuntime(busy=False)
     queued_titles = []

--- a/tests/test_party_name_violation_later.py
+++ b/tests/test_party_name_violation_later.py
@@ -1,0 +1,79 @@
+import asyncio
+
+from lxml import etree
+
+from ushareiplay.core.element_wrapper import ElementWrapper
+from ushareiplay.events.party_name_violation_later import PartyNameViolationLaterEvent
+from ushareiplay.managers.title_manager import TitleManager
+
+
+class _Logger:
+    def __init__(self):
+        self.info_messages = []
+
+    def info(self, message):
+        self.info_messages.append(message)
+
+    def warning(self, message):
+        self.info_messages.append(message)
+
+    def error(self, message):
+        self.info_messages.append(message)
+
+
+class _Element:
+    def __init__(self):
+        self.clicked = False
+
+    def click(self):
+        self.clicked = True
+
+
+class _Handler:
+    def __init__(self, element):
+        self.logger = _Logger()
+        self.controller = object()
+        self.element_finder = type("Finder", (), {"wait_for_element_clickable": lambda _self, _key: element})()
+
+
+class _Snapshot:
+    def __init__(self, text):
+        self._text = text
+
+    def context_text(self):
+        return self._text
+
+
+def test_element_wrapper_context_text_includes_dialog_siblings():
+    root = etree.fromstring(
+        "<hierarchy><dialog><label text='派对名称涉嫌违规'/><button resource-id='tvLater' text='稍后再说'/></dialog></hierarchy>"
+    )
+    wrapper = ElementWrapper(root.xpath("//*[@resource-id='tvLater']")[0])
+
+    assert "派对名称涉嫌违规" in wrapper.context_text()
+
+
+def test_non_violation_later_dialog_is_dismissed_without_resetting_title(monkeypatch):
+    element = _Element()
+    queued_titles = []
+    monkeypatch.setattr(TitleManager, "instance", lambda: type("Title", (), {"set_next_title": queued_titles.append})())
+    event = PartyNameViolationLaterEvent(_Handler(element))
+
+    handled = asyncio.run(event.handle("party_name_violation_later", _Snapshot("活动提醒\n稍后再说")))
+
+    assert handled is True
+    assert element.clicked is True
+    assert queued_titles == []
+
+
+def test_confirmed_party_name_violation_queues_daily_title(monkeypatch):
+    element = _Element()
+    queued_titles = []
+    monkeypatch.setattr(TitleManager, "instance", lambda: type("Title", (), {"set_next_title": queued_titles.append})())
+    event = PartyNameViolationLaterEvent(_Handler(element))
+
+    handled = asyncio.run(event.handle("party_name_violation_later", _Snapshot("派对名称涉嫌违规，请修改后重试\n稍后再说")))
+
+    assert handled is True
+    assert element.clicked is True
+    assert queued_titles == ["日推"]


### PR DESCRIPTION
## Summary
- Add a user-wide Device Lease and full E2E Session cleanup before local service startup.
- Add SSH-based remote status, log snapshots, command-spool pause, explicit force-stop, and session-scoped resume using only host and deployment path configuration.
- Prevent generic Soul `tvLater` dialogs from resetting the room title to `日推`.
- Read the visible room-title text before `content-desc`, preventing a normal `享乐｜…` title from being misclassified as invalid.

## Validation
- `uv run pytest -q` (337 passed)
- Deployed `46fd2b2` to `tony@192.168.8.103:~/github.com/forchain/UShareIPlay`.
- Remote service accepted `!stop` through `.agent/commands`, then restarted on the deployed revision.
- Fresh remote run `20260719-143231-91244bf2` reached `CommandReady`; startup and subsequent logs contained no automatic `日推` queue/write events.

## Deployment
- Remote local config changes were preserved.
- The existing title was left unchanged; it had already been set to `日推` by the earlier buggy revision.