### PR TITLE
fix: preserve active log inode during startup rotation

### DIFF
--- a/src/ushareiplay/core/log_rotation.py
+++ b/src/ushareiplay/core/log_rotation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os
+import shutil
 from datetime import datetime
 from pathlib import Path
 
@@ -35,6 +35,10 @@ def archive_active_log_on_startup(log_dir: Path, active_name: str) -> Path:
         return active_path
 
     archive_path = _archive_path(log_dir, active_name, _log_file_created_at(active_path))
-    os.replace(active_path, archive_path)
-    active_path.touch()
+    # Preserve the active file's inode. Existing ``tail -f`` processes follow
+    # the open descriptor, so replacing the path would leave them on the
+    # archived file forever. Copy the snapshot, then truncate in place.
+    shutil.copy2(active_path, archive_path)
+    with active_path.open("r+b") as active_file:
+        active_file.truncate(0)
     return active_path

--- a/tests/test_log_rotation.py
+++ b/tests/test_log_rotation.py
@@ -59,6 +59,27 @@ def test_archive_active_log_uses_created_time_in_archive_name(
     assert active_file.read_text(encoding="utf-8") == ""
 
 
+def test_archive_active_log_preserves_active_inode(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from ushareiplay.core import log_rotation
+
+    active_file = tmp_path / "chat.log"
+    active_file.write_text("old\n", encoding="utf-8")
+    original_inode = active_file.stat().st_ino
+    monkeypatch.setattr(
+        log_rotation,
+        "_log_file_created_at",
+        lambda path: datetime(2026, 7, 9, 8, 7, 6),
+    )
+
+    log_rotation.archive_active_log_on_startup(tmp_path, "chat.log")
+
+    assert active_file.stat().st_ino == original_inode
+    assert active_file.read_text(encoding="utf-8") == ""
+
+
 def test_app_handler_loggers_share_fixed_active_file(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- preserve the active log file inode during startup rotation
- keep existing `tail -f` readers attached to the active log after restart
- add a regression test for inode preservation

## Verification
- `uv run pytest -q` (324 passed)
