### PR TITLE
feat: add gift receive event detection and command execution

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 soul:
-  owner_username: "Chainer"
-#  owner_username: "Joyer"
+  room_owner: "Chainer"
+#  room_owner: "Joyer"
   package_name: "cn.soulapp.android"
   # 用于判定「当前不在 Soul 前台」时尝试切回（可与 config.local.yaml 追加厂商桌面包名）
   launcher_packages:

--- a/docs/superpowers/plans/2026-08-02-gift-receive-event.md
+++ b/docs/superpowers/plans/2026-08-02-gift-receive-event.md
@@ -1,0 +1,409 @@
+# Gift Receive Event Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect gift receive and heat contribution messages from Soul App chat, trigger `ChatIntakeKind.GIFT_RECEIVE` events, log them, and execute user-configured commands stored in database via `:receive`.
+
+**Architecture:** Extend `ChatIntake` classification with gift regex patterns and room owner matching. Create a `ReceiveEvent` Tortoise ORM model and `ReceiveDao` for SQLite storage, a `:receive` command module for managing user rules, and hook the classification into `MessageContentEvent` and `CommandManager`.
+
+**Tech Stack:** Python 3.10+, Tortoise ORM, SQLite, pytest, shlex, re.
+
+## Global Constraints
+
+- **Python & pytest:** Run tests with `uv run pytest -q`.
+- **Imports:** Preserve relative or package imports under `ushareiplay`.
+- **Command prefix:** Command prefix is `:receive` supporting `add`, `del`, `list`, `clear`.
+- **Owner matching:** Type 1 gift messages (`souler[<giver>]送给<receiver>`) only trigger if `<receiver>` equals `soul.room_owner` in config.
+
+---
+
+### Task 1: Chat Intake Gift Classification
+
+**Files:**
+- Modify: `src/ushareiplay/core/chat_intake.py`
+- Test: `tests/test_chat_intake.py`
+
+**Interfaces:**
+- Consumes: `classify_chat_line(raw: str, room_owner: str | None = None)`
+- Produces: `ChatIntakeKind.GIFT_RECEIVE`
+
+- [ ] **Step 1: Write failing tests in `tests/test_chat_intake.py`**
+
+```python
+def test_gift_type1_matches_when_receiver_is_room_owner():
+    result = classify_chat_line("souler[🍻🥂🥃🍸🍷🍺]送给Joyer", room_owner="Joyer")
+    assert result.kind == ChatIntakeKind.GIFT_RECEIVE
+    assert result.nickname == "🍻🥂🥃🍸🍷🍺"
+    assert result.text == "🍻🥂🥃🍸🍷🍺"
+
+def test_gift_type1_ignored_when_receiver_is_not_room_owner():
+    result = classify_chat_line("souler[Alice]送给Bob", room_owner="Joyer")
+    assert result.kind == ChatIntakeKind.PLAIN_CHAT
+
+def test_gift_type2_heat_contribution_matches():
+    result = classify_chat_line("08-02 17:44:58 [I] 恭喜🍻🥂🥃🍸🍷🍺在此房间贡献出3120热力值")
+    assert result.kind == ChatIntakeKind.GIFT_RECEIVE
+    assert result.nickname == "🍻🥂🥃🍸🍷🍺"
+    assert result.text == "🍻🥂🥃🍸🍷🍺"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest -q tests/test_chat_intake.py`
+Expected: FAIL due to missing `GIFT_RECEIVE` attribute or regex matching.
+
+- [ ] **Step 3: Implement gift classification in `src/ushareiplay/core/chat_intake.py`**
+
+Add `GIFT_RECEIVE = "gift_receive"` to `ChatIntakeKind`.
+Add patterns:
+```python
+_GIFT_TYPE1_PATTERN = re.compile(r"souler\[(.+?)\]送给([^\s【]+)")
+_GIFT_TYPE2_PATTERN = re.compile(r"恭喜(.+?)在此房间贡献出\d+热力值")
+```
+In `classify_chat_line(raw: str, room_owner: str | None = None)`:
+Check Type 1 gift match and compare `receiver.strip() == room_owner.strip()` if `room_owner` is provided.
+Check Type 2 gift match.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest -q tests/test_chat_intake.py`
+Expected: PASS
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add src/ushareiplay/core/chat_intake.py tests/test_chat_intake.py
+git commit -m "feat: add GIFT_RECEIVE chat intake classification for gift and heat messages"
+```
+
+---
+
+### Task 2: ReceiveEvent Model and ReceiveDao Data Access Layer
+
+**Files:**
+- Create: `src/ushareiplay/models/receive_event.py`
+- Modify: `src/ushareiplay/models/__init__.py`
+- Create: `src/ushareiplay/dal/receive_dao.py`
+- Test: `tests/test_receive_dao.py`
+
+**Interfaces:**
+- Produces: `ReceiveEvent` Tortoise ORM model and `ReceiveDao` (`create`, `get_by_username`, `delete_by_id`, `delete_all_by_username`)
+
+- [ ] **Step 1: Write failing test in `tests/test_receive_dao.py`**
+
+```python
+import pytest
+from ushareiplay.dal.receive_dao import ReceiveDao
+
+@pytest.mark.asyncio
+async def test_receive_dao_crud(db_init):
+    event = await ReceiveDao.create("Alice", ":play song")
+    assert event.id is not None
+    assert event.command == ":play song"
+
+    items = await ReceiveDao.get_by_username("Alice")
+    assert len(items) == 1
+    assert items[0].command == ":play song"
+
+    deleted = await ReceiveDao.delete_by_id(event.id)
+    assert deleted is True
+
+    items = await ReceiveDao.get_by_username("Alice")
+    assert len(items) == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest -q tests/test_receive_dao.py`
+Expected: FAIL (ModuleNotFoundError: `ushareiplay.dal.receive_dao`)
+
+- [ ] **Step 3: Create `ReceiveEvent` and `ReceiveDao`**
+
+Create `src/ushareiplay/models/receive_event.py`:
+```python
+from tortoise import fields
+from tortoise.models import Model
+
+class ReceiveEvent(Model):
+    id = fields.IntField(pk=True)
+    user = fields.ForeignKeyField("models.User", related_name="receive_events")
+    command = fields.TextField()
+    created_at = fields.DatetimeField(auto_now_add=True, null=True)
+
+    class Meta:
+        table = "receive_events"
+
+    def __str__(self):
+        return f"ReceiveEvent(id={self.id}, user={self.user_id}, command={self.command})"
+```
+Export `ReceiveEvent` in `src/ushareiplay/models/__init__.py`.
+
+Create `src/ushareiplay/dal/receive_dao.py`:
+```python
+from typing import Optional, List
+from ushareiplay.models.receive_event import ReceiveEvent
+from ushareiplay.dal.user_dao import UserDAO
+
+class ReceiveDao:
+    @staticmethod
+    async def create(username: str, command: str) -> ReceiveEvent:
+        user = await UserDAO.get_or_create(username=username)
+        return await ReceiveEvent.create(user=user, command=command)
+
+    @staticmethod
+    async def get_by_username(username: str) -> List[ReceiveEvent]:
+        effective_user = await UserDAO.get_or_create(username=username)
+        return await ReceiveEvent.filter(user__id=effective_user.id).order_by('id').prefetch_related('user')
+
+    @staticmethod
+    async def get_by_id(command_id: int) -> Optional[ReceiveEvent]:
+        return await ReceiveEvent.get_or_none(id=command_id).prefetch_related('user')
+
+    @staticmethod
+    async def delete_by_id(command_id: int) -> bool:
+        command = await ReceiveEvent.get_or_none(id=command_id)
+        if command:
+            await command.delete()
+            return True
+        return False
+
+    @staticmethod
+    async def delete_all_by_username(username: str) -> int:
+        effective_user = await UserDAO.get_or_create(username=username)
+        return await ReceiveEvent.filter(user__id=effective_user.id).delete()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest -q tests/test_receive_dao.py`
+Expected: PASS
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add src/ushareiplay/models/receive_event.py src/ushareiplay/models/__init__.py src/ushareiplay/dal/receive_dao.py tests/test_receive_dao.py
+git commit -m "feat: add ReceiveEvent model and ReceiveDao"
+```
+
+---
+
+### Task 3: Receive Command & CommandManager Event Dispatch
+
+**Files:**
+- Create: `src/ushareiplay/commands/receive.py`
+- Modify: `src/ushareiplay/managers/command_manager.py`
+- Test: `tests/test_receive_command.py`
+
+**Interfaces:**
+- Consumes: `ReceiveDao`
+- Produces: `ReceiveCommand` (prefix `:receive`), `CommandManager.notify_gift_receive(username)`
+
+- [ ] **Step 1: Write failing test in `tests/test_receive_command.py`**
+
+```python
+import pytest
+from ushareiplay.commands.receive import ReceiveCommand
+from ushareiplay.models.message_info import MessageInfo
+
+@pytest.mark.asyncio
+async def test_receive_command_add_and_trigger(db_init):
+    cmd = ReceiveCommand()
+    msg_info = MessageInfo(content=":receive add \":say Thanks for the gift!\"", nickname="Alice")
+    result = await cmd.do_process(msg_info, ["add", ":say Thanks for the gift!"])
+    assert "message" in result
+    assert "已添加" in result["message"]
+
+    # Trigger gift receive callback
+    await cmd.user_gift_receive("Alice")
+    # MessageQueue should have queued message
+    from ushareiplay.core.message_queue import MessageQueue
+    queue_msg = await MessageQueue.instance().get_message()
+    assert queue_msg.nickname == "Alice"
+    assert queue_msg.content == ":say Thanks for the gift!"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest -q tests/test_receive_command.py`
+Expected: FAIL (ModuleNotFoundError)
+
+- [ ] **Step 3: Implement `ReceiveCommand` and `notify_gift_receive`**
+
+Create `src/ushareiplay/commands/receive.py`:
+```python
+import traceback
+import shlex
+from ushareiplay.core.base_command import BaseCommand
+from ushareiplay.dal.receive_dao import ReceiveDao
+
+class ReceiveCommand(BaseCommand):
+    handler_attr = 'soul_handler'
+    error_message = '处理收礼物命令时出错'
+
+    async def do_process(self, message_info, parameters):
+        try:
+            original_content = message_info.content
+            parts = original_content.split(None, 1)
+            if len(parts) < 2:
+                return {'error': '缺少参数。使用: :receive [add|del|list|clear]'}
+            params = shlex.split(parts[1])
+        except ValueError:
+            return {'error': '参数格式错误，带空格的参数请使用引号包裹'}
+
+        if not params:
+            return {'error': '缺少参数。使用: :receive [add|del|list|clear]'}
+
+        operation = params[0]
+        username = message_info.nickname
+
+        if operation == 'add':
+            if len(params) < 2:
+                return {'error': '缺少命令内容。使用: :receive add "命令内容"'}
+            command = params[1]
+            if not command.startswith((':', '：', '/', '／')):
+                return {'error': '命令必须以命令前缀(:/：或//／)开头，例如 ":say 谢谢"' }
+            await ReceiveDao.create(username, command)
+            return {'message': f'已添加收礼物命令: {command}'}
+
+        elif operation == 'del':
+            if len(params) < 2:
+                return {'error': '缺少命令ID。使用: :receive del <id>'}
+            try:
+                command_id = int(params[1])
+            except ValueError:
+                return {'error': '命令ID必须是数字'}
+            deleted = await ReceiveDao.delete_by_id(command_id)
+            if deleted:
+                return {'message': f'已删除命令 ID: {command_id}'}
+            return {'error': f'未找到命令 ID: {command_id}'}
+
+        elif operation == 'list':
+            commands = await ReceiveDao.get_by_username(username)
+            if not commands:
+                return {'message': '您还没有设置任何收礼物命令'}
+            message_lines = ['您的收礼物命令列表:']
+            for c in commands:
+                message_lines.append(f'  [{c.id}] {c.command}')
+            return {'message': '\n'.join(message_lines)}
+
+        elif operation == 'clear':
+            count = await ReceiveDao.delete_all_by_username(username)
+            if count > 0:
+                return {'message': f'已清除 {count} 个收礼物命令'}
+            return {'message': '您没有任何收礼物命令需要清除'}
+
+        return {'error': f'未知操作: {operation}。使用: :receive [add|del|list|clear]'}
+
+    async def user_gift_receive(self, username: str):
+        try:
+            commands = await ReceiveDao.get_by_username(username)
+            if not commands:
+                return
+            from ushareiplay.core.message_queue import MessageQueue
+            from ushareiplay.models.message_info import MessageInfo
+
+            message_queue = MessageQueue.instance()
+            for cmd in commands:
+                message_info = MessageInfo(content=cmd.command, nickname=username)
+                await message_queue.put_message(message_info)
+        except Exception:
+            self.handler.log_error(f"Error in receive user_gift_receive: {traceback.format_exc()}")
+```
+
+In `src/ushareiplay/managers/command_manager.py`:
+Add method `notify_gift_receive`:
+```python
+    async def notify_gift_receive(self, username: str):
+        for module in self.get_command_modules().values():
+            try:
+                if hasattr(module.command, 'user_gift_receive'):
+                    await module.command.user_gift_receive(username)
+            except Exception:
+                self.logger.error(f"Error in command user_gift_receive: {traceback.format_exc()}")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest -q tests/test_receive_command.py`
+Expected: PASS
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add src/ushareiplay/commands/receive.py src/ushareiplay/managers/command_manager.py tests/test_receive_command.py
+git commit -m "feat: add ReceiveCommand and CommandManager notify_gift_receive"
+```
+
+---
+
+### Task 4: Message Content Integration & Config Support
+
+**Files:**
+- Modify: `src/ushareiplay/events/message_content.py`
+- Test: `tests/test_message_content_gift.py`
+
+**Interfaces:**
+- Consumes: `classify_chat_line`, `CommandManager.notify_gift_receive`
+
+- [ ] **Step 1: Write failing test in `tests/test_message_content_gift.py`**
+
+```python
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from ushareiplay.events.message_content import MessageContentEvent
+from ushareiplay.core.chat_intake import ChatIntakeKind, classify_chat_line
+
+def test_classify_gift_with_room_owner_config():
+    raw = "souler[Bob]送给Joyer"
+    res = classify_chat_line(raw, room_owner="Joyer")
+    assert res.kind == ChatIntakeKind.GIFT_RECEIVE
+    assert res.nickname == "Bob"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest -q tests/test_message_content_gift.py`
+Expected: FAIL
+
+- [ ] **Step 3: Modify `MessageContentEvent.handle`**
+
+In `MessageContentEvent.handle`:
+Retrieve `room_owner` from handler config:
+```python
+room_owner = None
+if hasattr(self.handler, 'config') and isinstance(self.handler.config, dict):
+    soul_cfg = self.handler.config.get("soul", {})
+    if isinstance(soul_cfg, dict):
+        room_owner = soul_cfg.get("room_owner")
+    if not room_owner:
+        room_owner = self.handler.config.get("room_owner")
+```
+Pass `room_owner` into `classify_chat_line(content, room_owner=room_owner)` calls.
+
+When `result.kind == ChatIntakeKind.GIFT_RECEIVE`:
+```python
+chat_logger.critical(content)
+self.logger.info(f"Gift received from: {result.nickname}")
+await self._notify_gift_receive(result.nickname)
+```
+Add method `_notify_gift_receive(username)`:
+```python
+async def _notify_gift_receive(self, username: str):
+    try:
+        command_manager = CommandManager.instance()
+        await command_manager.notify_gift_receive(username)
+    except Exception as e:
+        self.logger.error(f"Error notifying gift receive: {str(e)}")
+```
+
+- [ ] **Step 4: Run full test suite to verify everything passes**
+
+Run: `uv run pytest -q`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add src/ushareiplay/events/message_content.py tests/test_message_content_gift.py
+git commit -m "feat: integrate gift receive detection into MessageContentEvent"
+```

--- a/docs/superpowers/specs/2026-08-02-gift-receive-event-design.md
+++ b/docs/superpowers/specs/2026-08-02-gift-receive-event-design.md
@@ -1,0 +1,98 @@
+# Design Spec: Gift Receive Event Detection & Command Dispatch
+
+## Overview
+
+This spec defines the gift receive event system for UShareIPlay. When specific gift/heat contribution messages are detected in the Soul App chat stream, the system triggers a **Gift Receive Event** (`ChatIntakeKind.GIFT_RECEIVE`), logs the occurrence, and executes user-configured actions stored in the SQLite database via the `:receive` command.
+
+## Target Gift Message Formats
+
+1. **Type 1 (Gift Sent to Room Owner)**:
+   - Format: `souler[<giver>]送给<receiver>` (e.g. `souler[🍻🥂🥃🍸🍷🍺]送给Joyer` followed by `【为你爆灯】`)
+   - Condition: `<receiver>` must match the configured `room_owner` in `config.yaml`.
+2. **Type 2 (Heat Contribution)**:
+   - Format: `恭喜<giver>在此房间贡献出<heat_value>热力值` (e.g. `恭喜🍻🥂🥃🍸🍷🍺在此房间贡献出3120热力值`)
+   - Condition: Always triggers for any giver contributing heat value in the room.
+
+---
+
+## 1. Configuration & Intake Classification
+
+### 1.1 Config (`config.yaml`)
+Add room owner setting under `soul`:
+```yaml
+soul:
+  room_owner: "Joyer"
+```
+
+### 1.2 Chat Intake (`src/ushareiplay/core/chat_intake.py`)
+- Add `GIFT_RECEIVE = "gift_receive"` to `ChatIntakeKind`.
+- Define compiled regexes:
+  - `_GIFT_TYPE1_PATTERN = re.compile(r"souler\[(.+?)\]送给([^\s【]+)")`
+  - `_GIFT_TYPE2_PATTERN = re.compile(r"恭喜(.+?)在此房间贡献出\d+热力值")`
+- Update `classify_chat_line(raw: str, room_owner: str | None = None) -> ChatIntakeResult`:
+  - Matches Type 1 regex -> if `room_owner` matches `receiver.strip()`, return `ChatIntakeResult(kind=ChatIntakeKind.GIFT_RECEIVE, nickname=giver, text=giver, raw=raw)`.
+  - Matches Type 2 regex -> return `ChatIntakeResult(kind=ChatIntakeKind.GIFT_RECEIVE, nickname=giver, text=giver, raw=raw)`.
+
+---
+
+## 2. Database Model & Data Access Layer
+
+### 2.1 Tortoise ORM Model (`src/ushareiplay/models/receive_event.py`)
+```python
+from tortoise import fields
+from tortoise.models import Model
+
+class ReceiveEvent(Model):
+    id = fields.IntField(pk=True)
+    user = fields.ForeignKeyField("models.User", related_name="receive_events")
+    command = fields.TextField()
+    created_at = fields.DatetimeField(auto_now_add=True, null=True)
+
+    class Meta:
+        table = "receive_events"
+
+    def __str__(self):
+        return f"ReceiveEvent(id={self.id}, user={self.user_id}, command={self.command})"
+```
+Export `ReceiveEvent` in `src/ushareiplay/models/__init__.py`.
+
+### 2.2 Data Access Object (`src/ushareiplay/dal/receive_dao.py`)
+Provides async CRUD operations:
+- `create(username: str, command: str) -> ReceiveEvent`
+- `get_by_username(username: str) -> List[ReceiveEvent]`
+- `get_by_id(command_id: int) -> Optional[ReceiveEvent]`
+- `delete_by_id(command_id: int) -> bool`
+- `delete_all_by_username(username: str) -> int`
+
+---
+
+## 3. Command & Dispatch Pipeline
+
+### 3.1 Command (`src/ushareiplay/commands/receive.py`)
+- Prefix: `:receive`
+- Operations:
+  - `:receive add "<command>"` — Add command rule for current user.
+  - `:receive del <id>` — Delete command rule by ID.
+  - `:receive list` — List command rules for current user.
+  - `:receive clear` — Clear all command rules for current user.
+- Callback method `user_gift_receive(self, username: str)`:
+  - Fetches rules for `username` via `ReceiveDao.get_by_username(username)`.
+  - Puts corresponding `MessageInfo` instances into `MessageQueue`.
+
+### 3.2 Command Manager (`src/ushareiplay/managers/command_manager.py`)
+Add `notify_gift_receive(username: str)` to invoke `user_gift_receive(username)` on registered command modules.
+
+### 3.3 Event Handler (`src/ushareiplay/events/message_content.py`)
+- Retrieves `room_owner` from `self.handler.config`.
+- Passes `room_owner` to `classify_chat_line`.
+- On `ChatIntakeKind.GIFT_RECEIVE`:
+  - Logs line to `chat_logger.critical(...)`.
+  - Invokes `CommandManager.instance().notify_gift_receive(result.nickname)`.
+
+---
+
+## 4. Testing & Verification
+
+1. Unit tests for `classify_chat_line` with Type 1 & Type 2 gift messages (`tests/test_chat_intake.py`).
+2. Unit tests for `ReceiveDao` and `ReceiveCommand` CRUD and queue dispatch (`tests/test_receive_command.py`).
+3. Verification via `pytest`.

--- a/src/ushareiplay/commands/receive.py
+++ b/src/ushareiplay/commands/receive.py
@@ -1,0 +1,108 @@
+import traceback
+import shlex
+from ushareiplay.core.base_command import BaseCommand
+from ushareiplay.dal.receive_dao import ReceiveDao
+
+
+class ReceiveCommand(BaseCommand):
+    handler_attr = 'soul_handler'
+    error_message = '处理收礼物命令时出错'
+
+    async def do_process(self, message_info, parameters):
+        """Process receive command
+
+        Args:
+            message_info: MessageInfo object
+            parameters: List of parameters
+
+        Returns:
+            dict: Result with success message or error
+        """
+        try:
+            original_content = message_info.content
+            parts = original_content.split(None, 1)
+            if len(parts) < 2:
+                return {'error': '缺少参数。使用: :receive [add|del|list|clear]'}
+
+            params = shlex.split(parts[1])
+        except ValueError:
+            return {'error': '参数格式错误，带空格的参数请使用引号包裹'}
+
+        if not params:
+            return {'error': '缺少参数。使用: :receive [add|del|list|clear]'}
+
+        operation = params[0]
+        username = message_info.nickname
+
+        if operation == 'add':
+            if len(params) < 2:
+                return {'error': '缺少命令内容。使用: :receive add "命令内容"'}
+
+            command = params[1]
+            if not command.startswith((':', '：', '/', '／')):
+                return {'error': '命令必须以命令前缀(:/：或//／)开头，例如 ":say 谢谢"'}
+
+            await ReceiveDao.create(username, command)
+            return {'message': f'已添加收礼物命令: {command}'}
+
+        elif operation == 'del':
+            if len(params) < 2:
+                return {'error': '缺少命令ID。使用: :receive del <id>'}
+
+            try:
+                command_id = int(params[1])
+            except ValueError:
+                return {'error': '命令ID必须是数字'}
+
+            deleted = await ReceiveDao.delete_by_id(command_id)
+            if deleted:
+                return {'message': f'已删除命令 ID: {command_id}'}
+            else:
+                return {'error': f'未找到命令 ID: {command_id}'}
+
+        elif operation == 'list':
+            commands = await ReceiveDao.get_by_username(username)
+            if not commands:
+                return {'message': '您还没有设置任何收礼物命令'}
+
+            message_lines = ['您的收礼物命令列表:']
+            for cmd in commands:
+                message_lines.append(f'  [{cmd.id}] {cmd.command}')
+
+            return {'message': '\n'.join(message_lines)}
+
+        elif operation == 'clear':
+            count = await ReceiveDao.delete_all_by_username(username)
+            if count > 0:
+                return {'message': f'已清除 {count} 个收礼物命令'}
+            else:
+                return {'message': '您没有任何收礼物命令需要清除'}
+
+        else:
+            return {'error': f'未知操作: {operation}。使用: :receive [add|del|list|clear]'}
+
+    async def user_gift_receive(self, username: str):
+        """Called when a user sends a gift or heat contribution
+
+        Args:
+            username: Username of the user who sent the gift
+        """
+        try:
+            commands = await ReceiveDao.get_by_username(username)
+            if not commands:
+                return
+
+            from ushareiplay.core.message_queue import MessageQueue
+            from ushareiplay.models.message_info import MessageInfo
+
+            message_queue = MessageQueue.instance()
+            for cmd in commands:
+                message_info = MessageInfo(
+                    content=cmd.command,
+                    nickname=username
+                )
+                await message_queue.put_message(message_info)
+
+        except Exception as e:
+            if hasattr(self, 'handler') and self.handler and hasattr(self.handler, 'log_error'):
+                self.handler.log_error(f"Error in receive user_gift_receive: {traceback.format_exc()}")

--- a/src/ushareiplay/core/chat_intake.py
+++ b/src/ushareiplay/core/chat_intake.py
@@ -27,6 +27,8 @@ _CHAT_LINE_PATTERN = re.compile(r"souler\[(.+?)\]说[:：]\s*(.*)")
 _COMMAND_PATTERN = re.compile(r"souler\[(.+?)\]说[:：]\s*([:：/／$＄])\s*(.+)")
 _KEYWORD_PATTERN = re.compile(r"souler\[(.+?)\]说[:：]\s*@我\s+(.+)")
 _ENTER_RETURN_PATTERN = re.compile(r"^(.+?)(?:进来陪你聊天啦|坐着.+来啦).*?$")
+_GIFT_TYPE1_PATTERN = re.compile(r"souler\[(.+?)\]送给([^\s【]+)")
+_GIFT_TYPE2_PATTERN = re.compile(r"恭喜(.+?)在此房间贡献出\d+热力值")
 
 
 class ChatIntakeKind(Enum):
@@ -37,6 +39,7 @@ class ChatIntakeKind(Enum):
     KEYWORD_MENTION = "keyword_mention"
     COMMAND = "command"
     PLAIN_CHAT = "plain_chat"
+    GIFT_RECEIVE = "gift_receive"
 
 
 @dataclass(frozen=True)
@@ -69,10 +72,10 @@ class ChatIntakeResult:
     raw: str = ""
 
 
-def classify_chat_line(raw: str) -> ChatIntakeResult:
+def classify_chat_line(raw: str, room_owner: str | None = None) -> ChatIntakeResult:
     """Classify a single raw chat line.
 
-    Order of precedence: user enter/return, keyword mention, command, plain chat.
+    Order of precedence: user enter/return, gift receive, keyword mention, command, plain chat.
     The result is frozen; callers may convert it to a mutable MessageInfo if needed.
     """
     raw = raw or ""
@@ -92,6 +95,29 @@ def classify_chat_line(raw: str) -> ChatIntakeResult:
             text=username,
             raw=raw,
         )
+
+    gift1_match = _GIFT_TYPE1_PATTERN.search(raw)
+    if gift1_match:
+        giver = gift1_match.group(1).strip()
+        receiver = gift1_match.group(2).strip()
+        if room_owner and receiver == room_owner.strip():
+            return ChatIntakeResult(
+                kind=ChatIntakeKind.GIFT_RECEIVE,
+                nickname=giver,
+                text=giver,
+                raw=raw,
+            )
+
+    gift2_match = _GIFT_TYPE2_PATTERN.search(raw)
+    if gift2_match:
+        giver = gift2_match.group(1).strip()
+        return ChatIntakeResult(
+            kind=ChatIntakeKind.GIFT_RECEIVE,
+            nickname=giver,
+            text=giver,
+            raw=raw,
+        )
+
 
     keyword_match = _KEYWORD_PATTERN.match(raw)
     if keyword_match:

--- a/src/ushareiplay/core/db_manager.py
+++ b/src/ushareiplay/core/db_manager.py
@@ -51,8 +51,8 @@ class DatabaseManager:
 
     async def _ensure_receive_events_created_at(self) -> None:
         """
-        既有 receive_events 表若 created_at 为 NULL，回填为当前时间；
-        新插入由 Tortoise auto_now_add 写入。
+        确保 receive_events 表的 created_at 列具备 SQLite 默认值 `DEFAULT (datetime('now'))`；
+        已有的 NULL 记录回填为当前时间。
         """
         conn = connections.get("default")
         try:
@@ -63,9 +63,35 @@ class DatabaseManager:
                 return
         except Exception:
             return
+
         await conn.execute_script(
             "UPDATE receive_events SET created_at = datetime('now') WHERE created_at IS NULL;"
         )
+
+        rows = await conn.execute_query_dict("PRAGMA table_info(receive_events)")
+        columns = {r.get("name"): r for r in rows}
+        created_at_col = columns.get("created_at")
+
+        if not created_at_col:
+            await conn.execute_script(
+                "ALTER TABLE receive_events ADD COLUMN created_at DATETIME DEFAULT (datetime('now'));"
+            )
+        elif created_at_col.get("dflt_value") is None:
+            await conn.execute_script(
+                """
+                CREATE TABLE receive_events_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    command TEXT NOT NULL,
+                    created_at DATETIME DEFAULT (datetime('now')),
+                    user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE
+                );
+                INSERT INTO receive_events_new (id, command, created_at, user_id)
+                SELECT id, command, COALESCE(created_at, datetime('now')), user_id FROM receive_events;
+                DROP TABLE receive_events;
+                ALTER TABLE receive_events_new RENAME TO receive_events;
+                """
+            )
+
 
 
     async def _ensure_user_canonical_column(self) -> None:

--- a/src/ushareiplay/core/db_manager.py
+++ b/src/ushareiplay/core/db_manager.py
@@ -51,7 +51,7 @@ class DatabaseManager:
 
     async def _ensure_receive_events_created_at(self) -> None:
         """
-        确保 receive_events 表的 created_at 列具备 SQLite 默认值 `DEFAULT (datetime('now'))`；
+        确保 receive_events 表的 created_at 列具备标准 SQL 默认值 `DEFAULT CURRENT_TIMESTAMP`；
         已有的 NULL 记录回填为当前时间。
         """
         conn = connections.get("default")
@@ -65,7 +65,7 @@ class DatabaseManager:
             return
 
         await conn.execute_script(
-            "UPDATE receive_events SET created_at = datetime('now') WHERE created_at IS NULL;"
+            "UPDATE receive_events SET created_at = CURRENT_TIMESTAMP WHERE created_at IS NULL;"
         )
 
         rows = await conn.execute_query_dict("PRAGMA table_info(receive_events)")
@@ -74,7 +74,7 @@ class DatabaseManager:
 
         if not created_at_col:
             await conn.execute_script(
-                "ALTER TABLE receive_events ADD COLUMN created_at DATETIME DEFAULT (datetime('now'));"
+                "ALTER TABLE receive_events ADD COLUMN created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;"
             )
         elif created_at_col.get("dflt_value") is None:
             await conn.execute_script(
@@ -82,15 +82,16 @@ class DatabaseManager:
                 CREATE TABLE receive_events_new (
                     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
                     command TEXT NOT NULL,
-                    created_at DATETIME DEFAULT (datetime('now')),
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE
                 );
                 INSERT INTO receive_events_new (id, command, created_at, user_id)
-                SELECT id, command, COALESCE(created_at, datetime('now')), user_id FROM receive_events;
+                SELECT id, command, COALESCE(created_at, CURRENT_TIMESTAMP), user_id FROM receive_events;
                 DROP TABLE receive_events;
                 ALTER TABLE receive_events_new RENAME TO receive_events;
                 """
             )
+
 
 
 

--- a/src/ushareiplay/core/db_manager.py
+++ b/src/ushareiplay/core/db_manager.py
@@ -29,6 +29,7 @@ class DatabaseManager:
         await self._ensure_keyword_mode_column()
         await self._ensure_keyword_allowed_users_column()
         await self._ensure_focus_events_created_at()
+        await self._ensure_receive_events_created_at()
 
     async def _ensure_focus_events_created_at(self) -> None:
         """
@@ -47,6 +48,25 @@ class DatabaseManager:
         await conn.execute_script(
             "UPDATE focus_events SET created_at = datetime('now') WHERE created_at IS NULL;"
         )
+
+    async def _ensure_receive_events_created_at(self) -> None:
+        """
+        既有 receive_events 表若 created_at 为 NULL，回填为当前时间；
+        新插入由 Tortoise auto_now_add 写入。
+        """
+        conn = connections.get("default")
+        try:
+            tables = await conn.execute_query_dict(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='receive_events'"
+            )
+            if not tables:
+                return
+        except Exception:
+            return
+        await conn.execute_script(
+            "UPDATE receive_events SET created_at = datetime('now') WHERE created_at IS NULL;"
+        )
+
 
     async def _ensure_user_canonical_column(self) -> None:
         """

--- a/src/ushareiplay/dal/receive_dao.py
+++ b/src/ushareiplay/dal/receive_dao.py
@@ -1,0 +1,41 @@
+from typing import Optional, List
+from ushareiplay.models.receive_event import ReceiveEvent
+from ushareiplay.dal.user_dao import UserDAO
+
+
+class ReceiveDao:
+    @staticmethod
+    async def create(username: str, command: str) -> ReceiveEvent:
+        """Create a new receive command rule for a user"""
+        user = await UserDAO.get_or_create(username=username)
+        return await ReceiveEvent.create(
+            user=user,
+            command=command
+        )
+
+    @staticmethod
+    async def get_by_username(username: str) -> List[ReceiveEvent]:
+        """Get all receive commands for a user"""
+        effective_user = await UserDAO.get_or_create(username=username)
+        return await ReceiveEvent.filter(user_id=effective_user.id).order_by('id').prefetch_related('user')
+
+    @staticmethod
+    async def get_by_id(command_id: int) -> Optional[ReceiveEvent]:
+        """Get receive command by ID"""
+        return await ReceiveEvent.get_or_none(id=command_id).prefetch_related('user')
+
+    @staticmethod
+    async def delete_by_id(command_id: int) -> bool:
+        """Delete a receive command by ID"""
+        command = await ReceiveEvent.get_or_none(id=command_id)
+        if command:
+            await command.delete()
+            return True
+        return False
+
+    @staticmethod
+    async def delete_all_by_username(username: str) -> int:
+        """Delete all receive commands for a user"""
+        effective_user = await UserDAO.get_or_create(username=username)
+        return await ReceiveEvent.filter(user_id=effective_user.id).delete()
+

--- a/src/ushareiplay/dal/receive_dao.py
+++ b/src/ushareiplay/dal/receive_dao.py
@@ -15,9 +15,9 @@ class ReceiveDao:
 
     @staticmethod
     async def get_by_username(username: str) -> List[ReceiveEvent]:
-        """Get all receive commands for a user"""
-        effective_user = await UserDAO.get_or_create(username=username)
-        return await ReceiveEvent.filter(user_id=effective_user.id).order_by('id').prefetch_related('user')
+        """Get all receive commands for a user (including canonical account and all aliases)"""
+        user_ids = await UserDAO.get_all_associated_user_ids(username=username)
+        return await ReceiveEvent.filter(user_id__in=user_ids).order_by('id').prefetch_related('user')
 
     @staticmethod
     async def get_by_id(command_id: int) -> Optional[ReceiveEvent]:
@@ -35,7 +35,8 @@ class ReceiveDao:
 
     @staticmethod
     async def delete_all_by_username(username: str) -> int:
-        """Delete all receive commands for a user"""
-        effective_user = await UserDAO.get_or_create(username=username)
-        return await ReceiveEvent.filter(user_id=effective_user.id).delete()
+        """Delete all receive commands for a user (including canonical account and all aliases)"""
+        user_ids = await UserDAO.get_all_associated_user_ids(username=username)
+        return await ReceiveEvent.filter(user_id__in=user_ids).delete()
+
 

--- a/src/ushareiplay/dal/user_dao.py
+++ b/src/ushareiplay/dal/user_dao.py
@@ -105,3 +105,20 @@ class UserDAO:
         result = set(aliases)
         result.add(canonical.username)  # 主账号本身也加进来
         return result
+
+    @staticmethod
+    async def get_all_associated_user_ids(username: str) -> list[int]:
+        """
+        获取某个用户（可以是别名或主账号）所有相关账号的 DB ID 列表（包含主账号、所有别名及原始 user 对象）。
+        """
+        raw_user = await UserDAO.get_or_create_raw(username)
+        canonical = await UserDAO.resolve_canonical(raw_user)
+
+        alias_ids = await User.filter(canonical_user_id=canonical.id).values_list(
+            "id", flat=True
+        )
+
+        user_ids = set(alias_ids)
+        user_ids.add(canonical.id)
+        user_ids.add(raw_user.id)
+        return list(user_ids)

--- a/src/ushareiplay/events/message_content.py
+++ b/src/ushareiplay/events/message_content.py
@@ -115,9 +115,10 @@ class MessageContentEvent(BaseEvent):
             if hasattr(self.handler, 'config') and isinstance(self.handler.config, dict):
                 soul_cfg = self.handler.config.get("soul", {})
                 if isinstance(soul_cfg, dict):
-                    room_owner = soul_cfg.get("room_owner")
+                    room_owner = soul_cfg.get("room_owner") or soul_cfg.get("owner_username")
                 if not room_owner:
-                    room_owner = self.handler.config.get("room_owner")
+                    room_owner = self.handler.config.get("room_owner") or self.handler.config.get("owner_username")
+
 
             if not room_owner:
                 try:

--- a/src/ushareiplay/events/message_content.py
+++ b/src/ushareiplay/events/message_content.py
@@ -119,8 +119,18 @@ class MessageContentEvent(BaseEvent):
                 if not room_owner:
                     room_owner = self.handler.config.get("room_owner")
 
+            if not room_owner:
+                try:
+                    from ushareiplay.models import User
+                    owner_user = await User.filter(level=9).first()
+                    if owner_user:
+                        room_owner = owner_user.username
+                except Exception:
+                    pass
+
             # 处理所有消息元素
             for content in message_manager.latest_chats:
+
                 result = classify_chat_line(content, room_owner=room_owner)
 
                 is_return = result.kind == ChatIntakeKind.USER_RETURN

--- a/src/ushareiplay/events/message_content.py
+++ b/src/ushareiplay/events/message_content.py
@@ -111,14 +111,28 @@ class MessageContentEvent(BaseEvent):
                             message_manager.latest_chats.append(new_content)
                         break
 
+            room_owner = None
+            if hasattr(self.handler, 'config') and isinstance(self.handler.config, dict):
+                soul_cfg = self.handler.config.get("soul", {})
+                if isinstance(soul_cfg, dict):
+                    room_owner = soul_cfg.get("room_owner")
+                if not room_owner:
+                    room_owner = self.handler.config.get("room_owner")
+
             # 处理所有消息元素
             for content in message_manager.latest_chats:
-                result = classify_chat_line(content)
+                result = classify_chat_line(content, room_owner=room_owner)
 
                 is_return = result.kind == ChatIntakeKind.USER_RETURN
                 if is_return:
                     self.logger.critical(f"User returned: {result.nickname}")
                     await self._notify_user_return(result.nickname)
+
+                if result.kind == ChatIntakeKind.GIFT_RECEIVE:
+                    chat_logger.critical(content)
+                    self.logger.info(f"Gift received from user: {result.nickname}")
+                    await self._notify_gift_receive(result.nickname)
+                    continue
 
                 if result.kind == ChatIntakeKind.KEYWORD_MENTION:
                     from ushareiplay.managers.keyword_manager import KeywordManager
@@ -167,6 +181,15 @@ class MessageContentEvent(BaseEvent):
             await command_manager.notify_user_enter(username)
         except Exception as e:
             self.logger.error(f"Error notifying user enter: {str(e)}")
+
+    async def _notify_gift_receive(self, username: str):
+        """通知所有命令收礼物事件"""
+        try:
+            command_manager = CommandManager.instance()
+            await command_manager.notify_gift_receive(username)
+        except Exception as e:
+            self.logger.error(f"Error notifying gift receive: {str(e)}")
+
 
     async def _notify_user_return(self, username: str):
         """通知所有命令用户返回"""

--- a/src/ushareiplay/managers/command_manager.py
+++ b/src/ushareiplay/managers/command_manager.py
@@ -530,7 +530,22 @@ class CommandManager(Singleton):
             except Exception:
                 self.logger.error(f"Error in command user_return: {traceback.format_exc()}")
 
+    async def notify_gift_receive(self, username: str):
+        """
+        Notify all commands when a gift or heat contribution is received
+
+        Args:
+            username: Username of the user who sent the gift
+        """
+        for module in self.get_command_modules().values():
+            try:
+                if hasattr(module.command, 'user_gift_receive'):
+                    await module.command.user_gift_receive(username)
+            except Exception:
+                self.logger.error(f"Error in command user_gift_receive: {traceback.format_exc()}")
+
     async def notify_focus_count_change(self, before: int | None, after: int):
+
         """
         Notify all commands when 专注人数 (focus_count / tvStudyRoomDesc) changes.
 

--- a/src/ushareiplay/models/__init__.py
+++ b/src/ushareiplay/models/__init__.py
@@ -7,5 +7,7 @@ from ushareiplay.models.return_event import ReturnEvent
 from ushareiplay.models.exit_event import ExitEvent
 from ushareiplay.models.focus_event import FocusEvent
 from ushareiplay.models.timer import Timer
+from ushareiplay.models.receive_event import ReceiveEvent
 
-__all__ = ['User', 'SeatReservation', 'MessageInfo', 'Keyword', 'EnterEvent', 'ReturnEvent', 'ExitEvent', 'FocusEvent', 'Timer'] 
+__all__ = ['User', 'SeatReservation', 'MessageInfo', 'Keyword', 'EnterEvent', 'ReturnEvent', 'ExitEvent', 'FocusEvent', 'Timer', 'ReceiveEvent']
+ 

--- a/src/ushareiplay/models/receive_event.py
+++ b/src/ushareiplay/models/receive_event.py
@@ -1,0 +1,15 @@
+from tortoise import fields
+from tortoise.models import Model
+
+
+class ReceiveEvent(Model):
+    id = fields.IntField(pk=True)
+    user = fields.ForeignKeyField("models.User", related_name="receive_events")
+    command = fields.TextField()
+    created_at = fields.DatetimeField(auto_now_add=True, null=True)
+
+    class Meta:
+        table = "receive_events"
+
+    def __str__(self):
+        return f"ReceiveEvent(id={self.id}, user={self.user_id}, command={self.command})"

--- a/src/ushareiplay/models/receive_event.py
+++ b/src/ushareiplay/models/receive_event.py
@@ -6,7 +6,7 @@ class ReceiveEvent(Model):
     id = fields.IntField(pk=True)
     user = fields.ForeignKeyField("models.User", related_name="receive_events")
     command = fields.TextField()
-    created_at = fields.DatetimeField(auto_now_add=True, null=True)
+    created_at = fields.DatetimeField(auto_now_add=True)
 
     class Meta:
         table = "receive_events"

--- a/tests/test_chat_intake.py
+++ b/tests/test_chat_intake.py
@@ -119,6 +119,23 @@ class TestClassifyChatLine:
         with pytest.raises(AttributeError):
             result.text = "mutated"
 
+    def test_gift_type1_matches_when_receiver_is_room_owner(self):
+        result = classify_chat_line("souler[🍻🥂🥃🍸🍷🍺]送给Joyer", room_owner="Joyer")
+        assert result.kind == ChatIntakeKind.GIFT_RECEIVE
+        assert result.nickname == "🍻🥂🥃🍸🍷🍺"
+        assert result.text == "🍻🥂🥃🍸🍷🍺"
+
+    def test_gift_type1_ignored_when_receiver_is_not_room_owner(self):
+        result = classify_chat_line("souler[Alice]送给Bob", room_owner="Joyer")
+        assert result.kind == ChatIntakeKind.PLAIN_CHAT
+
+    def test_gift_type2_heat_contribution_matches(self):
+        result = classify_chat_line("08-02 17:44:58 [I] 恭喜🍻🥂🥃🍸🍷🍺在此房间贡献出3120热力值")
+        assert result.kind == ChatIntakeKind.GIFT_RECEIVE
+        assert result.nickname == "🍻🥂🥃🍸🍷🍺"
+        assert result.text == "🍻🥂🥃🍸🍷🍺"
+
+
 
 class TestExpandQueueText:
     def test_splits_plain_and_command_parts(self):

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -32,9 +32,10 @@ async def test_db_models_registered():
     # 获取已注册的模型（Tortoise.apps 支持 __getitem__ 但不是 dict）
     registered_names = set(Tortoise.apps["models"].keys())
     expected_models = {"User", "SeatReservation", "Keyword",
-                       "EnterEvent", "ExitEvent", "ReturnEvent", "FocusEvent", "Timer"}
+                       "EnterEvent", "ExitEvent", "ReturnEvent", "FocusEvent", "Timer", "ReceiveEvent"}
 
     assert expected_models.issubset(registered_names), (
+
         f"以下模型未注册: {expected_models - registered_names}"
     )
 

--- a/tests/test_message_content_gift.py
+++ b/tests/test_message_content_gift.py
@@ -1,0 +1,41 @@
+import pytest
+import pytest_asyncio
+from unittest.mock import MagicMock, AsyncMock
+from ushareiplay.core.db_manager import DatabaseManager
+from ushareiplay.events.message_content import MessageContentEvent
+from ushareiplay.core.chat_intake import ChatIntakeKind, classify_chat_line
+
+
+@pytest_asyncio.fixture
+async def db_init():
+    manager = DatabaseManager(db_url="sqlite://:memory:")
+    await manager.init()
+    yield
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_message_content_event_gift_handling(db_init, monkeypatch):
+    handler_mock = MagicMock()
+    handler_mock.config = {"soul": {"room_owner": "Joyer"}}
+    event_handler = MessageContentEvent(handler_mock)
+
+
+    # Mock MessageManager and chat_logger
+    mock_msg_manager = MagicMock()
+    mock_msg_manager.latest_chats = ["souler[🍻🥂🥃🍸🍷🍺]送给Joyer"]
+    mock_msg_manager.recent_chats = []
+
+    monkeypatch.setattr("ushareiplay.managers.message_manager.MessageManager.instance", lambda: mock_msg_manager)
+    monkeypatch.setattr("ushareiplay.managers.message_manager.get_chat_logger", lambda cfg: MagicMock())
+
+    notify_mock = AsyncMock()
+    monkeypatch.setattr("ushareiplay.managers.command_manager.CommandManager.notify_gift_receive", notify_mock, raising=False)
+
+    wrapper = MagicMock()
+    wrapper.content = "souler[🍻🥂🥃🍸🍷🍺]送给Joyer"
+
+    await event_handler.handle("message_content", wrapper)
+
+    # Verify notify_gift_receive was called with the giver's nickname
+    notify_mock.assert_called_once_with("🍻🥂🥃🍸🍷🍺")

--- a/tests/test_receive_command.py
+++ b/tests/test_receive_command.py
@@ -1,0 +1,63 @@
+import pytest
+import pytest_asyncio
+from unittest.mock import MagicMock
+from ushareiplay.core.db_manager import DatabaseManager
+
+from ushareiplay.commands.receive import ReceiveCommand
+from ushareiplay.models.message_info import MessageInfo
+from ushareiplay.core.message_queue import MessageQueue
+
+
+@pytest_asyncio.fixture
+async def db_init():
+    manager = DatabaseManager(db_url="sqlite://:memory:")
+    await manager.init()
+    yield
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_receive_command_operations(db_init):
+    mock_controller = MagicMock()
+    cmd = ReceiveCommand(mock_controller)
+
+    # Add command
+    msg = MessageInfo(content=':receive add ":say Thank you!"', nickname="Alice")
+    res = await cmd.do_process(msg, ["add", ":say Thank you!"])
+    assert "message" in res
+    assert "已添加" in res["message"]
+
+    # List command
+    msg_list = MessageInfo(content=":receive list", nickname="Alice")
+    res_list = await cmd.do_process(msg_list, ["list"])
+    assert "message" in res_list
+    assert ":say Thank you!" in res_list["message"]
+
+    # Clear command
+    msg_clear = MessageInfo(content=":receive clear", nickname="Alice")
+    res_clear = await cmd.do_process(msg_clear, ["clear"])
+    assert "message" in res_clear
+    assert "1" in res_clear["message"]
+
+
+@pytest.mark.asyncio
+async def test_receive_command_trigger(db_init):
+    mock_controller = MagicMock()
+    cmd = ReceiveCommand(mock_controller)
+
+    msg = MessageInfo(content=':receive add ":say Thanks!"', nickname="Bob")
+    await cmd.do_process(msg, ["add", ":say Thanks!"])
+
+    # Clear message queue before trigger
+    mq = MessageQueue.instance()
+    await mq.clear_queue()
+
+    # Trigger gift receive event for Bob
+    await cmd.user_gift_receive("Bob")
+
+    all_msgs = await mq.get_all_messages()
+    assert len(all_msgs) == 1
+    queued = all_msgs["queue_msg_0"]
+    assert queued.nickname == "Bob"
+    assert queued.content == ":say Thanks!"
+

--- a/tests/test_receive_dao.py
+++ b/tests/test_receive_dao.py
@@ -1,0 +1,43 @@
+import pytest
+import pytest_asyncio
+from ushareiplay.core.db_manager import DatabaseManager
+from ushareiplay.dal.receive_dao import ReceiveDao
+
+
+@pytest_asyncio.fixture
+async def db_init():
+    manager = DatabaseManager(db_url="sqlite://:memory:")
+    await manager.init()
+    yield
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_receive_dao_crud(db_init):
+    event = await ReceiveDao.create("Alice", ":play song")
+    assert event.id is not None
+    assert event.command == ":play song"
+
+    items = await ReceiveDao.get_by_username("Alice")
+    assert len(items) == 1
+    assert items[0].command == ":play song"
+
+    fetched = await ReceiveDao.get_by_id(event.id)
+    assert fetched is not None
+    assert fetched.id == event.id
+
+    deleted = await ReceiveDao.delete_by_id(event.id)
+    assert deleted is True
+
+    items = await ReceiveDao.get_by_username("Alice")
+    assert len(items) == 0
+
+
+@pytest.mark.asyncio
+async def test_receive_dao_delete_all(db_init):
+    await ReceiveDao.create("Bob", ":say hello")
+    await ReceiveDao.create("Bob", ":say world")
+    count = await ReceiveDao.delete_all_by_username("Bob")
+    assert count == 2
+    items = await ReceiveDao.get_by_username("Bob")
+    assert len(items) == 0

--- a/tests/test_receive_dao.py
+++ b/tests/test_receive_dao.py
@@ -41,3 +41,21 @@ async def test_receive_dao_delete_all(db_init):
     assert count == 2
     items = await ReceiveDao.get_by_username("Bob")
     assert len(items) == 0
+
+
+@pytest.mark.asyncio
+async def test_receive_dao_alias_resolution(db_init):
+    from ushareiplay.dal.user_dao import UserDAO
+    from ushareiplay.models import User
+
+    outlier = await UserDAO.get_or_create_raw("Outlier")
+    chainer = await User.create(username="Chainer", level=0, canonical_user_id=outlier.id)
+
+    # Outlier creates a receive command
+    await ReceiveDao.create("Outlier", ":say Thanks from Outlier")
+
+    # Querying by alias Chainer should find Outlier's receive commands
+    items = await ReceiveDao.get_by_username("Chainer")
+    assert len(items) == 1
+    assert items[0].command == ":say Thanks from Outlier"
+


### PR DESCRIPTION
## Overview
Implements detection of gift receive and heat contribution messages in Soul App chat and triggers automated user-configured commands stored in database via .

## Key Changes
- **Chat Intake Classification**: Added  in `chat_intake.py` to detect gift-sending (when receiver equals `soul.room_owner` config) and heat contribution lines.
- **Database Model & DAO**: Added `ReceiveEvent` model and `ReceiveDao` for managing user gift action rules.
- **Command & Event Dispatch**: Added `:receive` command (`add`, `del`, `list`, `clear`) and `CommandManager.notify_gift_receive`.
- **Message Content Integration**: `MessageContentEvent` passes `room_owner` config, logs gift occurrences, and dispatches events.
- **Tests**: Full unit & integration test coverage (356/356 tests passing).