### PR TITLE
[codex] fix online user selection for gift commands

### DIFF
--- a/src/ushareiplay/core/ui/gesture_handler.py
+++ b/src/ushareiplay/core/ui/gesture_handler.py
@@ -224,8 +224,6 @@ class GestureHandler:
             page_source, prev_hash = snapshot()
             values, matched = target_values(page_source)
             attribute_values_list.extend(values)
-            if matched:
-                return element_key, None, self._reversed_if_needed(attribute_values_list, direction)
 
             # 获取容器（横滑区等父节点可能不可点击，回退为仅存在即可）
             container = self.owner.element_finder.wait_for_element_clickable(container_key)
@@ -236,6 +234,32 @@ class GestureHandler:
                     f"scroll_container_until_element: 容器未找到: {container_key}"
                 )
                 return None, None, attribute_values_list
+
+            def find_visible_target() -> Optional[WebElement]:
+                candidates = self.owner.element_finder.find_child_elements(
+                    container, element_key
+                )
+                if attribute_value is None:
+                    return candidates[0] if candidates else None
+
+                attrs = (
+                    attribute_name.split("|")
+                    if attribute_name
+                    else ["content-desc", "text"]
+                )
+                for candidate in candidates:
+                    for attr in attrs:
+                        value = self.owner.element_finder.try_get_attribute(
+                            candidate, attr
+                        )
+                        if value == attribute_value:
+                            return candidate
+                return None
+
+            if matched:
+                target = find_visible_target()
+                if target:
+                    return element_key, target, self._reversed_if_needed(attribute_values_list, direction)
 
             # 方向规范化
             valid_dirs = {"up", "down", "left", "right"}
@@ -286,10 +310,13 @@ class GestureHandler:
 
             # 查找目标元素的辅助函数
             def find_target_element(source: str) -> Tuple[Optional[str], Optional[WebElement]]:
-                """从当前 page source 快照读取目标属性，不逐个访问 WebElement。"""
+                """先用 page source 判断命中，再解析对应的可见元素。"""
                 values, matched = target_values(source)
                 attribute_values_list.extend(values)
-                return (element_key, container) if matched else (None, None)
+                if not matched:
+                    return None, None
+                target = find_visible_target()
+                return (element_key, target) if target else (None, None)
 
             for _ in range(max_swipes):
                 # 计算滑动坐标并执行滑动

--- a/tests/test_gesture_handler.py
+++ b/tests/test_gesture_handler.py
@@ -143,6 +143,13 @@ def test_scroll_container_reads_target_attributes_from_page_source_cache():
         location={"x": 0, "y": 0},
         size={"width": 100, "height": 100},
     )
+    older = MagicMock()
+    anchor = MagicMock()
+    handler.owner.element_finder.find_child_elements.return_value = [older, anchor]
+    handler.owner.element_finder.try_get_attribute.side_effect = lambda element, attribute: {
+        (older, "content-desc"): "older",
+        (anchor, "text"): "anchor",
+    }.get((element, attribute))
 
     result = handler.scroll_container_until_element(
         "message_content",
@@ -153,9 +160,42 @@ def test_scroll_container_reads_target_attributes_from_page_source_cache():
     )
 
     assert result[0] == "message_content"
+    assert result[1] is anchor
     assert result[2] == ["anchor", "older"]
-    handler.owner.element_finder.wait_for_element_clickable.assert_not_called()
+    handler.owner.element_finder.wait_for_element_clickable.assert_called_once_with("message_list")
     handler.owner.element_finder.wait_for_element.assert_not_called()
     handler.owner.element_finder.find_child_element.assert_not_called()
-    handler.owner.element_finder.find_child_elements.assert_not_called()
-    handler.owner.element_finder.try_get_attribute.assert_not_called()
+
+
+def test_scroll_container_returns_the_visible_element_matching_attribute_value():
+    driver = MagicMock()
+    driver.page_source = """
+        <hierarchy>
+          <node resource-id="online-name" text="Joyer" />
+          <node resource-id="online-name" text="Outlier" />
+        </hierarchy>
+    """
+    handler = _make_handler(driver)
+    handler.owner.config = {"elements": {"online_user": "online-name"}}
+    handler.owner.element_finder = MagicMock()
+    container = SimpleNamespace(
+        location={"x": 0, "y": 0},
+        size={"width": 100, "height": 100},
+    )
+    joyer = MagicMock(text="Joyer")
+    outlier = MagicMock(text="Outlier")
+    handler.owner.element_finder.wait_for_element_clickable.return_value = container
+    handler.owner.element_finder.find_child_elements.return_value = [joyer, outlier]
+    handler.owner.element_finder.try_get_attribute.side_effect = (
+        lambda element, attribute: element.text if attribute == "text" else None
+    )
+
+    result = handler.scroll_container_until_element(
+        "online_user",
+        "online_users",
+        attribute_name="text",
+        attribute_value="Outlier",
+    )
+
+    assert result[0] == "online_user"
+    assert result[1] is outlier


### PR DESCRIPTION
## What changed
- Return the exact visible user element matching the requested nickname.
- Prevent gift commands from clicking the online-list container at a fixed position.
- Add regression coverage for selecting Outlier when Joyer is also visible.

## Root cause
The scroll helper detected a matching nickname in page source but returned the list container (or no element), so the caller clicked a fixed container position instead of the matched user.

## Validation
- `uv run pytest -q`: 324 passed
- Real E2E attempted with Android/Appium; blocked by recurring UiAutomator2 instrumentation crashes before gift processing.