### PR TITLE
refactor: introduce OnlineListUI port between OnlineListScraper and SoulHandler

### DIFF
--- a/openspec/changes/online-list-scraper-ui-seam/.openspec.yaml
+++ b/openspec/changes/online-list-scraper-ui-seam/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/online-list-scraper-ui-seam/proposal.md
+++ b/openspec/changes/online-list-scraper-ui-seam/proposal.md
@@ -1,0 +1,68 @@
+## Context
+
+架构评审（评级 Worth exploring，ports & adapters）指出：`OnlineListScraper` 全文直接调用 `handler.element_finder` 和 `handler.gesture_handler`——两跳深入 `SoulHandler` 内部。locality 差：不理解 `SoulHandler` 就无法推理 scraper，也无法在没有完整 `SoulHandler` 的情况下测试它。
+
+评审建议：抽取 UISeen 端口（抽象接口），`OnlineListScraper` 只与端口对话；`SoulHandler` 提供具体适配器。**一个适配器 = 假想 seam，两个适配器 = 真 seam**——测试提供第二个适配器。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 定义 `OnlineListUI` 抽象端口（`src/ushareiplay/state/online_list_ui.py`），方法集恰好等于 scraper 使用的 6 个 UI 原语
+- 提供生产适配器 `SoulOnlineListUI`（委托 `SoulHandler.element_finder` / `gesture_handler`）
+- `OnlineListScraper` 迁移为只通过 `self.ui` 端口访问 UI，删除 `handler` property
+- 测试提供第二个适配器 `FakeOnlineListUI`，scraper 可在无 `SoulHandler` 的情况下测试
+
+**Non-Goals:**
+- 不改变抓取逻辑（停止条件、DAO 更新、滑动参数）——行为保持型重构
+- 不把端口泛化给其他 scraper 使用（目前只有一个消费者；泛化是投机设计）
+- 不改变 `element_finder` / `gesture_handler` 本身
+
+## Decisions
+
+### 决策 1: 端口与 scraper 同处 state 包，而非 core/ui
+
+**选择**: `src/ushareiplay/state/online_list_ui.py`。
+
+**理由**:
+- 端口属于消费者（hexagonal architecture 惯例），`OnlineListUI` 的方法集由 scraper 的需求定义
+- `core/ui/` 存放的是 SoulHandler 侧的实现细节（`element_finder`、`gesture_handler`），端口放在那里会造成双向依赖
+
+### 决策 2: 端口签名机械映射 gesture/element_finder 原语
+
+**选择**: 端口方法签名与底层原语一一对应（`try_find_element(key, log)`、`swipe(x1,y1,x2,y2,duration_ms)` 等），不发明领域化命名。
+
+**理由**:
+- 调用点只有 scraper 一处，领域化命名（如 `scroll_online_list()`）会把抓取策略泄漏进适配器
+- 机械映射让适配器是纯透传，review 时一眼可验证正确性
+
+### 决策 3: 测试用 FakeOnlineListUI 作为第二适配器，而非 MagicMock
+
+**选择**: 测试文件内定义 `FakeOnlineListUI(OnlineListUI)`，用字典/列表记录调用。
+
+**理由**:
+- 继承 ABC 使测试适配器受接口约束——端口签名变化时测试编译期失败，而非运行期静默通过
+- 第二个适配器让 seam 从"假想"变"真实"（评审原话）
+- 比 MagicMock 链（`scraper._handler.element_finder.try_find_element.side_effect = ...`）更直接表达测试意图
+
+## Risks & Mitigations
+
+**Risk**: `InfoManager._propagate_injected_handler_logger` 仍会向 scraper 注入 `_handler`（本分支上该钩子仍存在）。
+**Mitigation**: 注入变成无害的未读属性；`document-info-manager-facade` 变更已删除该钩子，两个变更合并后自然消解。
+
+**Risk**: 端口方法集漏掉某个 UI 调用。
+**Mitigation**: 迁移后 grep `self.handler` 在 scraper 中零命中；全量测试 339/339 通过。
+
+## Testing Decisions
+
+**What makes a good test for this change:**
+- scraper 测试不再构造 `SoulHandler` 替身，只面对端口
+- `test_refresh_online_users_no_op_when_user_count_element_missing` 改为断言端口无交互（`swipes == []`、`clicks == []`），比断言 mock 调用次数更表达行为
+
+**Modules to test:**
+- `OnlineListScraper`（现有 `tests/state/test_online_list_scraper.py`，已迁移到 FakeOnlineListUI）
+- `UserCountEvent` 调用路径（现有 `tests/test_user_count_event.py`，不受影响）
+
+## Out of Scope
+
+- 把 `PlaybackBroadcaster` 等其他 state 模块也端口化（它们不直接触碰 handler 的 UI 子组件）
+- `online_container.location/size` 等元素协议的形式化（Appium ElementWrapper 已是事实标准）

--- a/openspec/changes/online-list-scraper-ui-seam/tasks.md
+++ b/openspec/changes/online-list-scraper-ui-seam/tasks.md
@@ -1,0 +1,21 @@
+## 1. 端口定义
+
+- [x] 1.1 统计 scraper 使用的全部 UI 原语：`try_find_element`、`wait_for_element`、`find_child_elements`、`find_child_element`、`swipe`、`click_element_at`
+- [x] 1.2 确认 `gesture_handler.swipe` / `click_element_at` 签名，端口机械映射
+- [x] 1.3 创建 `src/ushareiplay/state/online_list_ui.py`：`OnlineListUI` ABC + `SoulOnlineListUI` 生产适配器
+
+## 2. Scraper 迁移
+
+- [x] 2.1 `OnlineListScraper` 的 10 处 `self.handler.element_finder.*` / `self.handler.gesture_handler.*` 调用迁移到 `self.ui.*`
+- [x] 2.2 删除 `handler` property 与 `_handler` 字段，新增惰性 `ui` property（默认 `SoulOnlineListUI()`）
+- [x] 2.3 迁移后 grep 确认 scraper 中 `self.handler` 零命中
+
+## 3. 测试迁移到第二适配器
+
+- [x] 3.1 `tests/state/test_online_list_scraper.py`：定义 `FakeOnlineListUI(OnlineListUI)` 记录调用，替换 MagicMock handler 注入
+- [x] 3.2 元素 stub 改为端口字典配置（`ui.elements[...]` / `ui.wait_elements[...]` / `ui.child_element_map`）
+- [x] 3.3 no-op 测试改为断言端口无交互
+
+## 4. 验证
+
+- [x] 4.1 全量测试 339/339 通过（含 `tests/state/` 28 个、`tests/test_user_count_event.py`）

--- a/src/ushareiplay/state/online_list_scraper.py
+++ b/src/ushareiplay/state/online_list_scraper.py
@@ -5,11 +5,15 @@ from ushareiplay.core.singleton import Singleton
 
 
 class OnlineListScraper(Singleton):
-    """从 Soul App 在线用户列表 UI 抓取当前在线用户。"""
+    """从 Soul App 在线用户列表 UI 抓取当前在线用户。
+
+    只通过 OnlineListUI 端口（见 online_list_ui.py）访问 UI，
+    不直接触碰 SoulHandler 内部。
+    """
 
     def __init__(self):
         self._logger = None
-        self._handler = None
+        self._ui = None
 
     @property
     def logger(self):
@@ -20,12 +24,12 @@ class OnlineListScraper(Singleton):
         return self._logger
 
     @property
-    def handler(self):
-        """延迟获取 SoulHandler 实例"""
-        if self._handler is None:
-            from ushareiplay.handlers.soul_handler import SoulHandler
-            self._handler = SoulHandler.instance()
-        return self._handler
+    def ui(self):
+        """延迟获取 UISeen 端口适配器"""
+        if self._ui is None:
+            from ushareiplay.state.online_list_ui import SoulOnlineListUI
+            self._ui = SoulOnlineListUI()
+        return self._ui
 
     async def refresh_online_users(self):
         """人数变化时，从在线用户列表 UI 刷新在线用户集合，并更新用户等级。"""
@@ -37,13 +41,13 @@ class OnlineListScraper(Singleton):
             target_count = RoomState.instance().user_count
 
             # 打开在线用户列表
-            user_count_elem = self.handler.element_finder.try_find_element('user_count', log=False)
+            user_count_elem = self.ui.try_find_element('user_count', log=False)
             if not user_count_elem:
                 return
             user_count_elem.click()
             self.logger.info("Clicked user count element")
 
-            online_container = self.handler.element_finder.wait_for_element('online_users')
+            online_container = self.ui.wait_for_element('online_users')
             if not online_container:
                 self.logger.error("Online users container not found")
                 return
@@ -73,11 +77,11 @@ class OnlineListScraper(Singleton):
                 end_y = None
 
             for swipe_idx in range(max_swipes + 1):
-                visible_containers = self.handler.element_finder.find_child_elements(online_container, 'user_container')
+                visible_containers = self.ui.find_child_elements(online_container, 'user_container')
                 if visible_containers:
                     for container in visible_containers:
                         try:
-                            user_elem = self.handler.element_finder.find_child_element(container, 'online_user')
+                            user_elem = self.ui.find_child_element(container, 'online_user')
                             if not user_elem:
                                 continue
                             username = user_elem.text
@@ -89,7 +93,7 @@ class OnlineListScraper(Singleton):
                                 continue
                             all_online_user_names.add(username)
 
-                            follow_state_elem = self.handler.element_finder.find_child_element(container, 'follow_state')
+                            follow_state_elem = self.ui.find_child_element(container, 'follow_state')
                             follow_state = follow_state_elem.text if follow_state_elem else None
 
                             if follow_state:
@@ -106,7 +110,7 @@ class OnlineListScraper(Singleton):
 
                 # 停止条件 1：到底提示出现
                 try:
-                    no_more = self.handler.element_finder.try_find_element('no_more_data', log=False)
+                    no_more = self.ui.try_find_element('no_more_data', log=False)
                     if no_more and no_more.is_displayed():
                         self.logger.info("Detected no_more_data, stop scrolling online users.")
                         break
@@ -134,12 +138,12 @@ class OnlineListScraper(Singleton):
 
                 try:
                     if swipe_x is not None:
-                        ok = self.handler.gesture_handler.swipe(swipe_x, start_y, swipe_x, end_y, duration_ms=400)
+                        ok = self.ui.swipe(swipe_x, start_y, swipe_x, end_y, duration_ms=400)
                         if not ok:
                             self.logger.warning("Swipe failed, stop scrolling online users.")
                             break
                     else:
-                        self.handler.gesture_handler.swipe(500, 1500, 500, 800, 600)
+                        self.ui.swipe(500, 1500, 500, 800, 600)
                 except Exception as e:
                     self.logger.error(f"Error during swipe operation: {str(e)}")
                     break
@@ -151,9 +155,9 @@ class OnlineListScraper(Singleton):
 
             PresenceTracker.instance().update_online_users(list(all_online_user_names))
 
-            bottom_drawer = self.handler.element_finder.wait_for_element('bottom_drawer')
+            bottom_drawer = self.ui.wait_for_element('bottom_drawer')
             if bottom_drawer:
                 self.logger.info('Hide online users dialog')
-                self.handler.gesture_handler.click_element_at(bottom_drawer, 0.5, -0.1)
+                self.ui.click_element_at(bottom_drawer, 0.5, -0.1)
         except Exception:
             self.logger.error(f"Error refreshing online users: {traceback.format_exc()}")

--- a/src/ushareiplay/state/online_list_ui.py
+++ b/src/ushareiplay/state/online_list_ui.py
@@ -1,0 +1,66 @@
+from abc import ABC, abstractmethod
+
+
+class OnlineListUI(ABC):
+    """UISeen 端口：OnlineListScraper 抓取在线用户列表所需的 Soul UI 原语。
+
+    Scraper 只依赖这个窄接口；具体实现由适配器提供（生产：SoulOnlineListUI；
+    测试：FakeOnlineListUI）。
+    """
+
+    @abstractmethod
+    def try_find_element(self, key, log=True):
+        """按配置 key 查找元素，未找到返回 None。"""
+
+    @abstractmethod
+    def wait_for_element(self, key):
+        """按配置 key 等待元素出现，超时返回 None。"""
+
+    @abstractmethod
+    def find_child_elements(self, parent, key):
+        """在父元素内按配置 key 查找全部子元素。"""
+
+    @abstractmethod
+    def find_child_element(self, parent, key):
+        """在父元素内按配置 key 查找单个子元素，未找到返回 None。"""
+
+    @abstractmethod
+    def swipe(self, start_x, start_y, end_x, end_y, duration_ms=300):
+        """执行一次滑动，返回是否成功。"""
+
+    @abstractmethod
+    def click_element_at(self, element, x_ratio=0.5, y_ratio=0.5):
+        """按位置比例点击元素，返回是否成功。"""
+
+
+class SoulOnlineListUI(OnlineListUI):
+    """生产适配器：用 SoulHandler 的 element_finder / gesture_handler 实现端口。"""
+
+    def __init__(self, handler=None):
+        self._handler = handler
+
+    @property
+    def handler(self):
+        """延迟获取 SoulHandler 实例"""
+        if self._handler is None:
+            from ushareiplay.handlers.soul_handler import SoulHandler
+            self._handler = SoulHandler.instance()
+        return self._handler
+
+    def try_find_element(self, key, log=True):
+        return self.handler.element_finder.try_find_element(key, log=log)
+
+    def wait_for_element(self, key):
+        return self.handler.element_finder.wait_for_element(key)
+
+    def find_child_elements(self, parent, key):
+        return self.handler.element_finder.find_child_elements(parent, key)
+
+    def find_child_element(self, parent, key):
+        return self.handler.element_finder.find_child_element(parent, key)
+
+    def swipe(self, start_x, start_y, end_x, end_y, duration_ms=300):
+        return self.handler.gesture_handler.swipe(start_x, start_y, end_x, end_y, duration_ms=duration_ms)
+
+    def click_element_at(self, element, x_ratio=0.5, y_ratio=0.5):
+        return self.handler.gesture_handler.click_element_at(element, x_ratio, y_ratio)

--- a/tests/state/test_online_list_scraper.py
+++ b/tests/state/test_online_list_scraper.py
@@ -4,8 +4,41 @@ import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
 from ushareiplay.state.online_list_scraper import OnlineListScraper
+from ushareiplay.state.online_list_ui import OnlineListUI
 from ushareiplay.state.room_state import RoomState
 from ushareiplay.state.presence_tracker import PresenceTracker
+
+
+class FakeOnlineListUI(OnlineListUI):
+    """第二个适配器：测试用的 UISeen 端口实现，让 seam 成为真 seam。"""
+
+    def __init__(self):
+        self.elements = {}
+        self.wait_elements = {}
+        self.child_elements = []
+        self.child_element_map = {}
+        self.swipes = []
+        self.clicks = []
+
+    def try_find_element(self, key, log=True):
+        return self.elements.get(key)
+
+    def wait_for_element(self, key):
+        return self.wait_elements.get(key)
+
+    def find_child_elements(self, parent, key):
+        return self.child_elements
+
+    def find_child_element(self, parent, key):
+        return self.child_element_map.get(key)
+
+    def swipe(self, start_x, start_y, end_x, end_y, duration_ms=300):
+        self.swipes.append((start_x, start_y, end_x, end_y, duration_ms))
+        return True
+
+    def click_element_at(self, element, x_ratio=0.5, y_ratio=0.5):
+        self.clicks.append((element, x_ratio, y_ratio))
+        return True
 
 
 @pytest.fixture
@@ -17,7 +50,7 @@ def scraper():
         warning=lambda _msg: None,
         error=lambda _msg: None,
     )
-    s._handler = MagicMock()
+    s._ui = FakeOnlineListUI()
     return s
 
 
@@ -53,20 +86,15 @@ async def test_refresh_online_users_parses_and_updates_presence(scraper, reset_s
     follow_state_elem = MagicMock()
     follow_state_elem.text = ""
 
-    scraper._handler.element_finder.try_find_element.side_effect = lambda key, **kwargs: {
-        "user_count": user_count_elem,
-        "online_users": online_container,
-        "bottom_drawer": MagicMock(),
-    }.get(key)
-    scraper._handler.element_finder.find_child_elements.return_value = [user_container]
-    scraper._handler.element_finder.find_child_element.side_effect = lambda parent, key, **kwargs: {
+    ui = scraper._ui
+    ui.elements["user_count"] = user_count_elem
+    ui.wait_elements["online_users"] = online_container
+    ui.wait_elements["bottom_drawer"] = MagicMock()
+    ui.child_elements = [user_container]
+    ui.child_element_map = {
         "online_user": user_elem,
         "follow_state": follow_state_elem,
-    }.get(key)
-    scraper._handler.element_finder.wait_for_element.side_effect = lambda key: {
-        "online_users": online_container,
-        "bottom_drawer": MagicMock(),
-    }.get(key)
+    }
 
     with patch("ushareiplay.dal.user_dao.UserDAO.get_or_create", new=AsyncMock()):
         await scraper.refresh_online_users()
@@ -78,8 +106,8 @@ async def test_refresh_online_users_parses_and_updates_presence(scraper, reset_s
 def test_refresh_online_users_no_op_when_user_count_element_missing(scraper):
     RoomState.initialize()
     PresenceTracker.initialize()
-    scraper._handler.element_finder.try_find_element.return_value = None
     # Should return early without raising
     import asyncio
     asyncio.run(scraper.refresh_online_users())
-    scraper._handler.element_finder.try_find_element.assert_called_once_with("user_count", log=False)
+    assert scraper._ui.swipes == []
+    assert scraper._ui.clicks == []


### PR DESCRIPTION
## Summary

架构评审建议 #4（Worth exploring，ports & adapters）：`OnlineListScraper` 全文两跳深入 `SoulHandler` 内部（`handler.element_finder` / `handler.gesture_handler`），无法在没有完整 `SoulHandler` 的情况下测试。

按评审建议引入 UISeen 端口：

- **`OnlineListUI` ABC**（`state/online_list_ui.py`）：6 个 UI 原语，与 `element_finder`/`gesture_handler` 签名机械映射，适配器为纯透传
- **`SoulOnlineListUI`**：生产适配器，委托 `SoulHandler`
- **`FakeOnlineListUI`**：测试适配器——*一个适配器 = 假想 seam，两个适配器 = 真 seam*
- `OnlineListScraper` 只与 `self.ui` 对话，`handler` property 删除

抓取逻辑（停止条件、DAO 更新、滑动参数）零变化，行为保持型重构。

## Test plan

- [x] scraper 测试不再构造 SoulHandler 替身，只面对端口；no-op 测试断言端口无交互
- [x] 端口继承 ABC 使签名漂移在测试期即失败
- [x] 全量测试 339/339 通过
- [x] OpenSpec 变更文档随 PR 提交（`openspec/changes/online-list-scraper-ui-seam/`）

注：本分支上 `InfoManager._propagate_injected_handler_logger` 仍会向 scraper 写入已不再读取的 `_handler` 属性（无害）；PR #214 已删除该钩子，两 PR 合并后自然消解。

🤖 Generated with [Claude Code](https://claude.com/claude-code)