### PR TITLE
fix(singer): fix tab scrolling direction and fallback when first_song is absent

### DIFF
--- a/src/ushareiplay/commands/album.py
+++ b/src/ushareiplay/commands/album.py
@@ -33,29 +33,17 @@ class AlbumCommand(BaseCommand):
             album_tab = self.handler.element_finder.try_find_element('album_tab')
             if not album_tab:
                 # If not found, scroll music_tabs to find it
-                music_tabs = self.handler.element_finder.try_find_element('music_tabs')
-                if not music_tabs:
-                    self.handler.logger.error("Failed to find music tabs")
-                    return False
-
-                # Get size and location for scrolling
-                size = music_tabs.size
-                location = music_tabs.location
-
-                # Scroll to right
-                self.handler.gesture_handler.swipe(
-                    location['x'] + 200,  # Start from left
-                    location['y'] + size['height'] // 2,
-                    location['x'] + size['width'] - 10,  # End at right
-                    location['y'] + size['height'] // 2,
-                    1000
+                _, album_tab, _ = self.handler.gesture_handler.scroll_container_until_element(
+                    'album_tab',
+                    'music_tabs',
+                    'left',
+                    max_swipes=10,
                 )
-
-                # Try to find album tab again
-                album_tab = self.handler.element_finder.try_find_element('album_tab')
                 if not album_tab:
-                    self.handler.logger.error("Failed to find album tab after scrolling")
-                    return False
+                    album_tab = self.handler.element_finder.try_find_element('album_tab')
+                    if not album_tab:
+                        self.handler.logger.error("Failed to find album tab after scrolling")
+                        return False
 
             album_tab.click()
             self.handler.logger.info("Selected album tab")

--- a/src/ushareiplay/commands/playlist.py
+++ b/src/ushareiplay/commands/playlist.py
@@ -33,33 +33,25 @@ class PlaylistCommand(BaseCommand):
         return playing_info
 
     def select_playlist_tab(self):
-        """Select the 'Playlist' tab in search results by scrolling to the leftmost position"""
+        """Select the 'Playlist' tab in search results"""
         try:
-            # Try to find playlist tab first
+            # Try to find playlist tab first or music tabs container
             key, element = self.handler.element_finder.wait_for_any_element(['playlist_tab', 'music_tabs'])
 
             if key == 'playlist_tab':
                 playlist_tab = element
             elif key == 'music_tabs':
-                # Get size and location for scrolling
-                music_tabs = element
-                size = music_tabs.size
-                location = music_tabs.location
-
-                # Scroll to left (opposite direction of singer tab)
-                self.handler.gesture_handler.swipe(
-                    location['x'] + 200,  # Start from left
-                    location['y'] + size['height'] // 2,
-                    location['x'] + size['width'] - 10,  # End at right
-                    location['y'] + size['height'] // 2,
-                    1000
+                _, playlist_tab, _ = self.handler.gesture_handler.scroll_container_until_element(
+                    'playlist_tab',
+                    'music_tabs',
+                    'left',
+                    max_swipes=10,
                 )
-
-                # Try to find playlist tab again
-                playlist_tab = self.handler.element_finder.try_find_element('playlist_tab')
                 if not playlist_tab:
-                    self.handler.logger.error("Failed to find playlist tab after scrolling")
-                    return False
+                    playlist_tab = self.handler.element_finder.try_find_element('playlist_tab')
+                    if not playlist_tab:
+                        self.handler.logger.error("Failed to find playlist tab after scrolling")
+                        return False
             else:
                 self.handler.logger.error("Failed to find music tabs or playlist tab")
                 return False

--- a/src/ushareiplay/commands/singer.py
+++ b/src/ushareiplay/commands/singer.py
@@ -38,31 +38,19 @@ class SingerCommand(BaseCommand):
             singer_tab = self.handler.element_finder.try_find_element("singer_tab")
             if not singer_tab:
                 # If not found, scroll music_tabs to find it
-                music_tabs = self.handler.element_finder.wait_for_element_clickable("music_tabs")
-                if not music_tabs:
-                    self.handler.logger.error("Failed to find music tabs")
-                    return False
-
-                # Get size and location for scrolling
-                size = music_tabs.size
-                location = music_tabs.location
-
-                # Scroll to right
-                self.handler.gesture_handler.swipe(
-                    location["x"] + 200,  # Start from left
-                    location["y"] + size["height"] // 2,
-                    location["x"] + size["width"] - 10,  # End at right
-                    location["y"] + size["height"] // 2,
-                    1000,
+                _, singer_tab, _ = self.handler.gesture_handler.scroll_container_until_element(
+                    "singer_tab",
+                    "music_tabs",
+                    "left",
+                    max_swipes=10,
                 )
-
-                # Try to find singer tab again
-                singer_tab = self.handler.element_finder.try_find_element("singer_tab")
                 if not singer_tab:
-                    self.handler.logger.error(
-                        "Failed to find singer tab after scrolling"
-                    )
-                    return False
+                    singer_tab = self.handler.element_finder.try_find_element("singer_tab")
+                    if not singer_tab:
+                        self.handler.logger.error(
+                            "Failed to find singer tab after scrolling"
+                        )
+                        return False
 
             singer_tab.click()
             self.handler.logger.info("Selected singer tab")
@@ -85,25 +73,26 @@ class SingerCommand(BaseCommand):
         singer_name = 'Unknown'
         if from_key == "home_nav":
             key, element = self.handler.element_finder.wait_for_any_element(["first_song", "not_found"])
-            if not key or key == "not_found":
-                self.handler.logger.error(f'not found singer with query {query}')
-                return {
-                    'error': f'not found singer with query {query}',
-                }
-
-            if play_singer := self.handler.element_finder.try_find_element("play_singer_1"):
-                if singer_name := self.handler.element_finder.try_get_attribute(play_singer, "content-desc"):
-                    singer_name = singer_name.split(': ')[1]
-                    singer_name = singer_name.split('的歌曲')[0]
-            elif play_singer := self.handler.element_finder.try_find_element("play_singer"):
-                if singer_name_element := self.handler.element_finder.try_find_element("singer_name"):
-                    singer_name = singer_name_element.text
+            if key and key != "not_found":
+                if play_singer_elem := self.handler.element_finder.try_find_element("play_singer_1"):
+                    play_singer = play_singer_elem
+                    if singer_name_attr := self.handler.element_finder.try_get_attribute(play_singer, "content-desc"):
+                        singer_name = singer_name_attr.split(': ')[1]
+                        singer_name = singer_name.split('的歌曲')[0]
+                elif play_singer_elem := self.handler.element_finder.try_find_element("play_singer"):
+                    play_singer = play_singer_elem
+                    if singer_name_element := self.handler.element_finder.try_find_element("singer_name"):
+                        singer_name = singer_name_element.text
 
         if play_singer:
             play_singer.click()
             self.handler.logger.info("Selected singer play")
         else:
-            self.select_singer_tab()
+            if not self.select_singer_tab():
+                self.handler.logger.error(f"Failed to select singer tab with query {query}")
+                return {
+                    'error': f'not found singer with query {query}',
+                }
             key, element = self.handler.element_finder.wait_for_any_element(["singer_result", "not_found"])
             if not key or key == "not_found":
                 self.handler.logger.error(f'not found singer with query {query}')

--- a/src/ushareiplay/commands/singer.py
+++ b/src/ushareiplay/commands/singer.py
@@ -72,7 +72,7 @@ class SingerCommand(BaseCommand):
         play_singer = None
         singer_name = 'Unknown'
         if from_key == "home_nav":
-            key, element = self.handler.element_finder.wait_for_any_element(["first_song", "not_found"])
+            key, element = self.handler.element_finder.wait_for_any_element(["music_tabs", "not_found"], timeout=5)
             if key and key != "not_found":
                 if play_singer_elem := self.handler.element_finder.try_find_element("play_singer_1"):
                     play_singer = play_singer_elem

--- a/tests/test_singer_command.py
+++ b/tests/test_singer_command.py
@@ -33,8 +33,9 @@ def test_play_singer_falls_back_to_singer_tab_when_first_song_not_found():
     singer_result.text = "Lofi Girl"
     play_all_button = MagicMock()
 
+    command.handler.element_finder.try_find_element.return_value = None
     command.handler.element_finder.wait_for_any_element.side_effect = [
-        (None, None),  # first_song wait
+        ("music_tabs", MagicMock()),  # music_tabs wait
         ("singer_result", singer_result),  # singer_result wait
     ]
     command.handler.element_finder.wait_for_element_clickable.return_value = play_all_button

--- a/tests/test_singer_command.py
+++ b/tests/test_singer_command.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock
+from ushareiplay.commands.singer import SingerCommand
+
+
+def test_select_singer_tab_scrolls_and_clicks():
+    command = SingerCommand.__new__(SingerCommand)
+    command.handler = MagicMock()
+
+    singer_tab = MagicMock()
+    command.handler.element_finder.try_find_element.return_value = None
+    command.handler.gesture_handler.scroll_container_until_element.return_value = (
+        "singer_tab", singer_tab, []
+    )
+
+    assert command.select_singer_tab() is True
+    singer_tab.click.assert_called_once_with()
+    command.handler.gesture_handler.scroll_container_until_element.assert_called_once_with(
+        "singer_tab", "music_tabs", "left", max_swipes=10
+    )
+
+
+def test_play_singer_falls_back_to_singer_tab_when_first_song_not_found():
+    command = SingerCommand.__new__(SingerCommand)
+    command.handler = MagicMock()
+    command._info_manager = MagicMock()
+    command._title_manager = MagicMock()
+    command._topic_manager = MagicMock()
+
+    command.handler.query_music.return_value = "home_nav"
+    # When home_nav is returned, wait_for_any_element for first_song returns (None, None)
+    # Then wait_for_any_element for singer_result returns ("singer_result", singer_result)
+    singer_result = MagicMock()
+    singer_result.text = "Lofi Girl"
+    play_all_button = MagicMock()
+
+    command.handler.element_finder.wait_for_any_element.side_effect = [
+        (None, None),  # first_song wait
+        ("singer_result", singer_result),  # singer_result wait
+    ]
+    command.handler.element_finder.wait_for_element_clickable.return_value = play_all_button
+    command.handler.get_playlist_info.return_value = []
+
+    command.select_singer_tab = MagicMock(return_value=True)
+
+    result = command.play_singer("Lofi Girl")
+
+    command.select_singer_tab.assert_called_once()
+    singer_result.click.assert_called_once()
+    play_all_button.click.assert_called_once()
+    assert result == {"playlist": "Lofi Girl"}


### PR DESCRIPTION
## Summary

This PR resolves an issue where the `/singer` command failed when the "歌手" (Singer) tab was not immediately visible on the search results screen.

### Root Cause
1. `SingerCommand.play_singer` had an early return when `first_song` was not found on the default home search result view, preventing execution from falling back to `select_singer_tab()`.
2. `select_singer_tab()` performed a single manual swipe from Left to Right, which scrolled the tab bar in the wrong direction and couldn't reach tabs positioned further to the right.

### Fix
- Updated `SingerCommand.play_singer` to fall back to selecting the singer tab if direct singer cards or `first_song` are absent on the home view.
- Replaced manual swipe calls in `select_singer_tab()`, `select_album_tab()`, and `select_playlist_tab()` with `scroll_container_until_element(..., direction="left")` to dynamically locate and scroll to target tabs.
- Added unit tests in `tests/test_singer_command.py`.

### Verification
- `uv run pytest -q` passed (345 passed).