### PR TITLE
fix(follower_message): fix nickname parsing for room presence and entry warning messages

### DIFF
--- a/src/ushareiplay/events/follower_message.py
+++ b/src/ushareiplay/events/follower_message.py
@@ -24,7 +24,9 @@ class FollowerMessageEvent(BaseEvent):
         支持多种格式：
         1. "你关注的Outlier进入房间啦，打个招呼吧～" - 进入房间
         2. "你的兄弟 Outlier进来啦～" - 进入房间
-        3. "荒草 为派对点赞了" - 点赞
+        3. "你的兄弟 Outlier正在房间玩～" - 正在房间
+        4. "你的密友Chainer正在房间里，打个招呼吧～" - 正在房间
+        5. "荒草 为派对点赞了" - 点赞
         
         Args:
             message_text: follower_message 文本
@@ -32,23 +34,37 @@ class FollowerMessageEvent(BaseEvent):
         Returns:
             tuple: (nickname, is_join)
             nickname: 解析出的用户名，如果解析失败返回 None
-            is_join: 是否是进入房间消息
+            is_join: 是否是进入房间/在房间消息（需打招呼）
         """
-        # 格式1: 你关注的XXX进入房间啦
-        match = re.search(r'你关注的(.+?)进入房间啦', message_text)
-        if match:
-            return match.group(1).strip(), True
-        
-        # 格式2: 你的XX XXX进来啦（XX是两位字符，后面有空格）
-        match = re.search(r'你的.{2} (.+?)进来啦', message_text)
-        if match:
-            return match.group(1).strip(), True
-
-        # 格式3: XXX 为派对点赞了
+        # 格式: XXX 为派对点赞了
         match = re.search(r'(.+?) 为派对点赞了', message_text)
         if match:
             return match.group(1).strip(), False
-        
+
+        # 进入房间 / 在房间 消息动作关键字
+        action_pattern = r'(?:进入房间|进来|正在房间|在房间|来到了房间)'
+
+        # 格式1: 你关注的XXX...
+        match = re.search(r'你关注的(.+?)' + action_pattern, message_text)
+        if match:
+            return match.group(1).strip(), True
+
+        # 格式2: 你的<已知关系词> XXX... (无论是否有空格)
+        relations = r'(?:兄弟|密友|挚友|死党|闺蜜|基友|搭子|特别关注|好友|心动|同城|星人|萌友|CP|关注)'
+        match = re.search(r'你的' + relations + r'\s*(.+?)' + action_pattern, message_text)
+        if match:
+            return match.group(1).strip(), True
+
+        # 格式3: 你的<关系词> XXX... (带空格分隔的任意关系词)
+        match = re.search(r'你的\S{1,6}\s+(.+?)' + action_pattern, message_text)
+        if match:
+            return match.group(1).strip(), True
+
+        # 格式4: 备选通用兜底：你的XXX...
+        match = re.search(r'你的(.+?)' + action_pattern, message_text)
+        if match:
+            return match.group(1).strip(), True
+
         return None, False
 
     async def handle(self, key: str, element_wrapper):

--- a/tests/test_follower_message.py
+++ b/tests/test_follower_message.py
@@ -1,0 +1,43 @@
+"""
+FollowerMessageEvent 消息解析与事件处理测试
+"""
+
+import pytest
+from ushareiplay.events.follower_message import FollowerMessageEvent
+
+
+class TestFollowerMessageParser:
+    """测试 FollowerMessageEvent 的消息文本解析功能"""
+
+    def setup_method(self):
+        from unittest.mock import MagicMock
+        mock_handler = MagicMock()
+        mock_handler.logger = MagicMock()
+        self.event = FollowerMessageEvent(handler=mock_handler)
+
+    @pytest.mark.parametrize(
+        "message_text, expected_nickname, expected_is_join",
+        [
+            # 基础进入房间消息
+            ("你关注的Outlier进入房间啦，打个招呼吧～", "Outlier", True),
+            ("你的兄弟 Outlier进来啦～", "Outlier", True),
+            # 用户日志中出现的 Warning 消息格式
+            ("你的兄弟 Outlier正在房间玩～", "Outlier", True),
+            ("你的密友Chainer正在房间里，打个招呼吧～", "Chainer", True),
+            # 扩展场景：带空格/无空格、各种关系与动作
+            ("你的死党 张三 正在房间里，打个招呼吧～", "张三", True),
+            ("你的特别关注李四 正在房间里", "李四", True),
+            ("你的好友 王五 进来啦～", "王五", True),
+            ("你的挚友小红进入房间啦", "小红", True),
+            ("你的神秘嘉宾 Alex 来到了房间", "Alex", True),
+            # 点赞消息
+            ("荒草 为派对点赞了", "荒草", False),
+            # 无法解析的非法格式
+            ("系统公告：欢迎使用派对功能", None, False),
+            ("", None, False),
+        ],
+    )
+    def test_parse_message(self, message_text, expected_nickname, expected_is_join):
+        nickname, is_join = self.event._parse_message(message_text)
+        assert nickname == expected_nickname
+        assert is_join == expected_is_join


### PR DESCRIPTION
## Summary
Fixes warnings in `FollowerMessageEvent` when parsing Soul room entry and presence notifications.

### Problem
Messages such as:
- `你的兄弟 Outlier正在房间玩～`
- `你的密友Chainer正在房间里，打个招呼吧～`

were failing to parse, resulting in `Failed to parse nickname from message` warnings.

### Solution
1. **Parser Update (`src/ushareiplay/events/follower_message.py`)**:
   - Expanded room action keywords (`进入房间`, `进来`, `正在房间`, `在房间`, `来到了房间`).
   - Supported common relation titles (`兄弟`, `密友`, `挚友`, `死党`, `闺蜜`, `基友`, `特别关注`, `好友`, etc.) with or without space before nickname.
   - Added space-delimited relation title regex and fallback matching.
2. **Tests (`tests/test_follower_message.py`)**:
   - Added unit test suite covering all entry, presence, and like notifications.