### PR TITLE
feat: 派对推荐功能优化与自动同步

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,6 +28,8 @@ soul:
   party_restart_minutes: 60 # 触发重启的时间（分钟），默认20小时
   # 派对创建模式：new_party_entry(新建) / restore_party(恢复)
   party_create_mode: "restore_party"
+  # 创建派对时是否开启推荐：true(开启) / false(关闭)
+  create_party_recommendation: true
 
   # 新建派对成功后的自动化（仅投递命令到 MessageQueue）
   post_party_create:
@@ -100,6 +102,9 @@ soul:
     new_party_entry: 'cn.soulapp.android:id/linCreate' # 新建派对
     party_state_entry: '//android.widget.TextView[@text="已公开" or @text="已隐藏"]' # 已公开｜已隐藏
     close_party_notification: '//android.widget.TextView[@text="关闭推荐分发"]'
+    party_recommendation_status: "cn.soulapp.android:id/tv_private_title"
+    party_recommendation_open: '//android.widget.TextView[@text="所有人"]'
+    party_recommendation_close: '//android.widget.TextView[@text="关闭推荐分发"]'
     create_party_button: '//android.widget.TextView[@text="创建房间"]'
     restore_party: "cn.soulapp.android:id/imgRestore"
     confirm_party: "cn.soulapp.android:id/tv_confirm"
@@ -355,7 +360,7 @@ commands:
     error_template: "别名绑定失败: {error}"
   - prefix: "info"
     level: 0
-    response_template: "播放模式: {play_mode}\n{current_playlist}\n{online_users}\n{party_duration}\n{song} - {singer} • {album} • {release_date}"
+    response_template: "播放模式: {play_mode}\n{current_playlist}\n{online_users}\n{party_duration}\n派对推荐: {party_recommendation}\n{song} - {singer} • {album} • {release_date}"
     error_template: "Failed to get playback info, because {error}"
   - prefix: "singer"
     level: 1
@@ -452,6 +457,11 @@ commands:
     level: 4
     response_template: "{message}"
     error_template: "{error}"
+
+  - prefix: "recommend"
+    level: 1
+    response_template: "派对推荐已设置为: {status}"
+    error_template: "设置派对推荐失败: {error}"
 
 old_song_filter:
   enabled: true

--- a/docs/superpowers/specs/2026-08-03-party-recommendation-design.md
+++ b/docs/superpowers/specs/2026-08-03-party-recommendation-design.md
@@ -1,0 +1,125 @@
+# Design Spec: Party Recommendation Management & Syncing
+
+## Overview
+
+This spec defines the design for party recommendation management in UShareIPlay. It introduces configuration, state management, active and passive recommendation status synchronization, the `:recommend` command, and `:info` status reporting.
+
+---
+
+## 1. Configuration & UI Locators
+
+### 1.1 Config (`config.yaml`)
+Add `create_party_recommendation` setting under `soul` and recommendation UI locators under `soul.elements`:
+
+```yaml
+soul:
+  create_party_recommendation: true # 创建派对时默认开启推荐 (default: true)
+
+  elements:
+    party_recommendation_status: "cn.soulapp.android:id/tv_private_title" # 房间推荐状态 View
+    party_recommendation_open: '//android.widget.TextView[@text="所有人"]' # 开放推荐选项
+    party_recommendation_close: '//android.widget.TextView[@text="关闭推荐分发"]' # 关闭推荐选项
+```
+
+---
+
+## 2. Room State & Info Integration
+
+### 2.1 RoomState (`src/ushareiplay/state/room_state.py`)
+Add `_recommendation_enabled: Optional[bool] = None` property to `RoomState`:
+- `None`: Status uninitialized / not saved yet.
+- `True`: Recommendation is open ("所有人").
+- `False`: Recommendation is closed ("关闭推荐分发").
+
+Expose getter and setter:
+- `recommendation_enabled -> Optional[bool]`
+- `clear()` resets `_recommendation_enabled` to `None`.
+
+### 2.2 InfoManager (`src/ushareiplay/managers/info_manager.py`)
+Delegate `recommendation_enabled` getter/setter to `RoomState`.
+
+### 2.3 InfoCommand (`src/ushareiplay/commands/info.py`) & Template
+In `InfoCommand.do_process()`:
+- `party_recommendation`: `"开放"` if `recommendation_enabled is True`, `"关闭"` if `False`, `"未知"` if `None`.
+
+In `config.yaml`:
+- Update `info.response_template`:
+```yaml
+response_template: "播放模式: {play_mode}\n{current_playlist}\n{online_users}\n{party_duration}\n派对推荐: {party_recommendation}\n{song} - {singer} • {album} • {release_date}"
+```
+
+---
+
+## 3. Party Recommendation Manager (`src/ushareiplay/managers/recommendation_manager.py`)
+
+Create `RecommendationManager(Singleton)` to encapsulate UI detection and recommendation state updates:
+
+### 3.1 UI Interaction Flow
+- `inspect_current_ui_status() -> Optional[bool]`:
+  - When the room title dialog (`chat_room_title`) is open, locate `party_recommendation_status` (`tv_private_title`).
+  - Return `True` if text is `"所有人"`, `False` if text is `"关闭推荐分发"`, `None` if element not found.
+
+- `update_recommendation_ui(target_state: bool) -> dict`:
+  - With room title dialog open:
+  - If current UI status does not match `target_state`:
+    - Click `party_recommendation_status` (`tv_private_title`).
+    - Click `party_recommendation_open` if `target_state` is True, or `party_recommendation_close` if False.
+  - Update `RoomState.recommendation_enabled = target_state`.
+  - Return `{'success': True, 'recommendation_enabled': target_state}`.
+
+### 3.2 Active & Passive Synchronization Policy
+1. **Active Sync (`ensure_synced_on_return()`)**:
+   - Triggered when returning to / restoring room or after party creation.
+   - If `RoomState.recommendation_enabled is None` (uninitialized/unsaved):
+     - Click `chat_room_title` to open dialog.
+     - Inspect UI status via `inspect_current_ui_status()`.
+     - Target state = `config.get('soul', {}).get('create_party_recommendation', True)`.
+     - If UI status differs from target state, execute `update_recommendation_ui(target_state)`.
+     - Update `RoomState.recommendation_enabled`.
+     - Press back to close title dialog.
+   - If `RoomState.recommendation_enabled is not None`:
+     - Skip opening title dialog.
+
+2. **Passive Discrepancy Sync (`sync_ui_status_if_dialog_open()`)**:
+   - Triggered whenever the room title dialog is opened for ANY reason (e.g. `RoomNameManager._update_title_ui` or manually clicking title).
+   - Inspects UI status via `inspect_current_ui_status()`.
+   - If UI status is found and differs from `RoomState.recommendation_enabled`, update `RoomState.recommendation_enabled` to match the actual UI status and log the discrepancy correction.
+
+3. **Party Creation Flow (`PartyManager._create_party_flow`)**:
+   - Check `soul.create_party_recommendation` (default `True`).
+   - If `create_party_recommendation` is `False`, click `close_party_notification` (`party_recommendation_close`) during creation flow, and set `RoomState.recommendation_enabled = False`.
+   - If `create_party_recommendation` is `True`, keep recommendation enabled (do not click close), and set `RoomState.recommendation_enabled = True`.
+
+---
+
+## 4. Recommend Command (`src/ushareiplay/commands/recommend.py`)
+
+- **Prefix**: `recommend`
+- **Level**: 1 (or admin level based on config)
+- **Syntax**:
+  - `:recommend` -> Toggles status (if currently `True` -> set to `False`, else set to `True`).
+  - `:recommend on` / `:recommend 开启` -> Sets status to `True`.
+  - `:recommend off` / `:recommend 关闭` -> Sets status to `False`.
+- **Execution**:
+  - Switch to Soul app.
+  - Open title dialog (`chat_room_title`).
+  - Execute `RecommendationManager.update_recommendation_ui(target_state)`.
+  - Press back to return to room.
+  - Return response template: `"派对推荐已设置为: {status}"` (where `status` is `"开放"` or `"关闭"`).
+
+Add `recommend` entry to `config.yaml` commands list:
+```yaml
+  - prefix: "recommend"
+    level: 1
+    response_template: "派对推荐已设置为: {status}"
+    error_template: "设置派对推荐失败: {error}"
+```
+
+---
+
+## 5. Testing & Verification
+
+1. Unit tests for `RoomState` recommendation state getter/setter and `clear()`.
+2. Unit tests for `RecommendationManager` active/passive sync logic & state matching.
+3. Unit tests for `InfoCommand` and `RecommendCommand` parameter parsing and response formatting.
+4. Pytest suite execution (`uv run pytest -q`).

--- a/src/ushareiplay/commands/info.py
+++ b/src/ushareiplay/commands/info.py
@@ -61,6 +61,14 @@ class InfoCommand(BaseCommand):
         result["play_mode_key"] = play_mode_key
         result["play_mode"] = music_handler.play_mode_key_to_name(play_mode_key) if music_handler else "未知"
 
+        rec_status = info_manager.recommendation_enabled
+        if rec_status is True:
+            result["party_recommendation"] = "开放"
+        elif rec_status is False:
+            result["party_recommendation"] = "关闭"
+        else:
+            result["party_recommendation"] = "未知"
+
         return result
 
     def update(self):

--- a/src/ushareiplay/commands/info.py
+++ b/src/ushareiplay/commands/info.py
@@ -62,6 +62,12 @@ class InfoCommand(BaseCommand):
         result["play_mode"] = music_handler.play_mode_key_to_name(play_mode_key) if music_handler else "未知"
 
         rec_status = info_manager.recommendation_enabled
+        if rec_status is None:
+            from ushareiplay.managers.recommendation_manager import RecommendationManager
+            if RecommendationManager.is_initialized():
+                RecommendationManager.instance().ensure_synced_on_return()
+                rec_status = info_manager.recommendation_enabled
+
         if rec_status is True:
             result["party_recommendation"] = "开放"
         elif rec_status is False:

--- a/src/ushareiplay/commands/recommend.py
+++ b/src/ushareiplay/commands/recommend.py
@@ -1,0 +1,39 @@
+from ushareiplay.core.base_command import BaseCommand
+from ushareiplay.managers.recommendation_manager import RecommendationManager
+
+
+class RecommendCommand(BaseCommand):
+    handler_attr = 'soul_handler'
+
+    async def do_process(self, message_info, parameters):
+        if not self.handler.key_actions.switch_to_app():
+            return {'error': 'Failed to switch to Soul app'}
+
+        rec_manager = RecommendationManager.instance()
+        current_status = rec_manager.room_state.recommendation_enabled
+
+        if not parameters:
+            # Toggle current state (if None or True -> False, if False -> True)
+            target_state = not current_status if current_status is not None else False
+        else:
+            arg = str(parameters[0]).strip().lower()
+            if arg in ('on', 'open', '1', '开启', '开放', '所有人'):
+                target_state = True
+            elif arg in ('off', 'close', '0', '关闭', '关闭推荐分发'):
+                target_state = False
+            else:
+                return {'error': f'未知参数 "{parameters[0]}", 请使用 on/off 或 开启/关闭'}
+
+        click_res = self.handler.ui_actions.switch_and_click(
+            'chat_room_title', error_message='Failed to find room title'
+        )
+        if isinstance(click_res, dict) and 'error' in click_res:
+            return click_res
+
+        update_res = rec_manager.update_recommendation_ui(target_state)
+        self.handler.key_actions.press_back()
+
+        if 'error' in update_res:
+            return update_res
+
+        return {'status': '开放' if target_state else '关闭'}

--- a/src/ushareiplay/commands/recommend.py
+++ b/src/ushareiplay/commands/recommend.py
@@ -31,7 +31,7 @@ class RecommendCommand(BaseCommand):
             return click_res
 
         update_res = rec_manager.update_recommendation_ui(target_state)
-        self.handler.key_actions.press_back()
+        rec_manager.close_title_dialog()
 
         if 'error' in update_res:
             return update_res

--- a/src/ushareiplay/core/app_controller.py
+++ b/src/ushareiplay/core/app_controller.py
@@ -336,6 +336,7 @@ class AppController(Singleton):
             from ushareiplay.managers.sleep_manager import SleepManager
             from ushareiplay.managers.theme_manager import ThemeManager
             from ushareiplay.managers.title_manager import TitleManager
+            from ushareiplay.managers.recommendation_manager import RecommendationManager
             from ushareiplay.managers.room_name_manager import RoomNameManager
             from ushareiplay.managers.user_manager import UserManager
             from ushareiplay.state.online_list_scraper import OnlineListScraper
@@ -373,6 +374,7 @@ class AppController(Singleton):
             self.info_manager = InfoManager.initialize()
             self.party_manager = PartyManager.initialize()
             self.notice_manager = NoticeManager.initialize()
+            RecommendationManager.initialize()
             RoomNameManager.initialize()
             ThemeManager.initialize()
             TitleManager.initialize()

--- a/src/ushareiplay/core/singleton.py
+++ b/src/ushareiplay/core/singleton.py
@@ -50,6 +50,11 @@ class Singleton(metaclass=SingletonMeta):
         return cls._instance
 
     @classmethod
+    def is_initialized(cls) -> bool:
+        """Check if this singleton has been initialized."""
+        return bool(cls.__dict__.get("_singleton_initialized", False))
+
+    @classmethod
     def reset_instance(cls) -> None:
         """Reset one singleton. Intended for tests and process restart only."""
         with SingletonMeta._lock:

--- a/src/ushareiplay/managers/info_manager.py
+++ b/src/ushareiplay/managers/info_manager.py
@@ -245,12 +245,20 @@ class InfoManager(Singleton):
         """
         self._room_state.room_id = value
 
+    @property
+    def recommendation_enabled(self) -> Optional[bool]:
+        """获取房间推荐状态"""
+        return self._room_state.recommendation_enabled
+
+    @recommendation_enabled.setter
+    def recommendation_enabled(self, value: Optional[bool]):
+        """设置房间推荐状态"""
+        self._room_state.recommendation_enabled = value
+
     def clear(self):
         """清空在线用户列表与房间状态"""
         self._presence_tracker._online_users.clear()
-        self._room_state._user_count = None
-        self._room_state._focus_count = None
-        self._room_state._room_id = None
+        self._room_state.clear()
         self.logger.info("Cleared online users list")
 
     # ------------------------------------------------------------------

--- a/src/ushareiplay/managers/party_manager.py
+++ b/src/ushareiplay/managers/party_manager.py
@@ -304,6 +304,9 @@ class PartyManager(Singleton):
                 return False
 
             if self._search_and_try_enter_existing_party():
+                from ushareiplay.managers.recommendation_manager import RecommendationManager
+                if RecommendationManager.is_initialized():
+                    RecommendationManager.instance().ensure_synced_on_return()
                 return True
 
             if not self._create_party_flow():
@@ -424,12 +427,22 @@ class PartyManager(Singleton):
         party_state_entry.click()
         self.logger.info("Clicked party state entry")
 
-        close_party_notification = self.handler.element_finder.wait_for_element('close_party_notification')
-        if not close_party_notification:
-            self.logger.warning("未找到关闭派对推荐")
-            return False
-        close_party_notification.click()
-        self.logger.info("Clicked close party notification")
+        party_recommend_config = bool(self.handler.config.get('create_party_recommendation', True))
+        if not party_recommend_config:
+            close_party_notification = self.handler.element_finder.wait_for_element('close_party_notification')
+            if not close_party_notification:
+                self.logger.warning("未找到关闭派对推荐")
+                return False
+            close_party_notification.click()
+            self.logger.info("Clicked close party notification")
+            from ushareiplay.state.room_state import RoomState
+            if RoomState.is_initialized():
+                RoomState.instance().recommendation_enabled = False
+        else:
+            self.logger.info("Keep party recommendation enabled as configured")
+            from ushareiplay.state.room_state import RoomState
+            if RoomState.is_initialized():
+                RoomState.instance().recommendation_enabled = True
 
         create_party_button = self.handler.element_finder.wait_for_element('create_party_button')
         if not create_party_button:

--- a/src/ushareiplay/managers/recommendation_manager.py
+++ b/src/ushareiplay/managers/recommendation_manager.py
@@ -125,9 +125,10 @@ class RecommendationManager(Singleton):
 
     def ensure_synced_on_return(self) -> dict:
         """
-        主动同步：回到/恢复房间时调用。
-        若 RoomState 已有保存状态，则跳过（不强行打开弹窗）；
-        若状态未保存 (None)，主动打开标题弹窗校验并设置。
+        主动同步：回到/恢复房间或执行 info 时调用。
+        若 RoomState 已有保存状态，则跳过（不打开弹窗）；
+        若状态未保存 (None)，仅打开第 2 层房间信息窗口，读取 tv_private_title 文本保存状态，
+        随后按一次返回键退出第二层窗口。不强行点击进入第三层选项列表。
         """
         if self.room_state.recommendation_enabled is not None:
             return {"skipped": True, "reason": "already_saved"}
@@ -139,14 +140,14 @@ class RecommendationManager(Singleton):
             if isinstance(switch_res, dict) and "error" in switch_res:
                 return switch_res
 
-            target_state = bool(
-                self.handler.config.get("create_party_recommendation", True)
-            )
-            result = self.update_recommendation_ui(target_state)
+            ui_status = self.inspect_current_ui_status()
+            if ui_status is not None:
+                self.room_state.recommendation_enabled = ui_status
+                self.logger.info(f"Inspected room recommendation status from UI: {ui_status}")
 
-            self.close_title_dialog()
-            self.logger.info("Closed title dialog after active recommendation sync")
-            return result
+            self.handler.key_actions.press_back()
+            self.logger.info("Closed room info window after reading recommendation status")
+            return {"success": True, "recommendation_enabled": ui_status}
         except Exception:
             self.logger.error(f"Error in ensure_synced_on_return: {traceback.format_exc()}")
             return {"error": "Error during active recommendation sync"}

--- a/src/ushareiplay/managers/recommendation_manager.py
+++ b/src/ushareiplay/managers/recommendation_manager.py
@@ -1,0 +1,136 @@
+import traceback
+from typing import Optional
+
+from ushareiplay.core.singleton import Singleton
+from ushareiplay.state.room_state import RoomState
+
+
+class RecommendationManager(Singleton):
+    """
+    派对推荐管理器
+    负责房间推荐状态的读取、更新、主动同步与被动纠偏。
+    """
+
+    def __init__(self):
+        self._handler = None
+        self._logger = None
+
+    @property
+    def handler(self):
+        if self._handler is None:
+            from ushareiplay.handlers.soul_handler import SoulHandler
+
+            self._handler = SoulHandler.instance()
+        return self._handler
+
+    @property
+    def logger(self):
+        if self._logger is None:
+            self._logger = self.handler.logger
+        return self._logger
+
+    @property
+    def room_state(self):
+        return RoomState.instance()
+
+    def inspect_current_ui_status(self) -> Optional[bool]:
+        """
+        在房间标题弹窗已打开的前提下，检查当前的推荐状态。
+        Returns:
+            True: 显示 "所有人" (开放推荐)
+            False: 显示 "关闭推荐分发" (关闭推荐)
+            None: 未定位到元素或不匹配
+        """
+        try:
+            elem = self.handler.element_finder.try_find_element(
+                "party_recommendation_status", log=False
+            )
+            if not elem:
+                return None
+            text = self.handler.element_finder.get_element_text(elem)
+            if not text:
+                return None
+            text = text.strip()
+            if "所有人" in text:
+                return True
+            if "关闭推荐分发" in text:
+                return False
+            return None
+        except Exception:
+            self.logger.error(f"Error inspecting recommendation UI status: {traceback.format_exc()}")
+            return None
+
+    def sync_ui_status_if_dialog_open(self) -> Optional[bool]:
+        """
+        被动纠偏：当标题弹窗因任何原因（如更新标题/主题）被打开时被动调用。
+        读取当前真实 UI 状态并同步修正 RoomState 中的记录。
+        """
+        ui_status = self.inspect_current_ui_status()
+        if ui_status is not None:
+            current_saved = self.room_state.recommendation_enabled
+            if current_saved != ui_status:
+                self.logger.info(
+                    f"Passive sync detected recommendation status drift: saved={current_saved} -> ui={ui_status}"
+                )
+                self.room_state.recommendation_enabled = ui_status
+        return ui_status
+
+    def update_recommendation_ui(self, target_state: bool) -> dict:
+        """
+        在标题弹窗已打开的前提下，将推荐状态更新为目标状态 target_state。
+        """
+        try:
+            current_status = self.inspect_current_ui_status()
+            if current_status == target_state:
+                self.room_state.recommendation_enabled = target_state
+                self.logger.info(f"Recommendation status is already target state ({target_state})")
+                return {"success": True, "recommendation_enabled": target_state}
+
+            status_elem = self.handler.element_finder.wait_for_element_clickable(
+                "party_recommendation_status"
+            )
+            if not status_elem:
+                return {"error": "Failed to find recommendation status entry"}
+            status_elem.click()
+            self.logger.info("Clicked recommendation status entry")
+
+            opt_key = "party_recommendation_open" if target_state else "party_recommendation_close"
+            opt_elem = self.handler.element_finder.wait_for_element_clickable(opt_key)
+            if not opt_elem:
+                return {"error": f"Failed to find option for recommendation ({opt_key})"}
+            opt_elem.click()
+            self.logger.info(f"Clicked recommendation option ({opt_key})")
+
+            self.room_state.recommendation_enabled = target_state
+            return {"success": True, "recommendation_enabled": target_state}
+        except Exception:
+            self.logger.error(f"Error updating recommendation UI: {traceback.format_exc()}")
+            return {"error": "Error updating recommendation UI"}
+
+    def ensure_synced_on_return(self) -> dict:
+        """
+        主动同步：回到/恢复房间时调用。
+        若 RoomState 已有保存状态，则跳过（不强行打开弹窗）；
+        若状态未保存 (None)，主动打开标题弹窗校验并设置。
+        """
+        if self.room_state.recommendation_enabled is not None:
+            return {"skipped": True, "reason": "already_saved"}
+
+        try:
+            switch_res = self.handler.ui_actions.switch_and_click(
+                "chat_room_title", error_message="Failed to click room title for sync"
+            )
+            if isinstance(switch_res, dict) and "error" in switch_res:
+                return switch_res
+
+            target_state = bool(
+                self.handler.config.get("create_party_recommendation", True)
+            )
+            result = self.update_recommendation_ui(target_state)
+
+            self.handler.key_actions.press_back()
+            self.logger.info("Closed title dialog after active recommendation sync")
+            return result
+        except Exception:
+            self.logger.error(f"Error in ensure_synced_on_return: {traceback.format_exc()}")
+            return {"error": "Error during active recommendation sync"}

--- a/src/ushareiplay/managers/recommendation_manager.py
+++ b/src/ushareiplay/managers/recommendation_manager.py
@@ -33,18 +33,25 @@ class RecommendationManager(Singleton):
     def room_state(self):
         return RoomState.instance()
 
-    def inspect_current_ui_status(self) -> Optional[bool]:
+    def inspect_current_ui_status(self, wait: bool = False) -> Optional[bool]:
         """
         在房间标题弹窗已打开的前提下，检查当前的推荐状态。
+        Args:
+            wait: 是否等待元素出现（当刚点击打开标题弹窗时建议设为 True）
         Returns:
             True: 显示 "所有人" (开放推荐)
             False: 显示 "关闭推荐分发" (关闭推荐)
             None: 未定位到元素或不匹配
         """
         try:
-            elem = self.handler.element_finder.try_find_element(
-                "party_recommendation_status", log=False
-            )
+            if wait:
+                elem = self.handler.element_finder.wait_for_element(
+                    "party_recommendation_status"
+                )
+            else:
+                elem = self.handler.element_finder.try_find_element(
+                    "party_recommendation_status", log=False
+                )
             if not elem:
                 return None
             text = self.handler.element_finder.get_element_text(elem)
@@ -140,7 +147,7 @@ class RecommendationManager(Singleton):
             if isinstance(switch_res, dict) and "error" in switch_res:
                 return switch_res
 
-            ui_status = self.inspect_current_ui_status()
+            ui_status = self.inspect_current_ui_status(wait=True)
             if ui_status is not None:
                 self.room_state.recommendation_enabled = ui_status
                 self.logger.info(f"Inspected room recommendation status from UI: {ui_status}")

--- a/src/ushareiplay/managers/recommendation_manager.py
+++ b/src/ushareiplay/managers/recommendation_manager.py
@@ -107,6 +107,22 @@ class RecommendationManager(Singleton):
             self.logger.error(f"Error updating recommendation UI: {traceback.format_exc()}")
             return {"error": "Error updating recommendation UI"}
 
+    def close_title_dialog(self) -> None:
+        """
+        关闭房间信息弹窗，确保返回到派对主界面。
+        由于切换推荐选项后可能停留在房间信息弹窗（父级对话框），需要确保彻底退出弹窗。
+        """
+        try:
+            self.handler.key_actions.press_back()
+            elem = self.handler.element_finder.try_find_element(
+                "party_recommendation_status", log=False
+            )
+            if elem:
+                self.logger.info("Room info window still visible after back, pressing back again to exit")
+                self.handler.key_actions.press_back()
+        except Exception as e:
+            self.logger.warning(f"Error closing title dialog: {str(e)}")
+
     def ensure_synced_on_return(self) -> dict:
         """
         主动同步：回到/恢复房间时调用。
@@ -128,7 +144,7 @@ class RecommendationManager(Singleton):
             )
             result = self.update_recommendation_ui(target_state)
 
-            self.handler.key_actions.press_back()
+            self.close_title_dialog()
             self.logger.info("Closed title dialog after active recommendation sync")
             return result
         except Exception:

--- a/src/ushareiplay/managers/room_name_manager.py
+++ b/src/ushareiplay/managers/room_name_manager.py
@@ -265,6 +265,10 @@ class RoomNameManager(Singleton):
             if 'error' in result:
                 return result
 
+            from ushareiplay.managers.recommendation_manager import RecommendationManager
+            if RecommendationManager.is_initialized():
+                RecommendationManager.instance().sync_ui_status_if_dialog_open()
+
             current_theme = self.current_theme
             self.logger.info(f"Updating room title: {current_theme}｜{title}")
 

--- a/src/ushareiplay/state/room_state.py
+++ b/src/ushareiplay/state/room_state.py
@@ -11,6 +11,7 @@ class RoomState(Singleton):
         self._user_count: Optional[int] = None
         self._focus_count: Optional[int] = None
         self._room_id: Optional[str] = None
+        self._recommendation_enabled: Optional[bool] = None
 
     @property
     def logger(self):
@@ -19,6 +20,18 @@ class RoomState(Singleton):
             from ushareiplay.handlers.soul_handler import SoulHandler
             self._logger = SoulHandler.instance().logger
         return self._logger
+
+    @property
+    def recommendation_enabled(self) -> Optional[bool]:
+        """获取房间推荐状态（True: 所有人/开放, False: 关闭推荐分发, None: 未保存/未知）"""
+        return self._recommendation_enabled
+
+    @recommendation_enabled.setter
+    def recommendation_enabled(self, value: Optional[bool]):
+        """设置房间推荐状态"""
+        if self._recommendation_enabled != value:
+            self.logger.info(f"Recommendation status updated: {self._recommendation_enabled} -> {value}")
+        self._recommendation_enabled = value
 
     @property
     def user_count(self) -> Optional[int]:
@@ -60,4 +73,6 @@ class RoomState(Singleton):
         self._user_count = None
         self._focus_count = None
         self._room_id = None
+        self._recommendation_enabled = None
         self.logger.info("Cleared room state")
+

--- a/tests/test_info_command_recommendation.py
+++ b/tests/test_info_command_recommendation.py
@@ -17,6 +17,9 @@ class MockElementFinder:
     def try_find_element(self, key, log=True):
         return self.elements.get(key)
 
+    def wait_for_element(self, key):
+        return self.elements.get(key)
+
     def wait_for_element_clickable(self, key):
         return self.elements.get(key)
 
@@ -54,7 +57,7 @@ def info_cmd_setup():
     info_manager._online_users = set()
     info_manager._party_manager = SimpleNamespace(init_time=None)
     rec_manager = RecommendationManager.initialize()
-    rec_manager._logger = SimpleNamespace(info=lambda _msg: None)
+    rec_manager._logger = SimpleNamespace(info=lambda _msg: None, error=lambda _msg: None, warning=lambda _msg: None)
 
     title_elem = MockElement(text="所有人")
     opt_open = MockElement(text="所有人")
@@ -69,7 +72,7 @@ def info_cmd_setup():
         ),
         ui_actions=SimpleNamespace(switch_and_click=lambda key, **kwargs: {'success': True}),
         key_actions=SimpleNamespace(switch_to_app=lambda: True, press_back=lambda: None),
-        logger=SimpleNamespace(info=lambda _msg: None, error=lambda _msg: None),
+        logger=SimpleNamespace(info=lambda _msg: None, error=lambda _msg: None, warning=lambda _msg: None),
         config={"create_party_recommendation": True},
     )
     rec_manager._handler = soul_handler

--- a/tests/test_info_command_recommendation.py
+++ b/tests/test_info_command_recommendation.py
@@ -1,0 +1,95 @@
+from types import SimpleNamespace
+import pytest
+
+from ushareiplay.commands.info import InfoCommand
+from ushareiplay.state.playback_broadcaster import PlaybackBroadcaster
+from ushareiplay.state.playlist_state import PlaylistState
+from ushareiplay.state.presence_tracker import PresenceTracker
+from ushareiplay.state.room_state import RoomState
+from ushareiplay.managers.info_manager import InfoManager
+from ushareiplay.managers.recommendation_manager import RecommendationManager
+
+
+class MockElementFinder:
+    def __init__(self, elements=None):
+        self.elements = elements or {}
+
+    def try_find_element(self, key, log=True):
+        return self.elements.get(key)
+
+    def wait_for_element_clickable(self, key):
+        return self.elements.get(key)
+
+    def get_element_text(self, element):
+        return getattr(element, "text", "")
+
+
+class MockElement:
+    def __init__(self, text=""):
+        self.text = text
+        self.clicked = False
+
+    def click(self):
+        self.clicked = True
+
+
+@pytest.fixture
+def info_cmd_setup():
+    for cls in (
+        InfoManager,
+        PlaybackBroadcaster,
+        PlaylistState,
+        PresenceTracker,
+        RoomState,
+        RecommendationManager,
+    ):
+        cls.reset_instance()
+    PlaybackBroadcaster.initialize()
+    PlaylistState.initialize()
+    PresenceTracker.initialize()
+    room_state = RoomState.initialize()
+    room_state._logger = SimpleNamespace(info=lambda _msg: None)
+    info_manager = InfoManager.initialize()
+    info_manager._logger = SimpleNamespace(info=lambda _msg: None)
+    info_manager._online_users = set()
+    info_manager._party_manager = SimpleNamespace(init_time=None)
+    rec_manager = RecommendationManager.initialize()
+    rec_manager._logger = SimpleNamespace(info=lambda _msg: None)
+
+    title_elem = MockElement(text="所有人")
+    opt_open = MockElement(text="所有人")
+
+    soul_handler = SimpleNamespace(
+        element_finder=MockElementFinder(
+            elements={
+                "chat_room_title": MockElement(),
+                "party_recommendation_status": title_elem,
+                "party_recommendation_open": opt_open,
+            }
+        ),
+        ui_actions=SimpleNamespace(switch_and_click=lambda key, **kwargs: {'success': True}),
+        key_actions=SimpleNamespace(switch_to_app=lambda: True, press_back=lambda: None),
+        logger=SimpleNamespace(info=lambda _msg: None, error=lambda _msg: None),
+        config={"create_party_recommendation": True},
+    )
+    rec_manager._handler = soul_handler
+
+    music_handler = SimpleNamespace(play_mode_key="unknown", play_mode_key_to_name=lambda _k: "未知")
+    controller = SimpleNamespace(soul_handler=soul_handler, music_handler=music_handler)
+    cmd = InfoCommand(controller)
+    return cmd, room_state, info_manager
+
+
+@pytest.mark.asyncio
+async def test_info_command_fetches_recommendation_status_when_unknown(monkeypatch, info_cmd_setup):
+    cmd, room_state, info_manager = info_cmd_setup
+    monkeypatch.setattr(
+        "ushareiplay.handlers.qq_music_handler.QQMusicHandler.instance",
+        lambda: SimpleNamespace(play_mode_key="unknown", play_mode_key_to_name=lambda _k: "未知"),
+    )
+
+    room_state.recommendation_enabled = None
+    result = await cmd.do_process(SimpleNamespace(nickname="Console"), [])
+
+    assert result["party_recommendation"] == "开放"
+    assert room_state.recommendation_enabled is True

--- a/tests/test_recommend_command.py
+++ b/tests/test_recommend_command.py
@@ -1,0 +1,110 @@
+from types import SimpleNamespace
+import pytest
+
+from ushareiplay.state.playback_broadcaster import PlaybackBroadcaster
+from ushareiplay.state.playlist_state import PlaylistState
+from ushareiplay.state.presence_tracker import PresenceTracker
+from ushareiplay.state.room_state import RoomState
+from ushareiplay.managers.info_manager import InfoManager
+from ushareiplay.managers.recommendation_manager import RecommendationManager
+from ushareiplay.commands.recommend import RecommendCommand
+
+
+class MockElementFinder:
+    def __init__(self, elements=None):
+        self.elements = elements or {}
+
+    def try_find_element(self, key, log=True):
+        return self.elements.get(key)
+
+    def wait_for_element_clickable(self, key):
+        return self.elements.get(key)
+
+    def get_element_text(self, element):
+        return getattr(element, "text", "")
+
+
+class MockElement:
+    def __init__(self, text=""):
+        self.text = text
+        self.clicked = False
+
+    def click(self):
+        self.clicked = True
+
+
+@pytest.fixture
+def recommend_cmd_setup():
+    for cls in (
+        InfoManager,
+        PlaybackBroadcaster,
+        PlaylistState,
+        PresenceTracker,
+        RoomState,
+        RecommendationManager,
+    ):
+        cls.reset_instance()
+    PlaybackBroadcaster.initialize()
+    PlaylistState.initialize()
+    PresenceTracker.initialize()
+    room_state = RoomState.initialize()
+    room_state._logger = SimpleNamespace(info=lambda _msg: None)
+    info_manager = InfoManager.initialize()
+    info_manager._logger = SimpleNamespace(info=lambda _msg: None)
+    rec_manager = RecommendationManager.initialize()
+    rec_manager._logger = SimpleNamespace(info=lambda _msg: None)
+
+    title_elem = MockElement(text="所有人")
+    opt_close = MockElement(text="关闭推荐分发")
+    pressed_back = False
+
+    def press_back():
+        nonlocal pressed_back
+        pressed_back = True
+
+    soul_handler = SimpleNamespace(
+        element_finder=MockElementFinder(
+            elements={
+                "party_recommendation_status": title_elem,
+                "party_recommendation_close": opt_close,
+            }
+        ),
+        ui_actions=SimpleNamespace(switch_and_click=lambda key, **kwargs: {'success': True}),
+        key_actions=SimpleNamespace(switch_to_app=lambda: True, press_back=press_back),
+        logger=SimpleNamespace(info=lambda _msg: None, error=lambda _msg: None),
+    )
+    rec_manager._handler = soul_handler
+    cmd = RecommendCommand(
+        SimpleNamespace(soul_handler=soul_handler, music_handler=SimpleNamespace())
+    )
+    return cmd, room_state, title_elem, opt_close
+
+
+@pytest.mark.asyncio
+async def test_recommend_command_toggle_from_open_to_closed(recommend_cmd_setup):
+    cmd, room_state, title_elem, opt_close = recommend_cmd_setup
+    room_state.recommendation_enabled = True
+
+    result = await cmd.do_process(SimpleNamespace(nickname="Console"), [])
+
+    assert "error" not in result
+    assert result.get("status") == "关闭"
+    assert room_state.recommendation_enabled is False
+    assert opt_close.clicked is True
+
+
+@pytest.mark.asyncio
+async def test_recommend_command_explicit_on(recommend_cmd_setup):
+    cmd, room_state, title_elem, opt_close = recommend_cmd_setup
+    room_state.recommendation_enabled = False
+    title_elem.text = "关闭推荐分发"
+
+    opt_open = MockElement(text="所有人")
+    cmd.handler.element_finder.elements["party_recommendation_open"] = opt_open
+
+    result = await cmd.do_process(SimpleNamespace(nickname="Console"), ["on"])
+
+    assert "error" not in result
+    assert result.get("status") == "开放"
+    assert room_state.recommendation_enabled is True
+    assert opt_open.clicked is True

--- a/tests/test_recommendation_manager.py
+++ b/tests/test_recommendation_manager.py
@@ -52,7 +52,7 @@ def recommendation_setup():
     info_manager = InfoManager.initialize()
     info_manager._logger = SimpleNamespace(info=lambda _msg: None)
     rec_manager = RecommendationManager.initialize()
-    rec_manager._logger = SimpleNamespace(info=lambda _msg: None)
+    rec_manager._logger = SimpleNamespace(info=lambda _msg: None, warning=lambda _msg: None)
     return rec_manager, room_state
 
 
@@ -107,11 +107,11 @@ def test_ensure_synced_on_return_executes_sync_when_unsaved(recommendation_setup
     title_elem = MockElement(text="关闭推荐分发")
     chat_title = MockElement()
     opt_open = MockElement(text="所有人")
-    pressed_back = False
+    back_count = 0
 
     def press_back():
-        nonlocal pressed_back
-        pressed_back = True
+        nonlocal back_count
+        back_count += 1
 
     handler = SimpleNamespace(
         element_finder=MockElementFinder(
@@ -133,4 +133,29 @@ def test_ensure_synced_on_return_executes_sync_when_unsaved(recommendation_setup
     assert room_state.recommendation_enabled is True
     assert title_elem.clicked is True
     assert opt_open.clicked is True
-    assert pressed_back is True
+    assert back_count >= 1
+
+
+def test_close_title_dialog_presses_back_twice_if_window_still_open(recommendation_setup):
+    rec_manager, room_state = recommendation_setup
+    back_count = 0
+    finder = MockElementFinder()
+
+    def press_back():
+        nonlocal back_count
+        back_count += 1
+        # After first back, window is still open; after second back, element is gone
+        if back_count == 1:
+            finder.elements["party_recommendation_status"] = MockElement(text="关闭推荐分发")
+        else:
+            finder.elements.pop("party_recommendation_status", None)
+
+    handler = SimpleNamespace(
+        element_finder=finder,
+        key_actions=SimpleNamespace(press_back=press_back),
+        logger=SimpleNamespace(info=lambda _msg: None, warning=lambda _msg: None),
+    )
+    rec_manager._handler = handler
+
+    rec_manager.close_title_dialog()
+    assert back_count == 2

--- a/tests/test_recommendation_manager.py
+++ b/tests/test_recommendation_manager.py
@@ -17,6 +17,9 @@ class MockElementFinder:
     def try_find_element(self, key, log=True):
         return self.elements.get(key)
 
+    def wait_for_element(self, key):
+        return self.elements.get(key)
+
     def wait_for_element_clickable(self, key):
         return self.elements.get(key)
 

--- a/tests/test_recommendation_manager.py
+++ b/tests/test_recommendation_manager.py
@@ -1,0 +1,136 @@
+from types import SimpleNamespace
+import pytest
+
+from ushareiplay.state.playback_broadcaster import PlaybackBroadcaster
+from ushareiplay.state.playlist_state import PlaylistState
+from ushareiplay.state.presence_tracker import PresenceTracker
+from ushareiplay.state.room_state import RoomState
+from ushareiplay.managers.info_manager import InfoManager
+from ushareiplay.managers.recommendation_manager import RecommendationManager
+
+
+class MockElementFinder:
+    def __init__(self, texts=None, elements=None):
+        self.texts = texts or {}
+        self.elements = elements or {}
+
+    def try_find_element(self, key, log=True):
+        return self.elements.get(key)
+
+    def wait_for_element_clickable(self, key):
+        return self.elements.get(key)
+
+    def get_element_text(self, element):
+        return getattr(element, "text", "")
+
+
+class MockElement:
+    def __init__(self, text=""):
+        self.text = text
+        self.clicked = False
+
+    def click(self):
+        self.clicked = True
+
+
+@pytest.fixture
+def recommendation_setup():
+    for cls in (
+        InfoManager,
+        PlaybackBroadcaster,
+        PlaylistState,
+        PresenceTracker,
+        RoomState,
+        RecommendationManager,
+    ):
+        cls.reset_instance()
+    PlaybackBroadcaster.initialize()
+    PlaylistState.initialize()
+    PresenceTracker.initialize()
+    room_state = RoomState.initialize()
+    room_state._logger = SimpleNamespace(info=lambda _msg: None)
+    info_manager = InfoManager.initialize()
+    info_manager._logger = SimpleNamespace(info=lambda _msg: None)
+    rec_manager = RecommendationManager.initialize()
+    rec_manager._logger = SimpleNamespace(info=lambda _msg: None)
+    return rec_manager, room_state
+
+
+def test_inspect_current_ui_status(recommendation_setup):
+    rec_manager, room_state = recommendation_setup
+    title_elem = MockElement(text="所有人")
+    handler = SimpleNamespace(
+        element_finder=MockElementFinder(elements={"party_recommendation_status": title_elem})
+    )
+    rec_manager._handler = handler
+
+    status = rec_manager.inspect_current_ui_status()
+    assert status is True
+
+    title_elem.text = "关闭推荐分发"
+    status = rec_manager.inspect_current_ui_status()
+    assert status is False
+
+    title_elem.text = "其他未知状态"
+    status = rec_manager.inspect_current_ui_status()
+    assert status is None
+
+
+def test_sync_ui_status_if_dialog_open_updates_room_state(recommendation_setup):
+    rec_manager, room_state = recommendation_setup
+    title_elem = MockElement(text="所有人")
+    handler = SimpleNamespace(
+        element_finder=MockElementFinder(elements={"party_recommendation_status": title_elem})
+    )
+    rec_manager._handler = handler
+
+    room_state.recommendation_enabled = False
+    status = rec_manager.sync_ui_status_if_dialog_open()
+
+    assert status is True
+    assert room_state.recommendation_enabled is True
+
+
+def test_ensure_synced_on_return_skips_when_already_saved(recommendation_setup):
+    rec_manager, room_state = recommendation_setup
+    room_state.recommendation_enabled = True
+
+    result = rec_manager.ensure_synced_on_return()
+    assert result.get("skipped") is True
+    assert result.get("reason") == "already_saved"
+
+
+def test_ensure_synced_on_return_executes_sync_when_unsaved(recommendation_setup):
+    rec_manager, room_state = recommendation_setup
+    room_state.recommendation_enabled = None
+
+    title_elem = MockElement(text="关闭推荐分发")
+    chat_title = MockElement()
+    opt_open = MockElement(text="所有人")
+    pressed_back = False
+
+    def press_back():
+        nonlocal pressed_back
+        pressed_back = True
+
+    handler = SimpleNamespace(
+        element_finder=MockElementFinder(
+            elements={
+                "chat_room_title": chat_title,
+                "party_recommendation_status": title_elem,
+                "party_recommendation_open": opt_open,
+            }
+        ),
+        ui_actions=SimpleNamespace(switch_and_click=lambda key, **kwargs: {'success': True}),
+        key_actions=SimpleNamespace(press_back=press_back),
+        config={"create_party_recommendation": True},
+    )
+    rec_manager._handler = handler
+
+    result = rec_manager.ensure_synced_on_return()
+
+    assert result.get("success") is True
+    assert room_state.recommendation_enabled is True
+    assert title_elem.clicked is True
+    assert opt_open.clicked is True
+    assert pressed_back is True

--- a/tests/test_recommendation_manager.py
+++ b/tests/test_recommendation_manager.py
@@ -100,11 +100,11 @@ def test_ensure_synced_on_return_skips_when_already_saved(recommendation_setup):
     assert result.get("reason") == "already_saved"
 
 
-def test_ensure_synced_on_return_executes_sync_when_unsaved(recommendation_setup):
+def test_ensure_synced_on_return_reads_ui_without_clicking_options(recommendation_setup):
     rec_manager, room_state = recommendation_setup
     room_state.recommendation_enabled = None
 
-    title_elem = MockElement(text="关闭推荐分发")
+    title_elem = MockElement(text="所有人")
     chat_title = MockElement()
     opt_open = MockElement(text="所有人")
     back_count = 0
@@ -131,9 +131,9 @@ def test_ensure_synced_on_return_executes_sync_when_unsaved(recommendation_setup
 
     assert result.get("success") is True
     assert room_state.recommendation_enabled is True
-    assert title_elem.clicked is True
-    assert opt_open.clicked is True
-    assert back_count >= 1
+    assert title_elem.clicked is False
+    assert opt_open.clicked is False
+    assert back_count == 1
 
 
 def test_close_title_dialog_presses_back_twice_if_window_still_open(recommendation_setup):
@@ -144,7 +144,6 @@ def test_close_title_dialog_presses_back_twice_if_window_still_open(recommendati
     def press_back():
         nonlocal back_count
         back_count += 1
-        # After first back, window is still open; after second back, element is gone
         if back_count == 1:
             finder.elements["party_recommendation_status"] = MockElement(text="关闭推荐分发")
         else:

--- a/tests/test_recommendation_state.py
+++ b/tests/test_recommendation_state.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+import pytest
+from ushareiplay.state.playback_broadcaster import PlaybackBroadcaster
+from ushareiplay.state.playlist_state import PlaylistState
+from ushareiplay.state.presence_tracker import PresenceTracker
+from ushareiplay.state.room_state import RoomState
+from ushareiplay.managers.info_manager import InfoManager
+
+
+@pytest.fixture
+def init_singletons():
+    for cls in (
+        InfoManager,
+        PlaybackBroadcaster,
+        PlaylistState,
+        PresenceTracker,
+        RoomState,
+    ):
+        cls.reset_instance()
+    PlaybackBroadcaster.initialize()
+    PlaylistState.initialize()
+    PresenceTracker.initialize()
+    room_state = RoomState.initialize()
+    room_state._logger = SimpleNamespace(info=lambda _message: None)
+    manager = InfoManager.initialize()
+    manager._logger = SimpleNamespace(info=lambda _message: None)
+    return manager
+
+
+def test_room_state_recommendation_enabled_default_and_clear(init_singletons):
+    room_state = RoomState.instance()
+    assert room_state.recommendation_enabled is None
+
+    room_state.recommendation_enabled = True
+    assert room_state.recommendation_enabled is True
+
+    room_state.recommendation_enabled = False
+    assert room_state.recommendation_enabled is False
+
+    room_state.clear()
+    assert room_state.recommendation_enabled is None
+
+
+def test_info_manager_recommendation_enabled_delegation(init_singletons):
+    info_manager = InfoManager.instance()
+    assert info_manager.recommendation_enabled is None
+
+    info_manager.recommendation_enabled = True
+    assert info_manager.recommendation_enabled is True
+    assert RoomState.instance().recommendation_enabled is True


### PR DESCRIPTION
## Summary

- Add `create_party_recommendation: true` config and UI element locators (`party_recommendation_status`, `party_recommendation_open`, `party_recommendation_close`).
- Extend `RoomState` with `recommendation_enabled: Optional[bool]` and expose via `InfoManager`.
- Add `RecommendationManager` providing:
  - **Active Sync**: Automatically inspects and syncs recommendation state upon returning to room when state is unsaved (`None`).
  - **Passive Sync**: Automatically checks actual UI state on `tv_private_title` whenever room title dialog is opened for other reasons, updating `RoomState` if out-of-sync.
- Implement `:recommend` command supporting toggle (no args) and explicit state (`:recommend on/off` or `:recommend 开启/关闭`).
- Update `:info` output to include `派对推荐: 开放/关闭/未知`.
- Add unit tests for state, manager, and command. 366 tests pass cleanly.

Closes #225