### PR TITLE
fix(party): only open party_state_entry drawer when disabling recommendation during party creation

### DIFF
--- a/src/ushareiplay/managers/party_manager.py
+++ b/src/ushareiplay/managers/party_manager.py
@@ -416,19 +416,15 @@ class PartyManager(Singleton):
         if key == 'new_party_entry' or key == 'confirm_party':
             element.click()
             self.logger.info(f"Clicked new party entry: {key}")
-            party_state_entry = self.handler.element_finder.wait_for_element('party_state_entry')
-        elif key == 'party_state_entry':
-            party_state_entry = element
-
-        if not party_state_entry:
-            self.logger.warning("未找到创建派对屏幕")
-            return False
-
-        party_state_entry.click()
-        self.logger.info("Clicked party state entry")
 
         party_recommend_config = bool(self.handler.config.get('create_party_recommendation', True))
         if not party_recommend_config:
+            party_state_entry = element if key == 'party_state_entry' else self.handler.element_finder.wait_for_element('party_state_entry')
+            if not party_state_entry:
+                self.logger.warning("未找到派对状态入口按钮")
+                return False
+            party_state_entry.click()
+            self.logger.info("Clicked party state entry to disable recommendation")
             close_party_notification = self.handler.element_finder.wait_for_element('close_party_notification')
             if not close_party_notification:
                 self.logger.warning("未找到关闭派对推荐")
@@ -439,7 +435,7 @@ class PartyManager(Singleton):
             if RoomState.is_initialized():
                 RoomState.instance().recommendation_enabled = False
         else:
-            self.logger.info("Keep party recommendation enabled as configured")
+            self.logger.info("Keep party recommendation enabled as configured (default '所有人')")
             from ushareiplay.state.room_state import RoomState
             if RoomState.is_initialized():
                 RoomState.instance().recommendation_enabled = True


### PR DESCRIPTION
### Summary of Changes

1. **Unified Room Info Auditor Pipeline (`RoomInfoWindowAuditor`)**:
   - Implements single-pass auditing for all 4 room info attributes (`recommendation`, `room_type`, `theme & title`, `notice`) within the open window before calling Safe Exit Guard.
   - Includes `pending_audit_retry` guard to retry auditing in subsequent loop iterations if any attribute fails or is interrupted.

2. **In-Dialog Element Locators & Timing**:
   - Added `room_name_in_dialog: "cn.soulapp.android:id/tv_room_name"` to `config.yaml`.
   - Updated `RoomNameManager.get_room_title_text_from_ui()` with `wait_for_element('room_name_in_dialog', timeout=2)` to poll for `tv_room_name` after type switching UI transitions.
   - Updated `NoticeManager.get_notice_text_from_ui()` using `chat_room_notice` (`cn.soulapp.android:id/tv_notice`) to inspect actual notice text View while avoiding the `edit_notice_entry` ('编辑') button text.
   - Fixed `system_default_notices` lookup in `NoticeManager` to support unpacked `self.handler.config` dictionary.

3. **Creation Drawer Fix**:
   - Updated `PartyManager._create_party_flow()`: Only open `party_state_entry` drawer when disabling recommendation (`create_party_recommendation: False`). Avoids open modal drawer blocking `party_type_chat` ('闲聊唠嗑') when keeping default recommendation ('所有人').

### Test Coverage
- Unit tests added in `tests/test_room_info_auditor.py` and updated in `tests/test_notice_manager_passive.py`, `tests/test_party_manager_create_mode.py`.
- All 420 unit tests in Pytest suite pass cleanly.