### PR TITLE
fix(room-name): preserve pending theme update when initializing from UI

### DIFF
--- a/src/ushareiplay/managers/room_name_manager.py
+++ b/src/ushareiplay/managers/room_name_manager.py
@@ -130,11 +130,12 @@ class RoomNameManager(Singleton):
             parts = room_title_text.split('｜', 1)
             if len(parts) == 2:
                 theme_part = parts[0].strip()
-                self.current_theme = theme_part
+                if not self.pending_ui_update:
+                    self.current_theme = theme_part
                 self.current_title = parts[1].strip()
                 self.is_initialized = True
-                self.logger.info(f'Initialized room name from UI: theme={theme_part}, title={self.current_title}')
-                return {'success': True, 'theme': theme_part, 'title': self.current_title, 'initialized': True}
+                self.logger.info(f'Initialized room name from UI: theme={self.current_theme}, title={self.current_title}')
+                return {'success': True, 'theme': self.current_theme, 'title': self.current_title, 'initialized': True}
 
         self.current_title = room_title_text
         self.is_initialized = True
@@ -179,7 +180,9 @@ class RoomNameManager(Singleton):
         if '｜' in room_title_text:
             parts = room_title_text.split('｜', 1)
             if len(parts) == 2:
-                self.current_theme = parts[0].strip()
+                theme_part = parts[0].strip()
+                if not self.pending_ui_update:
+                    self.current_theme = theme_part
                 self.current_title = parts[1].strip()
                 self.is_initialized = True
                 self.logger.info(f"Initialized room name from UI: theme={self.current_theme}, title={self.current_title}")

--- a/tests/test_room_name_manager.py
+++ b/tests/test_room_name_manager.py
@@ -184,3 +184,26 @@ def test_reset_theme_uses_default_theme_from_config(monkeypatch):
 
     assert manager.get_current_theme() == "电音"
     assert manager.has_pending_ui_update() is True
+
+
+def test_process_pending_update_preserves_theme_when_uninitialized():
+    manager = _manager_with_fake_handler()
+    assert manager.is_initialized is False
+
+    manager.set_theme("三福")
+    assert manager.get_current_theme() == "三福"
+    assert manager.has_pending_ui_update() is True
+
+    fake_element = MagicMock()
+    manager._handler.element_finder.try_find_element.return_value = fake_element
+    manager._handler.element_finder.get_element_text.return_value = "回家｜Lofi Girl"
+    manager._handler.element_finder.wait_for_element_clickable.return_value = fake_element
+    manager._handler.gesture_handler.click_element_at.return_value = True
+    manager._handler.element_finder.wait_for_any_element.return_value = ("title_edit_entry", fake_element)
+
+    result = manager.process_pending_update()
+
+    assert result["ui_updated"] is True
+    fake_element.send_keys.assert_called_once_with("三福｜Lofi Girl")
+    assert manager.get_current_theme() == "三福"
+


### PR DESCRIPTION
## Description
Fixes an issue where executing `/theme <new_theme>` before room name state was initialized from the UI caused the pending theme change to be overwritten by the old theme read from the screen.

## Root Cause
When `RoomNameManager.is_initialized` was `False`, `get_title_to_update()` invoked `_parse_title_from_ui()`. Parsing the existing UI title unconditionally set `self.current_theme` to the parsed theme prefix (e.g. `回家`), destroying the pending theme update (`三福`).

## Solution
- Guarded `self.current_theme` UI updates in `_parse_title_from_ui` and `initialize_from_ui` with `if not self.pending_ui_update:`.
- Added unit test `test_process_pending_update_preserves_theme_when_uninitialized` in `tests/test_room_name_manager.py` to verify pending themes are preserved during uninitialized UI reads.