### PR TITLE
feat(command): add configurable command retry policy for failed executions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,7 +13,7 @@ The combined Soul App party room name `{theme}｜{title}`, its shared cooldown, 
 _Avoid_: ThemeManager, TitleManager (legacy adapters)
 
 **Command Execution**:
-All behavior that turns runtime queue entries or scanned chat rows into command outcomes, including command detection, normalization, routing, execution, and response delivery.
+All behavior that turns runtime queue entries or scanned chat rows into command outcomes, including command detection, normalization, routing, execution, configured command retries, and response delivery.
 _Avoid_: Command parser, queue drainer, chat command handler
 
 **Event Processing**:

--- a/config.yaml
+++ b/config.yaml
@@ -300,22 +300,27 @@ lyrics:
 commands:
   - prefix: "play"
     level: 1
+    retry: true
     response_template: "{song} - {singer} • {album} • {release_date}"
     error_template: "Failed to play music, because {error}"
   - prefix: "fav"
     level: 1
+    retry: true
     response_template: "{playlist}"
     error_template: "Failed to play favorites, because {error}"
   - prefix: "skip"
     level: 1
+    retry: true
     response_template: "Skipped {song} by {singer}"
     error_template: "Failed to skip song, because {error}"
   - prefix: "next"
     level: 0
+    retry: true
     response_template: "Added {song} by {singer} in {album} • {release_date} to playlist"
     error_template: "Failed to add songs to play list, because {error}"
   - prefix: "pause"
     level: 1
+    retry: true
     response_template: "{action} {song} by {singer}"
     error_template: "Failed to pause/resume song, because {error}"
   - prefix: "vol"
@@ -324,10 +329,12 @@ commands:
     error_template: "Failed to adjust volume, because {error}"
   - prefix: "acc"
     level: 2
+    retry: true
     response_template: "Accompaniment mode {enabled}"
     error_template: "Failed to toggle accompaniment mode, because {error}"
   - prefix: "lyrics"
     level: 1
+    retry: true
     response_template: "{lyrics}"
     error_template: "Failed to get lyrics, because {error}"
   - prefix: "help"
@@ -352,14 +359,17 @@ commands:
     error_template: "Failed to get playback info, because {error}"
   - prefix: "singer"
     level: 1
+    retry: true
     response_template: "{playlist}"
     error_template: "Failed to play singer, because {error}"
   - prefix: "playlist"
     level: 2
+    retry: true
     response_template: "{playlist}"
     error_template: "Failed to play playlist, because {error}"
   - prefix: "radio"
     level: 2
+    retry: true
     response_template: "{playlist}"
     error_template: "Failed to start radio, because {error}"
   - prefix: "mode"
@@ -377,6 +387,7 @@ commands:
     error_template: "Failed to change notice, because {error}"
   - prefix: "album"
     level: 2
+    retry: true
     response_template: "{playlist}"
     error_template: "Failed to play album, because {error}"
   - prefix: "seat"

--- a/src/ushareiplay/managers/command_manager.py
+++ b/src/ushareiplay/managers/command_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import sys
 import traceback
@@ -250,6 +251,7 @@ class CommandManager(Singleton):
             
             # UI 互斥：命令执行期间禁止 EventManager 的"未知页面自动 back"打断弹窗/子页面流程
             result = {'error': 'unknown'}
+            retry_enabled = bool(command_info.get("retry"))
             with command_silence(silent):
                 async with self.runtime.ui_session(f"command:{command_info.get('prefix', 'unknown')}"):
                     try:
@@ -265,6 +267,24 @@ class CommandManager(Singleton):
                     except Exception:
                         pass
                     result = await command.process(message_info, parameters)
+                    if 'error' in result and retry_enabled:
+                        cmd_prefix = command_info.get('prefix', 'unknown')
+                        self.logger.warning(
+                            f"Command '{cmd_prefix}' failed on first attempt ({result.get('error')}), retrying (1/1)..."
+                        )
+                        try:
+                            self.runtime.emit(
+                                "command.retry",
+                                ctx={
+                                    "prefix": cmd_prefix,
+                                    "first_error": result.get("error"),
+                                    "nickname": message_info.nickname,
+                                },
+                            )
+                        except Exception:
+                            pass
+                        await asyncio.sleep(0.5)
+                        result = await command.process(message_info, parameters)
 
             if 'error' in result:
                 # 合并 result 中的字段（如 party_id），以便各命令的 error_template 能正确渲染

--- a/tests/test_command_manager_retry.py
+++ b/tests/test_command_manager_retry.py
@@ -1,0 +1,166 @@
+import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+from ushareiplay.managers.command_manager import CommandManager
+from ushareiplay.models.message_info import MessageInfo
+
+
+class FakeMessageDispatch:
+    def __init__(self):
+        self.screen_messages = []
+        self.command_outputs = []
+
+    def bind_handler(self, _handler):
+        return self
+
+    def send_screen_message(self, message, silent=False):
+        self.screen_messages.append((message, silent))
+
+    def send_for_message_info(self, message_info, response, silent=False):
+        self.command_outputs.append((message_info.nickname, response, silent))
+        return True
+
+
+class FakeLogger:
+    def __init__(self):
+        self.warnings = []
+        self.errors = []
+        self.infos = []
+
+    def warning(self, message):
+        self.warnings.append(message)
+
+    def error(self, message):
+        self.errors.append(message)
+
+    def info(self, message):
+        self.infos.append(message)
+
+
+class FakeObserver:
+    def __init__(self):
+        self.events = []
+
+    def emit(self, name, **kwargs):
+        self.events.append((name, kwargs))
+
+
+class FakeRuntime:
+    def __init__(self, controller):
+        self.controller = controller
+        self.obs = controller.obs
+        self.session_reasons = []
+
+    def emit(self, event, **kwargs):
+        self.obs.emit(event, **kwargs)
+
+    @asynccontextmanager
+    async def ui_session(self, reason):
+        self.session_reasons.append(reason)
+        yield
+
+
+class FlakyCommand:
+    def __init__(self, fail_times=1):
+        self.attempts = 0
+        self.fail_times = fail_times
+
+    async def process(self, message_info, parameters):
+        self.attempts += 1
+        if self.attempts <= self.fail_times:
+            return {"error": f"Attempt {self.attempts} failed"}
+        return {"song": "Test Song", "singer": "Test Singer", "album": "Test Album"}
+
+
+def make_manager():
+    controller = SimpleNamespace(
+        obs=FakeObserver(),
+        soul_handler=object(),
+        music_handler=object(),
+    )
+    runtime = FakeRuntime(controller)
+    manager = CommandManager.__new__(CommandManager)
+    manager.__init__()
+    manager.configure_runtime(runtime)
+    manager._logger = FakeLogger()
+    manager._handler = SimpleNamespace(config={"system_users": ["Console"]})
+    return manager, runtime, controller
+
+
+def test_command_retry_success_on_second_attempt(monkeypatch):
+    manager, runtime, controller = make_manager()
+    flaky = FlakyCommand(fail_times=1)
+    dispatch = FakeMessageDispatch()
+
+    manager._message_dispatch = dispatch
+    monkeypatch.setattr(manager, "get_command", lambda prefix: flaky)
+
+    command_info = {
+        "prefix": "play",
+        "retry": True,
+        "parameters": ["test"],
+        "response_template": "{song} - {singer}",
+        "error_template": "Failed: {error}",
+    }
+    msg = MessageInfo(content="play test", nickname="Console")
+
+    response = asyncio.run(manager.process_command(flaky, msg, command_info))
+
+    assert flaky.attempts == 2
+    assert "Test Song - Test Singer" in response
+    assert any("retrying (1/1)" in w for w in manager.logger.warnings)
+
+    retry_events = [e for e in controller.obs.events if e[0] == "command.retry"]
+    assert len(retry_events) == 1
+    assert retry_events[0][1]["ctx"]["prefix"] == "play"
+
+
+def test_command_retry_fails_on_both_attempts(monkeypatch):
+    manager, runtime, controller = make_manager()
+    flaky = FlakyCommand(fail_times=2)
+    dispatch = FakeMessageDispatch()
+
+    manager._message_dispatch = dispatch
+    monkeypatch.setattr(manager, "get_command", lambda prefix: flaky)
+
+    command_info = {
+        "prefix": "play",
+        "retry": True,
+        "parameters": ["test"],
+        "response_template": "{song} - {singer}",
+        "error_template": "Failed: {error}",
+    }
+    msg = MessageInfo(content="play test", nickname="Console")
+
+    response = asyncio.run(manager.process_command(flaky, msg, command_info))
+
+    assert flaky.attempts == 2
+    assert "Failed: Attempt 2 failed" in response
+    assert any("retrying (1/1)" in w for w in manager.logger.warnings)
+
+
+def test_command_no_retry_when_disabled(monkeypatch):
+    manager, runtime, controller = make_manager()
+    flaky = FlakyCommand(fail_times=1)
+    dispatch = FakeMessageDispatch()
+
+    manager._message_dispatch = dispatch
+    monkeypatch.setattr(manager, "get_command", lambda prefix: flaky)
+
+    command_info = {
+        "prefix": "play",
+        "retry": False,
+        "parameters": ["test"],
+        "response_template": "{song} - {singer}",
+        "error_template": "Failed: {error}",
+    }
+    msg = MessageInfo(content="play test", nickname="Console")
+
+    response = asyncio.run(manager.process_command(flaky, msg, command_info))
+
+    assert flaky.attempts == 1
+    assert "Failed: Attempt 1 failed" in response
+    assert len(manager.logger.warnings) == 0
+    retry_events = [e for e in controller.obs.events if e[0] == "command.retry"]
+    assert len(retry_events) == 0


### PR DESCRIPTION
## Summary
Adds a configurable command retry mechanism to `CommandManager` for commands that fail during execution (UI timeouts, errors, exceptions).

- **Config Layer**: Added optional `retry: true` parameter to `config.yaml` command entries. Enabled for all music playback commands (`play`, `fav`, `skip`, `next`, `pause`, `acc`, `lyrics`, `singer`, `playlist`, `radio`, `album`).
- **Command Execution Layer**: `CommandManager.process_command` retries failed execution once within the `ui_session` block after a 0.5s delay if `retry: true` is configured.
- **User Feedback & Observability**: Logs a warning on 1st attempt failure, emits `command.retry` event, silences failure message to channel on 1st attempt, and only sends error response if the retry attempt also fails.
- **Tests & Docs**: Added unit tests in `tests/test_command_manager_retry.py` and updated `CONTEXT.md`.