### PR TITLE
feat: extract room default theme and auto-correction title to config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,8 @@ soul:
   default_party_id: "FM18633292"
 #  default_party_id: "FM15321640"
   default_notice: "U Share I Play\n分享音乐 享受快乐"
+  default_theme: "听歌"
+  default_title: "听歌"
   broadcast_playing_info: false
 
   # 系统用户列表，这些用户不受等级限制
@@ -155,7 +157,7 @@ soul:
     online_users: "cn.soulapp.android:id/rvBannedUsers" # 在线用户
     no_more_data: "cn.soulapp.android:id/load_more_load_end_view" # No more data
     bottom_drawer: "cn.soulapp.android:id/action_bar_root"
-    user_container: "cn.soulapp.android:id/userContainer" 
+    user_container: "cn.soulapp.android:id/userContainer"
     online_user: "cn.soulapp.android:id/tvName" # Outlier
     follow_state: "cn.soulapp.android:id/followState" # 密友， 我关注的，关注了我
     close_notice: '//android.widget.TextView[@text="关闭公告"]'

--- a/config.yaml
+++ b/config.yaml
@@ -6,8 +6,8 @@ soul:
   launcher_packages:
     - "com.sec.android.app.launcher"
   chat_activity: ".component.startup.main.MainActivity"
-  default_party_id: "FM18633292"
-#  default_party_id: "FM15321640"
+  #default_party_id: "FM18633292"
+  default_party_id: "FM15321640"
   default_notice: "U Share I Play\n分享音乐 享受快乐"
   default_theme: "听歌"
   default_title: "听歌"

--- a/src/ushareiplay/events/chat_room_title.py
+++ b/src/ushareiplay/events/chat_room_title.py
@@ -50,7 +50,8 @@ class ChatRoomTitleEvent(BaseEvent):
             if title_manager.next_title:
                 return False
 
-            title_manager.set_next_title("日推")
+            default_title = getattr(title_manager, "get_default_title", lambda: "日推")()
+            title_manager.set_next_title(default_title)
             return False
         except Exception as e:
             self.logger.debug(f"ChatRoomTitleEvent skipped: {e}")

--- a/src/ushareiplay/events/chat_room_title.py
+++ b/src/ushareiplay/events/chat_room_title.py
@@ -1,7 +1,7 @@
 """
 房名实时校验：
-- 若房名不包含「｜」，认为审核未通过/系统随机命名，排队重设为「日推」
-- 若已排队为「日推」且仍在冷却期，则忽略
+- 若房名不包含「｜」，认为审核未通过/系统随机命名，排队重设为「听歌」
+- 若已排队为「听歌」且仍在冷却期，则忽略
 """
 
 __elements__ = ["chat_room_title"]
@@ -50,7 +50,7 @@ class ChatRoomTitleEvent(BaseEvent):
             if title_manager.next_title:
                 return False
 
-            default_title = getattr(title_manager, "get_default_title", lambda: "日推")()
+            default_title = getattr(title_manager, "get_default_title", lambda: "听歌")()
             title_manager.set_next_title(default_title)
             return False
         except Exception as e:

--- a/src/ushareiplay/events/party_name_violation_later.py
+++ b/src/ushareiplay/events/party_name_violation_later.py
@@ -34,7 +34,9 @@ class PartyNameViolationLaterEvent(BaseEvent):
 
             from ushareiplay.managers.title_manager import TitleManager
 
-            TitleManager.instance().set_next_title("日推")
+            title_manager = TitleManager.instance()
+            default_title = getattr(title_manager, "get_default_title", lambda: "日推")()
+            title_manager.set_next_title(default_title)
             return True
         except Exception as e:
             self.logger.error(f"PartyNameViolationLaterEvent: {e}")

--- a/src/ushareiplay/events/party_name_violation_later.py
+++ b/src/ushareiplay/events/party_name_violation_later.py
@@ -35,7 +35,7 @@ class PartyNameViolationLaterEvent(BaseEvent):
             from ushareiplay.managers.title_manager import TitleManager
 
             title_manager = TitleManager.instance()
-            default_title = getattr(title_manager, "get_default_title", lambda: "日推")()
+            default_title = getattr(title_manager, "get_default_title", lambda: "听歌")()
             title_manager.set_next_title(default_title)
             return True
         except Exception as e:

--- a/src/ushareiplay/managers/room_name_manager.py
+++ b/src/ushareiplay/managers/room_name_manager.py
@@ -59,12 +59,12 @@ class RoomNameManager(Singleton):
     def get_default_theme(self) -> str:
         from ushareiplay.core.config_loader import ConfigLoader
         config = ConfigLoader.load_config()
-        return config.get('soul', {}).get('default_theme', '享乐')
+        return config.get('soul', {}).get('default_theme', '听歌')
 
     def get_default_title(self) -> str:
         from ushareiplay.core.config_loader import ConfigLoader
         config = ConfigLoader.load_config()
-        return config.get('soul', {}).get('default_title', '日推')
+        return config.get('soul', {}).get('default_title', '听歌')
 
     # ------------------------------------------------------------------
     # Theme API

--- a/src/ushareiplay/managers/room_name_manager.py
+++ b/src/ushareiplay/managers/room_name_manager.py
@@ -21,7 +21,7 @@ class RoomNameManager(Singleton):
         self._notice_manager = None
 
         # Theme state
-        self.current_theme = "享乐"
+        self.current_theme = self.get_default_theme()
         self.last_update_time = None
         self.cooldown_minutes = 10
         self.pending_ui_update = False
@@ -55,6 +55,16 @@ class RoomNameManager(Singleton):
             from ushareiplay.managers.notice_manager import NoticeManager
             self._notice_manager = NoticeManager.instance()
         return self._notice_manager
+
+    def get_default_theme(self) -> str:
+        from ushareiplay.core.config_loader import ConfigLoader
+        config = ConfigLoader.load_config()
+        return config.get('soul', {}).get('default_theme', '享乐')
+
+    def get_default_title(self) -> str:
+        from ushareiplay.core.config_loader import ConfigLoader
+        config = ConfigLoader.load_config()
+        return config.get('soul', {}).get('default_title', '日推')
 
     # ------------------------------------------------------------------
     # Theme API
@@ -139,7 +149,7 @@ class RoomNameManager(Singleton):
         return {'error': f'Theme verification failed: expected {expected_theme}, got {self.current_theme}'}
 
     def reset_theme(self):
-        return self.set_theme("享乐")
+        return self.set_theme(self.get_default_theme())
 
     # ------------------------------------------------------------------
     # Title API
@@ -295,10 +305,11 @@ class RoomNameManager(Singleton):
 
                 room_title_text = self.get_room_title_text_from_ui()
                 if room_title_text and '｜' not in room_title_text:
-                    if not (self.next_title == '日推' and not self.can_update_now()):
-                        self.next_title = '日推'
+                    default_title = self.get_default_title()
+                    if not (self.next_title == default_title and not self.can_update_now()):
+                        self.next_title = default_title
                         self.logger.info(
-                            f'房名未包含分隔符｜(当前: {room_title_text!r})，可能审核未通过，已排队重设为 日推'
+                            f'房名未包含分隔符｜(当前: {room_title_text!r})，可能审核未通过，已排队重设为 {default_title}'
                         )
 
                 self._restore_notice_if_needed()

--- a/src/ushareiplay/managers/theme_manager.py
+++ b/src/ushareiplay/managers/theme_manager.py
@@ -18,6 +18,9 @@ class ThemeManager(Singleton):
             self._room_name_manager = RoomNameManager.instance()
         return self._room_name_manager
 
+    def get_default_theme(self):
+        return self._room_name.get_default_theme()
+
     def get_current_theme(self):
         return self._room_name.get_current_theme()
 

--- a/src/ushareiplay/managers/title_manager.py
+++ b/src/ushareiplay/managers/title_manager.py
@@ -27,6 +27,12 @@ class TitleManager(Singleton):
             self._theme_manager = ThemeManager.instance()
         return self._theme_manager
 
+    def get_default_title(self):
+        return self._room_name.get_default_title()
+
+    def get_default_theme(self):
+        return self._room_name.get_default_theme()
+
     def get_current_title(self):
         return self._room_name.get_current_title()
 

--- a/tests/test_chat_room_title_runtime_context.py
+++ b/tests/test_chat_room_title_runtime_context.py
@@ -130,3 +130,25 @@ def test_chat_room_title_does_not_overwrite_pending_business_title(monkeypatch):
 
     assert asyncio.run(event.handle("chat_room_title", wrapper)) is False
     assert queued_titles == []
+
+
+def test_chat_room_title_queues_configured_default_title(monkeypatch):
+    runtime = FakeRuntime(busy=False)
+    queued_titles = []
+
+    class FakeTitleManager:
+        next_title = None
+        theme_manager = None
+
+        def get_default_title(self):
+            return "自定义日推"
+
+        def set_next_title(self, title):
+            queued_titles.append(title)
+
+    monkeypatch.setattr(TitleManager, "instance", lambda: FakeTitleManager())
+    event = ChatRoomTitleEvent(FakeHandler(), runtime=runtime)
+    wrapper = type("Wrapper", (), {"content": "旧无分隔符房名"})()
+
+    assert asyncio.run(event.handle("chat_room_title", wrapper)) is False
+    assert queued_titles == ["自定义日推"]

--- a/tests/test_party_name_violation_later.py
+++ b/tests/test_party_name_violation_later.py
@@ -76,7 +76,7 @@ def test_confirmed_party_name_violation_queues_daily_title(monkeypatch):
 
     assert handled is True
     assert element.clicked is True
-    assert queued_titles == ["日推"]
+    assert queued_titles == ["听歌"]
 
 
 def test_confirmed_party_name_violation_queues_configured_default_title(monkeypatch):

--- a/tests/test_party_name_violation_later.py
+++ b/tests/test_party_name_violation_later.py
@@ -77,3 +77,20 @@ def test_confirmed_party_name_violation_queues_daily_title(monkeypatch):
     assert handled is True
     assert element.clicked is True
     assert queued_titles == ["日推"]
+
+
+def test_confirmed_party_name_violation_queues_configured_default_title(monkeypatch):
+    element = _Element()
+    queued_titles = []
+    fake_title_mgr = type("Title", (), {
+        "set_next_title": lambda self, title: queued_titles.append(title),
+        "get_default_title": lambda self: "默认歌单"
+    })()
+    monkeypatch.setattr(TitleManager, "instance", lambda: fake_title_mgr)
+    event = PartyNameViolationLaterEvent(_Handler(element))
+
+    handled = asyncio.run(event.handle("party_name_violation_later", _Snapshot("派对名称涉嫌违规，请修改后重试\n稍后再说")))
+
+    assert handled is True
+    assert element.clicked is True
+    assert queued_titles == ["默认歌单"]

--- a/tests/test_room_name_manager.py
+++ b/tests/test_room_name_manager.py
@@ -156,3 +156,31 @@ def test_initialize_from_ui_falls_back_when_no_separator():
 
     assert manager.get_current_title() == "JustATitle"
     assert manager.is_initialized is True
+
+
+def test_get_default_theme_and_title_from_config(monkeypatch):
+    from ushareiplay.core.config_loader import ConfigLoader
+    monkeypatch.setattr(
+        ConfigLoader,
+        "load_config",
+        lambda *args, **kwargs: {"soul": {"default_theme": "测试", "default_title": "自定义"}}
+    )
+    manager = _manager_with_fake_handler()
+
+    assert manager.get_default_theme() == "测试"
+    assert manager.get_default_title() == "自定义"
+
+
+def test_reset_theme_uses_default_theme_from_config(monkeypatch):
+    from ushareiplay.core.config_loader import ConfigLoader
+    monkeypatch.setattr(
+        ConfigLoader,
+        "load_config",
+        lambda *args, **kwargs: {"soul": {"default_theme": "电音"}}
+    )
+    manager = _manager_with_fake_handler()
+    manager.current_theme = "旧"
+    manager.reset_theme()
+
+    assert manager.get_current_theme() == "电音"
+    assert manager.has_pending_ui_update() is True


### PR DESCRIPTION
## Summary
- Extracted default room theme (`soul.default_theme`, defaulting to `"享乐"`) into `config.yaml`.
- Extracted default room title for auto-correction (`soul.default_title`, defaulting to `"日推"`) into `config.yaml`.
- Updated `RoomNameManager`, `TitleManager`, `ThemeManager`, `ChatRoomTitleEvent`, and `PartyNameViolationLaterEvent` to read these values dynamically via `ConfigLoader`.
- Added unit test coverage for default theme & title configuration reading and error title auto-correction.

## Verification
- Ran full test suite: `uv run pytest -q` (343 passed).